### PR TITLE
Add option to disable showing the bottom navigation bar

### DIFF
--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -378,6 +378,7 @@ class MainActivity : ComponentActivity() {
 
                         InboxActivity(
                             navController = navController,
+                            appSettingsViewModel = appSettingsViewModel,
                             inboxViewModel = inboxViewModel,
                             accountViewModel = accountViewModel,
                             homeViewModel = homeViewModel,

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -64,6 +64,11 @@ data class AppSettings(
         defaultValue = "0",
     )
     val postViewMode: Int,
+    @ColumnInfo(
+        name = "show_bottom_nav",
+        defaultValue = "1",
+    )
+    val showBottomNav: Boolean,
 )
 
 @Dao
@@ -287,8 +292,18 @@ val MIGRATION_8_9 = object : Migration(8, 9) {
     }
 }
 
+val MIGRATION_9_10 = object : Migration(9, 10) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // Add show_bottom_nav column
+        database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
+        database.execSQL(
+            "ALTER TABLE AppSettings add column show_bottom_nav INTEGER NOT NULL default 1",
+        )
+    }
+}
+
 @Database(
-    version = 9,
+    version = 10,
     entities = [Account::class, AppSettings::class],
     exportSchema = true,
 )
@@ -321,6 +336,7 @@ abstract class AppDB : RoomDatabase() {
                         MIGRATION_6_7,
                         MIGRATION_7_8,
                         MIGRATION_8_9,
+                        MIGRATION_9_10,
                     )
                     // Necessary because it can't insert data on creation
                     .addCallback(object : Callback() {

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -43,6 +43,7 @@ import com.jerboa.datatypes.api.GetUnreadCountResponse
 import com.jerboa.datatypes.samplePersonSafe
 import com.jerboa.datatypes.samplePost
 import com.jerboa.db.Account
+import com.jerboa.db.AppSettings
 import com.jerboa.loginFirstToast
 import com.jerboa.siFormat
 import com.jerboa.ui.components.person.PersonProfileLink
@@ -76,6 +77,7 @@ fun SimpleTopAppBar(
 @Composable
 fun BottomAppBarAll(
     navController: NavController = rememberNavController(),
+    appSettings: AppSettings? = null,
     screen: String,
     unreadCounts: GetUnreadCountResponse? = null,
     onClickSaved: () -> Unit,
@@ -84,98 +86,100 @@ fun BottomAppBarAll(
 ) {
     val totalUnreads = unreadCounts?.let { unreadCountTotal(it) }
 
-    BottomAppBar {
-        NavigationBarItem(
-            icon = {
-                if (screen == "home") {
-                    Icon(
-                        imageVector = Icons.Filled.Home,
-                        tint = MaterialTheme.colorScheme.primary,
-                        contentDescription = "TODO",
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Outlined.Home,
-                        contentDescription = "TODO",
-                    )
-                }
-            },
-            selected = false,
-            onClick = {
-                navController.navigate("home")
-            },
-        )
+    if (appSettings?.showBottomNav != false) {
+        BottomAppBar {
+            NavigationBarItem(
+                icon = {
+                    if (screen == "home") {
+                        Icon(
+                            imageVector = Icons.Filled.Home,
+                            tint = MaterialTheme.colorScheme.primary,
+                            contentDescription = "TODO",
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.Home,
+                            contentDescription = "TODO",
+                        )
+                    }
+                },
+                selected = false,
+                onClick = {
+                    navController.navigate("home")
+                },
+            )
 
-        NavigationBarItem(
-            icon = {
-                Icon(
-                    imageVector = Icons.Outlined.List,
-                    contentDescription = "TODO",
-                )
-            },
-            onClick = {
-                navController.navigate("communityList")
-            },
-            selected = screen == "communityList",
-        )
-        NavigationBarItem(
-            icon = {
-                if (screen == "inbox") {
-                    InboxIconAndBadge(
-                        iconBadgeCount = totalUnreads,
-                        icon = Icons.Filled.Email,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                } else {
-                    InboxIconAndBadge(
-                        iconBadgeCount = totalUnreads,
-                        icon = Icons.Outlined.Email,
-                    )
-                }
-            },
-            onClick = {
-                onClickInbox()
-            },
-            selected = false,
-        )
-        NavigationBarItem(
-            icon = {
-                if (screen == "saved") {
+            NavigationBarItem(
+                icon = {
                     Icon(
-                        imageVector = Icons.Filled.Bookmarks,
-                        tint = MaterialTheme.colorScheme.primary,
+                        imageVector = Icons.Outlined.List,
                         contentDescription = "TODO",
                     )
-                } else {
-                    Icon(
-                        imageVector = Icons.Outlined.Bookmarks,
-                        contentDescription = "TODO",
-                    )
-                }
-            },
-            onClick = {
-                onClickSaved()
-            },
-            selected = false,
-        )
-        NavigationBarItem(
-            icon = {
-                if (screen == "profile") {
-                    Icon(
-                        imageVector = Icons.Filled.Person,
-                        tint = MaterialTheme.colorScheme.primary,
-                        contentDescription = "TODO",
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Outlined.Person,
-                        contentDescription = "TODO",
-                    )
-                }
-            },
-            onClick = onClickProfile,
-            selected = false,
-        )
+                },
+                onClick = {
+                    navController.navigate("communityList")
+                },
+                selected = screen == "communityList",
+            )
+            NavigationBarItem(
+                icon = {
+                    if (screen == "inbox") {
+                        InboxIconAndBadge(
+                            iconBadgeCount = totalUnreads,
+                            icon = Icons.Filled.Email,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    } else {
+                        InboxIconAndBadge(
+                            iconBadgeCount = totalUnreads,
+                            icon = Icons.Outlined.Email,
+                        )
+                    }
+                },
+                onClick = {
+                    onClickInbox()
+                },
+                selected = false,
+            )
+            NavigationBarItem(
+                icon = {
+                    if (screen == "saved") {
+                        Icon(
+                            imageVector = Icons.Filled.Bookmarks,
+                            tint = MaterialTheme.colorScheme.primary,
+                            contentDescription = "TODO",
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.Bookmarks,
+                            contentDescription = "TODO",
+                        )
+                    }
+                },
+                onClick = {
+                    onClickSaved()
+                },
+                selected = false,
+            )
+            NavigationBarItem(
+                icon = {
+                    if (screen == "profile") {
+                        Icon(
+                            imageVector = Icons.Filled.Person,
+                            tint = MaterialTheme.colorScheme.primary,
+                            contentDescription = "TODO",
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Outlined.Person,
+                            contentDescription = "TODO",
+                        )
+                    }
+                },
+                onClick = onClickProfile,
+                selected = false,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -245,6 +245,7 @@ fun CommunityActivity(
         },
         bottomBar = {
             BottomAppBarAll(
+                appSettings = appSettingsViewModel.appSettings.value,
                 screen = "communityList",
                 unreadCounts = homeViewModel.unreadCountResponse,
                 onClickProfile = {

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -131,6 +131,7 @@ fun HomeActivity(
                 },
                 bottomBar = {
                     BottomAppBarAll(
+                        appSettings = appSettingsViewModel.appSettings.value,
                         screen = "home",
                         unreadCounts = homeViewModel.unreadCountResponse,
                         onClickProfile = {

--- a/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
@@ -21,6 +21,7 @@ import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.jerboa.*
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
+import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.ui.components.comment.mentionnode.CommentMentionNode
 import com.jerboa.ui.components.comment.reply.CommentReplyViewModel
 import com.jerboa.ui.components.comment.reply.ReplyItem
@@ -37,6 +38,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun InboxActivity(
     navController: NavController,
+    appSettingsViewModel: AppSettingsViewModel,
     inboxViewModel: InboxViewModel,
     homeViewModel: HomeViewModel,
     accountViewModel: AccountViewModel,
@@ -107,6 +109,7 @@ fun InboxActivity(
         },
         bottomBar = {
             BottomAppBarAll(
+                appSettings = appSettingsViewModel.appSettings.value,
                 screen = "inbox",
                 unreadCounts = homeViewModel.unreadCountResponse,
                 onClickProfile = {

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -142,6 +142,7 @@ fun PersonProfileActivity(
         },
         bottomBar = {
             BottomAppBarAll(
+                appSettings = appSettingsViewModel.appSettings.value,
                 screen = bottomAppBarScreen,
                 unreadCounts = homeViewModel.unreadCountResponse,
                 onClickProfile = {

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -17,8 +17,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.alorma.compose.settings.storage.base.SettingValueState
+import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
 import com.alorma.compose.settings.storage.base.rememberFloatSettingState
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.alorma.compose.settings.ui.SettingsCheckbox
 import com.alorma.compose.settings.ui.SettingsList
 import com.alorma.compose.settings.ui.SettingsSlider
 import com.jerboa.PostViewMode
@@ -45,6 +47,7 @@ fun LookAndFeelActivity(
             ?: DEFAULT_FONT_SIZE.toFloat(),
     )
     val postViewModeState = rememberIntSettingState(settings?.postViewMode ?: 0)
+    val showBottomNavState = rememberBooleanSettingState(settings?.showBottomNav ?: true)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -75,6 +78,7 @@ fun LookAndFeelActivity(
                             themeState,
                             themeColorState,
                             postViewModeState,
+                            showBottomNavState,
                         )
                     },
                 )
@@ -98,6 +102,7 @@ fun LookAndFeelActivity(
                             themeState,
                             themeColorState,
                             postViewModeState,
+                            showBottomNavState,
                         )
                     },
                 )
@@ -121,6 +126,7 @@ fun LookAndFeelActivity(
                             themeState,
                             themeColorState,
                             postViewModeState,
+                            showBottomNavState,
                         )
                     },
                 )
@@ -144,6 +150,23 @@ fun LookAndFeelActivity(
                             themeState,
                             themeColorState,
                             postViewModeState,
+                            showBottomNavState,
+                        )
+                    },
+                )
+                SettingsCheckbox(
+                    state = showBottomNavState,
+                    title = {
+                        Text(text = "Show navigation bar")
+                    },
+                    onCheckedChange = {
+                        updateAppSettings(
+                            appSettingsViewModel,
+                            fontSizeState,
+                            themeState,
+                            themeColorState,
+                            postViewModeState,
+                            showBottomNavState,
                         )
                     },
                 )
@@ -158,6 +181,7 @@ private fun updateAppSettings(
     themeState: SettingValueState<Int>,
     themeColorState: SettingValueState<Int>,
     postViewModeState: SettingValueState<Int>,
+    showBottomNav: SettingValueState<Boolean>,
 ) {
     appSettingsViewModel.update(
         AppSettings(
@@ -167,6 +191,7 @@ private fun updateAppSettings(
             themeColor = themeColorState.value,
             viewedChangelog = appSettingsViewModel.appSettings.value?.viewedChangelog ?: 0,
             postViewMode = postViewModeState.value,
+            showBottomNav = showBottomNav.value,
         ),
     )
 }


### PR DESCRIPTION
This adds a checkbox option to disable the bottom navigation bar throughout the app. Testing locally it seems to work correctly, including migrations.