### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{kt,kts}]
+
+indent_size = 4
+insert_final_newline = true
+end_of_line = lf
+
+ktlint_standard_no-wildcard-imports = disabled

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'com.android.library' version '8.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
     id "com.github.ben-manes.versions" version "0.42.0"
-    id 'org.jmailen.kotlinter' version "3.13.0" apply false
+    id 'org.jmailen.kotlinter' version "3.15.0" apply false
     id 'com.google.devtools.ksp' version "1.8.20-1.0.11" apply false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,6 @@ plugins {
 
 subprojects {
   apply plugin: "org.jmailen.kotlinter" // Version should be inherited from parent
-  kotlinter {
-      disabledRules = ["no-wildcard-imports"]
-  }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
`ktlint` follows the rules in this file.

For the sake of simplicity, the rules in the file are aligned with what's in place in the project already. No additional formatting is necessary after this PR is merged.