### PR TITLE
Add option to show contents of collapsed comments

### DIFF
--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -424,6 +424,7 @@ class MainActivity : ComponentActivity() {
                             commentReplyViewModel = commentReplyViewModel,
                             postEditViewModel = postEditViewModel,
                             navController = navController,
+                            showCollapsedCommentContent = appSettings?.showCollapsedCommentContent ?: false,
                         )
                     }
                     composable(
@@ -453,6 +454,7 @@ class MainActivity : ComponentActivity() {
                             commentReplyViewModel = commentReplyViewModel,
                             postEditViewModel = postEditViewModel,
                             navController = navController,
+                            showCollapsedCommentContent = appSettings?.showCollapsedCommentContent ?: false,
                         )
                     }
                     composable(

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -312,7 +312,7 @@ val MIGRATION_10_11 = object : Migration(10, 11) {
         // Add show_bottom_nav column
         database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
         database.execSQL(
-            "ALTER TABLE AppSettings add column show_collapsed_comment_content INTEGER NOT NULL default 1",
+            "ALTER TABLE AppSettings add column show_collapsed_comment_content INTEGER NOT NULL default 0",
         )
     }
 }

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -69,6 +69,11 @@ data class AppSettings(
         defaultValue = "1",
     )
     val showBottomNav: Boolean,
+    @ColumnInfo(
+        name = "show_collapsed_comment_content",
+        defaultValue = "0",
+    )
+    val showCollapsedCommentContent: Boolean,
 )
 
 @Dao
@@ -302,8 +307,18 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
     }
 }
 
+val MIGRATION_10_11 = object : Migration(10, 11) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // Add show_bottom_nav column
+        database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
+        database.execSQL(
+            "ALTER TABLE AppSettings add column show_collapsed_comment_content INTEGER NOT NULL default 1",
+        )
+    }
+}
+
 @Database(
-    version = 10,
+    version = 11,
     entities = [Account::class, AppSettings::class],
     exportSchema = true,
 )
@@ -337,6 +352,7 @@ abstract class AppDB : RoomDatabase() {
                         MIGRATION_7_8,
                         MIGRATION_8_9,
                         MIGRATION_9_10,
+                        MIGRATION_10_11,
                     )
                     // Necessary because it can't insert data on creation
                     .addCallback(object : Callback() {

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -353,7 +353,7 @@ private fun ShowMoreChildrenNode(
     depth: Int,
     commentView: CommentView,
     onFetchChildrenClick: (commentView: CommentView) -> Unit,
-    isCollapsedByParent: Boolean
+    isCollapsedByParent: Boolean,
 ) {
     val newDepth = depth + 1
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -187,6 +187,7 @@ fun LazyListScope.commentNodeItem(
     showCollapsedCommentContent: Boolean = false,
     showPostAndCommunityContext: Boolean = false,
     account: Account?,
+    isCollapsedByParent: Boolean,
 ) {
     val commentView = node.commentView
     val commentId = commentView.comment.id
@@ -218,87 +219,93 @@ fun LazyListScope.commentNodeItem(
             )
         }
 
-        Column(
-            modifier = Modifier
-                .padding(
-                    start = offset,
-                ),
+        AnimatedVisibility(
+            visible = !isCollapsedByParent,
+            enter = expandVertically(),
+            exit = shrinkVertically(),
         ) {
-            Divider()
             Column(
-                modifier = Modifier.border(start = border),
-            ) {
-                Column(
-                    modifier = Modifier.padding(
-                        start = offset2,
-                        end = MEDIUM_PADDING,
+                modifier = Modifier
+                    .padding(
+                        start = offset,
                     ),
+            ) {
+                Divider()
+                Column(
+                    modifier = Modifier.border(start = border),
                 ) {
-                    if (showPostAndCommunityContext) {
-                        PostAndCommunityContextHeader(
-                            post = commentView.post,
-                            community = commentView.community,
-                            onCommunityClick = onCommunityClick,
-                            onPostClick = onPostClick,
-                        )
-                    }
-                    CommentNodeHeader(
-                        commentView = commentView,
-                        onPersonClick = onPersonClick,
-                        score = instantScores.value.score,
-                        myVote = instantScores.value.myVote,
-                        isModerator = isModerator(commentView.creator, moderators),
-                        onClick = {
-                            toggleExpanded(commentId)
-                        },
-                        collapsedCommentsCount = getDecendentsCount(node),
-                        isExpanded = isExpanded(commentId),
-                    )
-                    AnimatedVisibility(
-                        visible = isExpanded(commentId) || showCollapsedCommentContent,
-                        enter = expandVertically(),
-                        exit = shrinkVertically(),
+                    Column(
+                        modifier = Modifier.padding(
+                            start = offset2,
+                            end = MEDIUM_PADDING,
+                        ),
                     ) {
-                        Column {
-                            CommentBody(
-                                comment = commentView.comment,
-                                viewSource = viewSource,
-                                onClick = {
-                                    toggleExpanded(commentId)
-                                },
+                        if (showPostAndCommunityContext) {
+                            PostAndCommunityContextHeader(
+                                post = commentView.post,
+                                community = commentView.community,
+                                onCommunityClick = onCommunityClick,
+                                onPostClick = onPostClick,
                             )
-                            CommentFooterLine(
-                                commentView = commentView,
-                                instantScores = instantScores.value,
-                                onUpvoteClick = {
-                                    instantScores.value = calculateNewInstantScores(
-                                        instantScores.value,
-                                        voteType = VoteType.Upvote,
-                                    )
-                                    onUpvoteClick(it)
-                                },
-                                onDownvoteClick = {
-                                    instantScores.value = calculateNewInstantScores(
-                                        instantScores.value,
-                                        voteType = VoteType.Downvote,
-                                    )
-                                    onDownvoteClick(it)
-                                },
-                                onViewSourceClick = {
-                                    viewSource = !viewSource
-                                },
-                                onEditCommentClick = onEditCommentClick,
-                                onDeleteCommentClick = onDeleteCommentClick,
-                                onReplyClick = onReplyClick,
-                                onSaveClick = onSaveClick,
-                                onReportClick = onReportClick,
-                                onCommentLinkClick = onCommentLinkClick,
-                                onBlockCreatorClick = onBlockCreatorClick,
-                                onClick = {
-                                    toggleExpanded(commentId)
-                                },
-                                account = account,
-                            )
+                        }
+                        CommentNodeHeader(
+                            commentView = commentView,
+                            onPersonClick = onPersonClick,
+                            score = instantScores.value.score,
+                            myVote = instantScores.value.myVote,
+                            isModerator = isModerator(commentView.creator, moderators),
+                            onClick = {
+                                toggleExpanded(commentId)
+                            },
+                            collapsedCommentsCount = getDecendentsCount(node),
+                            isExpanded = isExpanded(commentId),
+                        )
+                        AnimatedVisibility(
+                            visible = isExpanded(commentId) || showCollapsedCommentContent,
+                            enter = expandVertically(),
+                            exit = shrinkVertically(),
+                        ) {
+                            Column {
+                                CommentBody(
+                                    comment = commentView.comment,
+                                    viewSource = viewSource,
+                                    onClick = {
+                                        toggleExpanded(commentId)
+                                    },
+                                )
+                                CommentFooterLine(
+                                    commentView = commentView,
+                                    instantScores = instantScores.value,
+                                    onUpvoteClick = {
+                                        instantScores.value = calculateNewInstantScores(
+                                            instantScores.value,
+                                            voteType = VoteType.Upvote,
+                                        )
+                                        onUpvoteClick(it)
+                                    },
+                                    onDownvoteClick = {
+                                        instantScores.value = calculateNewInstantScores(
+                                            instantScores.value,
+                                            voteType = VoteType.Downvote,
+                                        )
+                                        onDownvoteClick(it)
+                                    },
+                                    onViewSourceClick = {
+                                        viewSource = !viewSource
+                                    },
+                                    onEditCommentClick = onEditCommentClick,
+                                    onDeleteCommentClick = onDeleteCommentClick,
+                                    onReplyClick = onReplyClick,
+                                    onSaveClick = onSaveClick,
+                                    onReportClick = onReportClick,
+                                    onCommentLinkClick = onCommentLinkClick,
+                                    onBlockCreatorClick = onBlockCreatorClick,
+                                    onClick = {
+                                        toggleExpanded(commentId)
+                                    },
+                                    account = account,
+                                )
+                            }
                         }
                     }
                 }
@@ -312,32 +319,31 @@ fun LazyListScope.commentNodeItem(
         }
     }
 
-    if (isExpanded(commentId)) {
-        node.children?.also { nodes ->
-            commentNodeItems(
-                nodes = nodes,
-                isFlat = isFlat,
-                toggleExpanded = toggleExpanded,
-                isExpanded = isExpanded,
-                onUpvoteClick = onUpvoteClick,
-                onDownvoteClick = onDownvoteClick,
-                onSaveClick = onSaveClick,
-                onMarkAsReadClick = onMarkAsReadClick,
-                onEditCommentClick = onEditCommentClick,
-                onDeleteCommentClick = onDeleteCommentClick,
-                onPersonClick = onPersonClick,
-                onCommunityClick = onCommunityClick,
-                onPostClick = onPostClick,
-                showPostAndCommunityContext = showPostAndCommunityContext,
-                onReportClick = onReportClick,
-                onCommentLinkClick = onCommentLinkClick,
-                onFetchChildrenClick = onFetchChildrenClick,
-                onReplyClick = onReplyClick,
-                onBlockCreatorClick = onBlockCreatorClick,
-                account = account,
-                moderators = moderators,
-            )
-        }
+    node.children?.also { nodes ->
+        commentNodeItems(
+            nodes = nodes,
+            isFlat = isFlat,
+            toggleExpanded = toggleExpanded,
+            isExpanded = isExpanded,
+            onUpvoteClick = onUpvoteClick,
+            onDownvoteClick = onDownvoteClick,
+            onSaveClick = onSaveClick,
+            onMarkAsReadClick = onMarkAsReadClick,
+            onEditCommentClick = onEditCommentClick,
+            onDeleteCommentClick = onDeleteCommentClick,
+            onPersonClick = onPersonClick,
+            onCommunityClick = onCommunityClick,
+            onPostClick = onPostClick,
+            showPostAndCommunityContext = showPostAndCommunityContext,
+            onReportClick = onReportClick,
+            onCommentLinkClick = onCommentLinkClick,
+            onFetchChildrenClick = onFetchChildrenClick,
+            onReplyClick = onReplyClick,
+            onBlockCreatorClick = onBlockCreatorClick,
+            account = account,
+            moderators = moderators,
+            isCollapsedByParent = isCollapsedByParent || !isExpanded(commentId),
+        )
     }
 }
 
@@ -560,6 +566,7 @@ fun CommentNodesPreview() {
         onPostClick = {},
         moderators = listOf(),
         listState = rememberLazyListState(),
+        isCollapsedByParent = false,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -89,6 +89,8 @@ fun CommentNodeHeader(
     score: Int,
     myVote: Int?,
     isModerator: Boolean,
+    collapsedCommentsCount: Int,
+    isExpanded: Boolean,
     onClick: () -> Unit,
 ) {
     CommentOrPostNodeHeader(
@@ -102,6 +104,8 @@ fun CommentNodeHeader(
         isPostCreator = isPostCreator(commentView),
         isModerator = isModerator,
         isCommunityBanned = commentView.creator_banned_from_community,
+        collapsedCommentsCount = collapsedCommentsCount,
+        isExpanded = isExpanded,
         onClick = onClick,
     )
 }
@@ -116,6 +120,8 @@ fun CommentNodeHeaderPreview() {
         isModerator = false,
         onPersonClick = {},
         onClick = {},
+        collapsedCommentsCount = 5,
+        isExpanded = false,
     )
 }
 
@@ -245,6 +251,8 @@ fun LazyListScope.commentNodeItem(
                         onClick = {
                             toggleExpanded(commentId)
                         },
+                        collapsedCommentsCount = getDecendentsCount(node),
+                        isExpanded = isExpanded(commentId),
                     )
                     AnimatedVisibility(
                         visible = isExpanded(commentId) || showCollapsedCommentContent,
@@ -718,4 +726,13 @@ fun ShowCommentContextButtonsPreview() {
         onPostClick = {},
         onCommentClick = {},
     )
+}
+
+fun getDecendentsCount(commentNode: CommentNodeData): Int {
+    var count = 0
+    commentNode.children?.forEach {
+        count += 1
+        count += getDecendentsCount(it)
+    }
+    return count
 }

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -184,7 +184,7 @@ fun LazyListScope.commentNodeItem(
     onCommentLinkClick: (commentView: CommentView) -> Unit,
     onBlockCreatorClick: (creator: PersonSafe) -> Unit,
     onFetchChildrenClick: (commentView: CommentView) -> Unit,
-    showCollapsedCommentContent: Boolean = false,
+    showCollapsedCommentContent: Boolean,
     showPostAndCommunityContext: Boolean = false,
     account: Account?,
     isCollapsedByParent: Boolean,
@@ -343,6 +343,7 @@ fun LazyListScope.commentNodeItem(
             account = account,
             moderators = moderators,
             isCollapsedByParent = isCollapsedByParent || !isExpanded(commentId),
+            showCollapsedCommentContent = showCollapsedCommentContent,
         )
     }
 }
@@ -567,6 +568,7 @@ fun CommentNodesPreview() {
         moderators = listOf(),
         listState = rememberLazyListState(),
         isCollapsedByParent = false,
+        showCollapsedCommentContent = false,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -178,6 +178,7 @@ fun LazyListScope.commentNodeItem(
     onCommentLinkClick: (commentView: CommentView) -> Unit,
     onBlockCreatorClick: (creator: PersonSafe) -> Unit,
     onFetchChildrenClick: (commentView: CommentView) -> Unit,
+    showCollapsedCommentContent: Boolean = false,
     showPostAndCommunityContext: Boolean = false,
     account: Account?,
 ) {
@@ -246,7 +247,7 @@ fun LazyListScope.commentNodeItem(
                         },
                     )
                     AnimatedVisibility(
-                        visible = isExpanded(commentId),
+                        visible = isExpanded(commentId) || showCollapsedCommentContent,
                         enter = expandVertically(),
                         exit = shrinkVertically(),
                     ) {

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
@@ -35,7 +35,7 @@ fun CommentNodes(
     account: Account? = null,
     moderators: List<CommunityModeratorView>,
     showPostAndCommunityContext: Boolean = false,
-    showCollapsedCommentContent: Boolean = false,
+    showCollapsedCommentContent: Boolean,
     isCollapsedByParent: Boolean,
 ) {
     // Holds the un-expanded comment ids
@@ -98,7 +98,7 @@ fun LazyListScope.commentNodeItems(
     account: Account? = null,
     moderators: List<CommunityModeratorView>,
     showPostAndCommunityContext: Boolean = false,
-    showCollapsedCommentContent: Boolean = false,
+    showCollapsedCommentContent: Boolean,
     isCollapsedByParent: Boolean,
 ) {
     nodes.forEach { node ->

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
@@ -35,6 +35,7 @@ fun CommentNodes(
     account: Account? = null,
     moderators: List<CommunityModeratorView>,
     showPostAndCommunityContext: Boolean = false,
+    showCollapsedCommentContent: Boolean = false,
 ) {
     // Holds the un-expanded comment ids
     val unExpandedComments = remember { mutableStateListOf<Int>() }
@@ -68,6 +69,7 @@ fun CommentNodes(
             onFetchChildrenClick = onFetchChildrenClick,
             onBlockCreatorClick = onBlockCreatorClick,
             showPostAndCommunityContext = showPostAndCommunityContext,
+            showCollapsedCommentContent = showCollapsedCommentContent,
         )
     }
 }
@@ -94,6 +96,7 @@ fun LazyListScope.commentNodeItems(
     account: Account? = null,
     moderators: List<CommunityModeratorView>,
     showPostAndCommunityContext: Boolean = false,
+    showCollapsedCommentContent: Boolean = false,
 ) {
     nodes.forEach { node ->
         commentNodeItem(
@@ -118,6 +121,7 @@ fun LazyListScope.commentNodeItems(
             onFetchChildrenClick = onFetchChildrenClick,
             onBlockCreatorClick = onBlockCreatorClick,
             showPostAndCommunityContext = showPostAndCommunityContext,
+            showCollapsedCommentContent = showCollapsedCommentContent,
         )
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
@@ -36,6 +36,7 @@ fun CommentNodes(
     moderators: List<CommunityModeratorView>,
     showPostAndCommunityContext: Boolean = false,
     showCollapsedCommentContent: Boolean = false,
+    isCollapsedByParent: Boolean,
 ) {
     // Holds the un-expanded comment ids
     val unExpandedComments = remember { mutableStateListOf<Int>() }
@@ -70,6 +71,7 @@ fun CommentNodes(
             onBlockCreatorClick = onBlockCreatorClick,
             showPostAndCommunityContext = showPostAndCommunityContext,
             showCollapsedCommentContent = showCollapsedCommentContent,
+            isCollapsedByParent = isCollapsedByParent,
         )
     }
 }
@@ -97,6 +99,7 @@ fun LazyListScope.commentNodeItems(
     moderators: List<CommunityModeratorView>,
     showPostAndCommunityContext: Boolean = false,
     showCollapsedCommentContent: Boolean = false,
+    isCollapsedByParent: Boolean,
 ) {
     nodes.forEach { node ->
         commentNodeItem(
@@ -122,6 +125,7 @@ fun LazyListScope.commentNodeItems(
             onBlockCreatorClick = onBlockCreatorClick,
             showPostAndCommunityContext = showPostAndCommunityContext,
             showCollapsedCommentContent = showCollapsedCommentContent,
+            isCollapsedByParent = isCollapsedByParent,
         )
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
@@ -88,6 +88,8 @@ fun RepliedComment(
             score = commentView.counts.score,
             myVote = commentView.my_vote,
             isModerator = isModerator,
+            collapsedCommentsCount = 0,
+            isExpanded = true,
             onClick = {},
         )
         SelectionContainer {

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -223,6 +223,8 @@ fun CommentOrPostNodeHeader(
     isModerator: Boolean,
     isCommunityBanned: Boolean,
     onClick: () -> Unit,
+    isExpanded: Boolean = true,
+    collapsedCommentsCount: Int = 0,
 ) {
     FlowRow(
         mainAxisAlignment = FlowMainAxisAlignment.SpaceBetween,
@@ -262,7 +264,14 @@ fun CommentOrPostNodeHeader(
                 isCommunityBanned = isCommunityBanned,
             )
         }
-        ScoreAndTime(score = score, myVote = myVote, published = published, updated = updated)
+        ScoreAndTime(
+            score = score,
+            myVote = myVote,
+            published = published,
+            updated = updated,
+            isExpanded = isExpanded,
+            collapsedCommentsCount = collapsedCommentsCount,
+        )
     }
 }
 
@@ -417,7 +426,8 @@ fun Sidebar(
 
     LazyColumn(
         state = listState,
-        modifier = Modifier.padding(padding)
+        modifier = Modifier
+            .padding(padding)
             .simpleVerticalScrollbar(listState),
         verticalArrangement = Arrangement.spacedBy(MEDIUM_PADDING),
     ) {

--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -1,11 +1,24 @@
 package com.jerboa.ui.components.common
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -78,11 +91,15 @@ fun ScoreAndTime(
     myVote: Int?,
     published: String,
     updated: String?,
+    isExpanded: Boolean = true,
+    collapsedCommentsCount: Int = 0,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(SMALL_PADDING),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        CollapsedIndicator(visible = !isExpanded, descendants = collapsedCommentsCount)
+        Spacer(modifier = Modifier.padding(end = SMALL_PADDING))
         Text(
             text = score.toString(),
             color = scoreColor(myVote = myVote),
@@ -102,4 +119,34 @@ fun ScoreAndTimePreview() {
         published = samplePost.published,
         updated = samplePost.updated,
     )
+}
+
+@Composable
+fun CollapsedIndicator(visible: Boolean, descendants: Int) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        Column(modifier = Modifier.wrapContentSize(Alignment.Center)) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(MaterialTheme.colorScheme.secondary)
+                    .padding(horizontal = SMALL_PADDING),
+            ) {
+                Text(
+                    text = "+$descendants",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CollapsedIndicatorPreview() {
+    CollapsedIndicator(visible = true, descendants = 23)
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -124,7 +124,7 @@ fun ScoreAndTimePreview() {
 @Composable
 fun CollapsedIndicator(visible: Boolean, descendants: Int) {
     AnimatedVisibility(
-        visible = visible,
+        visible = visible && descendants > 0,
         enter = fadeIn(),
         exit = fadeOut(),
     ) {

--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -138,7 +138,7 @@ fun CollapsedIndicator(visible: Boolean, descendants: Int) {
                 Text(
                     text = "+$descendants",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White,
+                    color = MaterialTheme.colorScheme.onSecondary,
                 )
             }
         }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -516,6 +516,7 @@ fun UserTabs(
                             showPostAndCommunityContext = true,
                             account = account,
                             moderators = listOf(),
+                            isCollapsedByParent = false,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -514,6 +514,7 @@ fun UserTabs(
                                 }
                             },
                             showPostAndCommunityContext = true,
+                            showCollapsedCommentContent = true,
                             account = account,
                             moderators = listOf(),
                             isCollapsedByParent = false,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -50,6 +50,7 @@ fun PostActivity(
     commentReplyViewModel: CommentReplyViewModel,
     postEditViewModel: PostEditViewModel,
     navController: NavController,
+    showCollapsedCommentContent: Boolean,
 ) {
     Log.d("jerboa", "got to post activity")
 
@@ -311,6 +312,7 @@ fun PostActivity(
                             onPostClick = {}, // Do nothing
                             account = account,
                             moderators = postViewModel.moderators,
+                            showCollapsedCommentContent = showCollapsedCommentContent,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -313,6 +313,7 @@ fun PostActivity(
                             account = account,
                             moderators = postViewModel.moderators,
                             showCollapsedCommentContent = showCollapsedCommentContent,
+                            isCollapsedByParent = false,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -47,6 +47,8 @@ fun LookAndFeelActivity(
     )
     val postViewModeState = rememberIntSettingState(settings?.postViewMode ?: 0)
     val showBottomNavState = rememberBooleanSettingState(settings?.showBottomNav ?: true)
+    val showCollapsedCommentContentState =
+        rememberBooleanSettingState(settings?.showCollapsedCommentContent ?: false)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -60,6 +62,7 @@ fun LookAndFeelActivity(
                 fontSize = fontSizeState.value.toInt(),
                 postViewMode = postViewModeState.value,
                 showBottomNav = showBottomNavState.value,
+                showCollapsedCommentContent = showCollapsedCommentContentState.value,
             ),
         )
     }
@@ -141,6 +144,13 @@ fun LookAndFeelActivity(
                     state = showBottomNavState,
                     title = {
                         Text(text = "Show navigation bar")
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = showCollapsedCommentContentState,
+                    title = {
+                        Text(text = "Show content for collapsed comments")
                     },
                     onCheckedChange = { updateAppSettings() },
                 )


### PR DESCRIPTION
Basic functionality is working, but still a few TODOs on this:

- ~No indication if a comment is collapsed since the whole body is shown. Boost uses a little +N icon in the top bar.~
- ~Comments folding isn't animated currently~
- ~Settings migrations needs to be tested~