### PR TITLE
Added Black and System Black theme modes, fixes https://github.com/dessalines/jerboa/issues/376

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -714,8 +714,10 @@ fun Context.findActivity(): Activity? = when (this) {
 
 enum class ThemeMode {
     System,
+    SystemBlack,
     Light,
-    Dark
+    Dark,
+    Black
 }
 
 enum class ThemeColor {

--- a/app/src/main/java/com/jerboa/ui/theme/Theme.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
@@ -44,16 +45,28 @@ fun JerboaTheme(
         ThemeColor.Pink -> pink()
     }
 
+    fun makeBlack(darkTheme: ColorScheme): ColorScheme {
+        return darkTheme.copy(
+            background=Color(0xFF000000),
+            surface=Color(0xFF000000))
+    }
+
     val systemTheme = if (!isSystemInDarkTheme()) {
         colorPair.first
     } else {
-        colorPair.second
+        if (themeMode == ThemeMode.SystemBlack) {
+            makeBlack(colorPair.second)
+        } else {
+            colorPair.second
+        }
     }
 
     val colors = when (themeMode) {
         ThemeMode.System -> systemTheme
+        ThemeMode.SystemBlack -> systemTheme
         ThemeMode.Light -> colorPair.first
         ThemeMode.Dark -> colorPair.second
+        ThemeMode.Black -> makeBlack(colorPair.second)
     }
 
     val typography = generateTypography(fontSize)


### PR DESCRIPTION
Added Black theme mode. Looks exactly like the Dark theme mode except near-black background colors are true black. Also added theme mode SystemBlack, which uses Light/Black instead of Light/Dark depending on system setting. Fixes https://github.com/dessalines/jerboa/issues/376.

![green-black](https://github.com/dessalines/jerboa/assets/6295625/9b6d8b41-ba26-4df6-ba1e-590740ba2384)

![theme_mode](https://github.com/dessalines/jerboa/assets/6295625/14663705-b3aa-4fd2-9bac-a726d4a90433)
