### PR TITLE
Adjust the status bar while using the system dark theme to not use dark icons

### DIFF
--- a/app/src/main/java/com/jerboa/ui/theme/Theme.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/Theme.kt
@@ -1,15 +1,19 @@
 package com.jerboa.ui.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
+import androidx.core.view.WindowCompat
 import com.jerboa.ThemeColor
 import com.jerboa.ThemeMode
 import com.jerboa.db.AppSettings
@@ -53,6 +57,16 @@ fun JerboaTheme(
     }
 
     val typography = generateTypography(fontSize)
+
+    val view = LocalView.current
+
+    if(isSystemInDarkTheme()) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            val insets = WindowCompat.getInsetsController(window, view)
+            insets.isAppearanceLightStatusBars = false
+        }
+    }
 
     MaterialTheme(
         colorScheme = colors,

--- a/app/src/main/java/com/jerboa/ui/theme/Theme.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/Theme.kt
@@ -60,7 +60,7 @@ fun JerboaTheme(
 
     val view = LocalView.current
 
-    if(isSystemInDarkTheme()) {
+    if (isSystemInDarkTheme()) {
         SideEffect {
             val window = (view.context as Activity).window
             val insets = WindowCompat.getInsetsController(window, view)


### PR DESCRIPTION
Hello!

I noticed while using Jerboa that while my phone is using the dark theme, the status bar icons within the app are also dark which makes it seem a bit out of place. I'm opening this pull request to try to resolve this issue. I'm pretty new to the Jetpack Compose toolkit, so hopefully this approach looks appropriate. The following are screenshots from before and after to demonstrate the change:

Before:

![image](https://user-images.githubusercontent.com/773179/233997051-3756a240-c5e1-4c56-8e36-89d082523b5e.png)

After:

![image](https://user-images.githubusercontent.com/773179/233997087-9c55d385-df10-4946-9c9c-7b53c9c794b0.png)

I tested this on my physical Pixel 6a running Android 13, however as a precaution I went ahead and also tested this on a virtual Pixel 3a running Android 11, just to make sure there were no introduced incompatibility changes.
