### PR TITLE
Show settings in sidebar even when user is not logged in

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -229,9 +229,7 @@ fun DrawerItemsMain(
             }
         }
         item {
-            myUserInfo?.also {
-                Divider()
-            }
+            Divider()
         }
         item {
             myUserInfo?.also {
@@ -253,13 +251,11 @@ fun DrawerItemsMain(
             }
         }
         item {
-            myUserInfo?.also {
-                IconAndTextDrawerItem(
-                    text = "Settings",
-                    icon = Icons.Outlined.Settings,
-                    onClick = onClickSettings
-                )
-            }
+            IconAndTextDrawerItem(
+                text = "Settings",
+                icon = Icons.Outlined.Settings,
+                onClick = onClickSettings
+            )
         }
         item {
             myUserInfo?.also {

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -359,11 +359,7 @@ fun MainDrawer(
             closeDrawer(scope, drawerState)
         },
         onClickSettings = {
-            account.also {
-                navController.navigate(route = "settings")
-            } ?: run {
-                loginFirstToast(ctx)
-            }
+            navController.navigate(route = "settings")
             closeDrawer(scope, drawerState)
         }
     )


### PR DESCRIPTION
Right now the only way to access the settings menu is to first log in to an account. This change shows the settings menu button in the drawer even when not logged in.