### PR TITLE
Fix the backspace bug by setting KeyboardType to 'Email'

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -122,8 +122,8 @@ fun MarkdownTextField(
                 modifier = modifier.focusRequester(focusRequester),
                 keyboardOptions = KeyboardOptions.Default.copy(
                     capitalization = KeyboardCapitalization.Sentences,
-                    keyboardType = KeyboardType.Text
-                    // autoCorrect = true,
+                    keyboardType = KeyboardType.Email,
+                    autoCorrect = false
                 )
             )
         } else {
@@ -134,8 +134,8 @@ fun MarkdownTextField(
                 modifier = modifier.focusRequester(focusRequester),
                 keyboardOptions = KeyboardOptions.Default.copy(
                     capitalization = KeyboardCapitalization.Sentences,
-                    keyboardType = KeyboardType.Text
-                    // autoCorrect = true,
+                    keyboardType = KeyboardType.Email,
+                    autoCorrect = false
                 ),
                 colors = TextFieldDefaults.textFieldColors(
                     textColor = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -44,7 +44,7 @@ fun MyTextField(
         placeholder = { placeholder?.let { Text(text = it) } },
         keyboardOptions = KeyboardOptions.Default.copy(
             capitalization = KeyboardCapitalization.None,
-            keyboardType = KeyboardType.Text,
+            keyboardType = KeyboardType.Email,
             autoCorrect = false
         )
     )

--- a/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettings.kt
@@ -45,7 +45,7 @@ fun SettingsTextField(
             singleLine = true,
             keyboardOptions = KeyboardOptions.Default.copy(
                 capitalization = KeyboardCapitalization.None,
-                keyboardType = KeyboardType.Text,
+                keyboardType = KeyboardType.Email,
                 autoCorrect = false
             )
         )


### PR DESCRIPTION
A proposed approach to eliminate the backspace bug. Fixes #194, fixes #148 


The autoCorrect is triggering the following undesirable behavior for text fields:

Given:

"Hello world <Cursor position>"

Pressing backspace two times will result in:

"Helloworl"

An attempt was made to turn autoCorrect off, but the approach failed because the KeyboardType.Text does not respect the autoCorrect = false setting. ([See documentation](https://developer.android.com/reference/kotlin/androidx/compose/foundation/text/KeyboardOptions#autoCorrect()))

The proposed solution is to change the KeyboardType to KeyboardType.Email, which does respect the autoCorrect = false setting.

I have tested this approach over a period of a few days. The backspace bug disappears, and I did not experience any negative effects from using the Email keyboard type. 

I looked into how to apply the autoCorrect = false setting to KeyboardType.Text, but I could not find how to do that.



