### PR TITLE
Add link to Jerboa on F-Droid

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Jerboa is a native-android client for Lemmy, built using the native Android Tool
 ## Installation / Releases
 
 - [Releases](https://github.com/dessalines/jerboa/releases)
-- FDroid TBD...
+- [F-Droid](https://f-droid.org/en/packages/com.jerboa/)
 
 ## Support / Donate
 


### PR DESCRIPTION
Seeing as Jerboa has made it to the F-Droid repository, it is time to update the installation information from the README.