### PR TITLE
Collapse comments by tapping directly on the comment body

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -86,7 +86,7 @@ fun CommentNodeHeader(
     score: Int,
     myVote: Int?,
     isModerator: Boolean,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit
 ) {
     CommentOrPostNodeHeader(
         creator = commentView.creator,
@@ -111,7 +111,8 @@ fun CommentNodeHeaderPreview() {
         score = 23,
         myVote = 26,
         isModerator = false,
-        onPersonClick = {}
+        onPersonClick = {},
+        onClick = {}
     )
 }
 
@@ -119,7 +120,7 @@ fun CommentNodeHeaderPreview() {
 fun CommentBody(
     comment: Comment,
     viewSource: Boolean,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit
 ) {
     val content = if (comment.removed) {
         "*Removed*"
@@ -147,7 +148,11 @@ fun CommentBody(
 @Preview
 @Composable
 fun CommentBodyPreview() {
-    CommentBody(comment = sampleCommentView.comment, viewSource = false)
+    CommentBody(
+        comment = sampleCommentView.comment,
+        viewSource = false,
+        onClick = {}
+    )
 }
 
 fun LazyListScope.commentNodeItem(

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -86,7 +86,7 @@ fun CommentNodeHeader(
     score: Int,
     myVote: Int?,
     isModerator: Boolean,
-    onLongClick: () -> Unit = {}
+    onClick: () -> Unit = {}
 ) {
     CommentOrPostNodeHeader(
         creator = commentView.creator,
@@ -99,7 +99,7 @@ fun CommentNodeHeader(
         isPostCreator = isPostCreator(commentView),
         isModerator = isModerator,
         isCommunityBanned = commentView.creator_banned_from_community,
-        onLongClick = onLongClick
+        onClick = onClick
     )
 }
 
@@ -118,7 +118,8 @@ fun CommentNodeHeaderPreview() {
 @Composable
 fun CommentBody(
     comment: Comment,
-    viewSource: Boolean
+    viewSource: Boolean,
+    onClick: () -> Unit = {}
 ) {
     val content = if (comment.removed) {
         "*Removed*"
@@ -131,11 +132,15 @@ fun CommentBody(
     if (viewSource) {
         SelectionContainer {
             Text(
-                text = comment.content
+                text = comment.content,
+                modifier = Modifier.clickable { onClick() }
             )
         }
     } else {
-        MyMarkdownText(markdown = content)
+        MyMarkdownText(
+            markdown = content,
+            onClick = onClick
+        )
     }
 }
 
@@ -228,7 +233,7 @@ fun LazyListScope.commentNodeItem(
                         score = instantScores.value.score,
                         myVote = instantScores.value.myVote,
                         isModerator = isModerator(commentView.creator, moderators),
-                        onLongClick = {
+                        onClick = {
                             toggleExpanded(commentId)
                         }
                     )
@@ -240,7 +245,10 @@ fun LazyListScope.commentNodeItem(
                         Column {
                             CommentBody(
                                 comment = commentView.comment,
-                                viewSource = viewSource
+                                viewSource = viewSource,
+                                onClick = {
+                                    toggleExpanded(commentId)
+                                }
                             )
                             CommentFooterLine(
                                 commentView = commentView,

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -56,7 +56,7 @@ fun CommentMentionNodeHeader(
     onPersonClick: (personId: Int) -> Unit,
     score: Int,
     myVote: Int?,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit
 ) {
     CommentOrPostNodeHeader(
         creator = personMentionView.creator,
@@ -80,7 +80,8 @@ fun CommentMentionNodeHeaderPreview() {
         personMentionView = samplePersonMentionView,
         score = 23,
         myVote = 26,
-        onPersonClick = {}
+        onPersonClick = {},
+        onClick = {}
     )
 }
 
@@ -298,7 +299,8 @@ fun CommentMentionNode(
             Column {
                 CommentBody(
                     comment = personMentionView.comment,
-                    viewSource = viewSource
+                    viewSource = viewSource,
+                    onClick = {}
                 )
                 CommentMentionNodeFooterLine(
                     personMentionView = personMentionView,

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -56,7 +56,7 @@ fun CommentMentionNodeHeader(
     onPersonClick: (personId: Int) -> Unit,
     score: Int,
     myVote: Int?,
-    onLongClick: () -> Unit = {}
+    onClick: () -> Unit = {}
 ) {
     CommentOrPostNodeHeader(
         creator = personMentionView.creator,
@@ -69,7 +69,7 @@ fun CommentMentionNodeHeader(
         isPostCreator = false,
         isModerator = false,
         isCommunityBanned = personMentionView.creator_banned_from_community,
-        onLongClick = onLongClick
+        onClick = onClick
     )
 }
 
@@ -286,7 +286,7 @@ fun CommentMentionNode(
             onPersonClick = onPersonClick,
             score = score,
             myVote = myVote,
-            onLongClick = {
+            onClick = {
                 isExpanded = !isExpanded
             }
         )

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
@@ -87,7 +87,8 @@ fun RepliedComment(
             onPersonClick = onPersonClick,
             score = commentView.counts.score,
             myVote = commentView.my_vote,
-            isModerator = isModerator
+            isModerator = isModerator,
+            onClick = {}
         )
         SelectionContainer {
             Text(text = commentView.comment.content)
@@ -105,7 +106,8 @@ fun RepliedCommentReply(
             commentReplyView = commentReplyView,
             onPersonClick = onPersonClick,
             score = commentReplyView.counts.score,
-            myVote = commentReplyView.my_vote
+            myVote = commentReplyView.my_vote,
+            onClick = {}
         )
         SelectionContainer {
             Text(text = commentReplyView.comment.content)
@@ -123,7 +125,8 @@ fun RepliedMentionReply(
             personMentionView = personMentionView,
             onPersonClick = onPersonClick,
             score = personMentionView.counts.score,
-            myVote = personMentionView.my_vote
+            myVote = personMentionView.my_vote,
+            onClick = {}
         )
         SelectionContainer {
             Text(text = personMentionView.comment.content)

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
@@ -56,7 +56,7 @@ fun CommentReplyNodeHeader(
     onPersonClick: (personId: Int) -> Unit,
     score: Int,
     myVote: Int?,
-    onLongClick: () -> Unit = {}
+    onClick: () -> Unit = {}
 ) {
     CommentOrPostNodeHeader(
         creator = commentReplyView.creator,
@@ -69,7 +69,7 @@ fun CommentReplyNodeHeader(
         isPostCreator = false,
         isModerator = false,
         isCommunityBanned = commentReplyView.creator_banned_from_community,
-        onLongClick = onLongClick
+        onClick = onClick
     )
 }
 
@@ -286,7 +286,7 @@ fun CommentReplyNode(
             onPersonClick = onPersonClick,
             score = score,
             myVote = myVote,
-            onLongClick = {
+            onClick = {
                 isExpanded = !isExpanded
             }
         )

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
@@ -56,7 +56,7 @@ fun CommentReplyNodeHeader(
     onPersonClick: (personId: Int) -> Unit,
     score: Int,
     myVote: Int?,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit
 ) {
     CommentOrPostNodeHeader(
         creator = commentReplyView.creator,
@@ -80,7 +80,8 @@ fun CommentReplyNodeHeaderPreview() {
         commentReplyView = sampleCommentReplyView,
         score = 23,
         myVote = 26,
-        onPersonClick = {}
+        onPersonClick = {},
+        onClick = {}
     )
 }
 
@@ -298,7 +299,8 @@ fun CommentReplyNode(
             Column {
                 CommentBody(
                     comment = commentReplyView.comment,
-                    viewSource = viewSource
+                    viewSource = viewSource,
+                    onClick = {}
                 )
                 CommentReplyNodeFooterLine(
                     commentReplyView = commentReplyView,

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -203,7 +203,7 @@ fun CommentOrPostNodeHeader(
     isPostCreator: Boolean,
     isModerator: Boolean,
     isCommunityBanned: Boolean,
-    onLongClick: () -> Unit = {}
+    onClick: () -> Unit = {}
 ) {
     FlowRow(
         mainAxisAlignment = FlowMainAxisAlignment.SpaceBetween,
@@ -215,8 +215,8 @@ fun CommentOrPostNodeHeader(
                 bottom = MEDIUM_PADDING
             )
             .combinedClickable(
-                onLongClick = onLongClick,
-                onClick = {}
+                onLongClick = {},
+                onClick = onClick
             )
     ) {
         Row(

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -203,7 +203,7 @@ fun CommentOrPostNodeHeader(
     isPostCreator: Boolean,
     isModerator: Boolean,
     isCommunityBanned: Boolean,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit
 ) {
     FlowRow(
         mainAxisAlignment = FlowMainAxisAlignment.SpaceBetween,
@@ -258,7 +258,8 @@ fun CommentOrPostNodeHeaderPreview() {
         onPersonClick = {},
         isPostCreator = true,
         isModerator = true,
-        isCommunityBanned = false
+        isCommunityBanned = false,
+        onClick = {}
     )
 }
 
@@ -452,7 +453,8 @@ fun Sidebar(
                 ) {
                     MyMarkdownText(
                         markdown = it,
-                        color = MaterialTheme.colorScheme.onBackground.muted
+                        color = MaterialTheme.colorScheme.onBackground.muted,
+                        onClick = {}
                     )
                 }
             }

--- a/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
@@ -280,7 +280,10 @@ fun ShowChangelog(appSettingsViewModel: AppSettingsViewModel) {
             AlertDialog(
                 text = {
                     Column(modifier = Modifier.fillMaxSize().verticalScroll(scrollState)) {
-                        MyMarkdownText(markdown = DONATION_MARKDOWN + markdown.value)
+                        MyMarkdownText(
+                            markdown = DONATION_MARKDOWN + markdown.value,
+                            onClick = {}
+                        )
                     }
                 },
                 confirmButton = {

--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -323,7 +323,8 @@ fun ShowPreviewDialog(
                 modifier = Modifier.verticalScroll(rememberScrollState())
             ) {
                 MyMarkdownText(
-                    markdown = content
+                    markdown = content,
+                    onClick = {}
                 )
             }
         },
@@ -675,7 +676,7 @@ fun PreviewLines(
 fun MyMarkdownText(
     markdown: String,
     color: Color = MaterialTheme.colorScheme.onSurface,
-    onClick: () -> Unit = {}
+    onClick: () -> Unit
 ) {
     MarkdownText(
         markdown = markdown,

--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -674,11 +674,13 @@ fun PreviewLines(
 @Composable
 fun MyMarkdownText(
     markdown: String,
-    color: Color = MaterialTheme.colorScheme.onSurface
+    color: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: () -> Unit = {}
 ) {
     MarkdownText(
         markdown = markdown,
         modifier = Modifier.fillMaxSize(),
+        onClick = onClick,
         color = color,
         fontSize = MaterialTheme.typography.bodyLarge.fontSize.times(MARKDOWN_FONT_MULTIPLIER)
 //        style = MaterialTheme.typography.titleLarge,

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -623,6 +623,9 @@ fun Tagline(taglines: List<Tagline>) {
     Column(
         Modifier.padding(LARGE_PADDING)
     ) {
-        MyMarkdownText(markdown = tagline.content)
+        MyMarkdownText(
+            markdown = tagline.content,
+            onClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -85,7 +85,8 @@ fun PersonProfileTopSection(
             personView.person.bio?.also {
                 MyMarkdownText(
                     markdown = it,
-                    color = MaterialTheme.colorScheme.onBackground.muted
+                    color = MaterialTheme.colorScheme.onBackground.muted,
+                    onClick = {}
                 )
             }
         }

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -233,7 +233,8 @@ fun PostNodeHeader(
         onPersonClick = onPersonClick,
         isPostCreator = true,
         isModerator = isModerator,
-        isCommunityBanned = postView.creator_banned_from_community
+        isCommunityBanned = postView.creator_banned_from_community,
+        onClick = {}
     )
 }
 
@@ -391,7 +392,8 @@ fun PostBody(
                                 .padding(MEDIUM_PADDING)
                         ) {
                             MyMarkdownText(
-                                markdown = text
+                                markdown = text,
+                                onClick = {}
                             )
                         }
                     } else {
@@ -1133,7 +1135,10 @@ fun MetadataCard(post: Post) {
                 post.embed_description?.also {
                     Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
                     // This is actually html, but markdown can render it
-                    MyMarkdownText(markdown = it)
+                    MyMarkdownText(
+                        markdown = it,
+                        onClick = {}
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessage.kt
@@ -85,7 +85,10 @@ fun PrivateMessageViewPreview() {
 
 @Composable
 fun PrivateMessageBody(privateMessageView: PrivateMessageView) {
-    MyMarkdownText(markdown = privateMessageView.private_message.content)
+    MyMarkdownText(
+        markdown = privateMessageView.private_message.content,
+        onClick = {}
+    )
 }
 
 @Composable


### PR DESCRIPTION
Users can now collapse comments by tapping anywhere on the comment body or header, and expand comments again by tapping on the comment header. This replaces the old behaviour (tap and hold on comment headers), which wasn't as intuitive for new users.

Tested on comment markdown text as well as "View source" comment text. Tested clickable links in the comment body and usernames in the comment header are still clickable.