### PR TITLE
Roll back AGP to `8.0.2`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '8.2.0-alpha06' apply false
-    id 'com.android.library' version '8.2.0-alpha06' apply false
+    id 'com.android.application' version '8.0.2' apply false
+    id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
     id "com.github.ben-manes.versions" version "0.42.0"
     id 'org.jmailen.kotlinter' version "3.13.0" apply false


### PR DESCRIPTION
This makes it so that an alpha-build of Android Studio is not necessary to contribute to the project.