### PR TITLE
Fixed ExposedDropdownMenuBox not expanding in Settings menu when clicked

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -605,7 +605,7 @@ fun MyDropDown(
         TextField(
             readOnly = true,
             value = selectedText,
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.menuAnchor().fillMaxWidth(),
             onValueChange = { },
             label = { Text(label) },
             trailingIcon = {


### PR DESCRIPTION
Small bugfix for the Settings menu dropdowns (Default Listing Type, Default Sort Type) not expanding when clicked. Used the solution provided here:

https://stackoverflow.com/questions/73946042/jetpack-compose-exposeddropdownmenu-not-showing-up-when-pressed