### PR TITLE
Change CommunityTopBar to use LargeTopAppBar from ExperimentalMaterial3Api

### DIFF
--- a/app/src/androidTest/java/com/jerboa/CommunityTopSectionTest.kt
+++ b/app/src/androidTest/java/com/jerboa/CommunityTopSectionTest.kt
@@ -1,0 +1,103 @@
+package com.jerboa
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.jerboa.datatypes.sampleCommunityNoBannerView
+import com.jerboa.datatypes.sampleCommunityNoBannerViewSubscribed
+import com.jerboa.datatypes.sampleCommunityView
+import com.jerboa.datatypes.sampleCommunityViewSubscribed
+import com.jerboa.ui.components.community.CommunityTopSection
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CommunityTopSectionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun communityTopSection_RenderedCorrectlyWithoutBanner() {
+        // Arrange
+        val communityView = sampleCommunityNoBannerView
+        // Act
+        composeTestRule.setContent {
+            CommunityTopSection(
+                communityView = communityView,
+                onClickFollowCommunity = {},
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithText("Socialism").assertIsDisplayed()
+        composeTestRule.onNodeWithText("82 users / month").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Subscribe").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Joined").assertDoesNotExist()
+    }
+
+    @Test
+    fun communityTopSection_WithBanner() {
+        // Arrange
+        val communityView = sampleCommunityView
+
+        // Act
+        composeTestRule.setContent {
+            CommunityTopSection(
+                communityView = communityView,
+                onClickFollowCommunity = {},
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithContentDescription("Banner image for Socialism")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("82 users / month").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Subscribe").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Joined").assertDoesNotExist()
+    }
+
+    @Test
+    fun communityTopSection_NoBannerSubscribed() {
+        // Arrange
+        val communityView = sampleCommunityNoBannerViewSubscribed
+
+        // Act
+        composeTestRule.setContent {
+            CommunityTopSection(
+                communityView = communityView,
+                onClickFollowCommunity = {},
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithText("Socialism").assertIsDisplayed()
+        composeTestRule.onNodeWithText("82 users / month").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Joined").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Subscribe").assertDoesNotExist()
+    }
+
+    @Test
+    fun communityTopSection_WithBannerSubscribed() {
+        // Arrange
+        val communityView = sampleCommunityViewSubscribed
+
+        // Act
+        composeTestRule.setContent {
+            CommunityTopSection(
+                communityView = communityView,
+                onClickFollowCommunity = {},
+            )
+        }
+
+        // Assert
+        composeTestRule.onNodeWithContentDescription("Banner image for Socialism")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("82 users / month").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Joined").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Subscribe").assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/jerboa/datatypes/SampleData.kt
+++ b/app/src/main/java/com/jerboa/datatypes/SampleData.kt
@@ -137,7 +137,6 @@ val samplePersonSafe2 = PersonSafe(
     ban_expires = null,
     instance_id = 0,
 )
-
 val sampleCommunitySafe = CommunitySafe(
     id = 14681,
     name = "socialism",
@@ -156,7 +155,24 @@ val sampleCommunitySafe = CommunitySafe(
     hidden = false,
     posting_restricted_to_mods = false,
 )
-
+val sampleCommunityNoBannerSafe = CommunitySafe(
+    id = 14681,
+    name = "socialism",
+    title = "Socialism",
+    description = "This is the r/socialism community",
+    removed = false,
+    published = "2019-04-30T13:28:35.965035",
+    updated = "2021-01-25T16:27:15.804739",
+    deleted = false,
+    nsfw = false,
+    actor_id = "https://lemmy.ml/c/socialism",
+    local = true,
+    icon = "https://lemmy.ml/pictrs/image/QtiqDmp9XY.png",
+    banner = null,
+    instance_id = 0,
+    hidden = false,
+    posting_restricted_to_mods = false,
+)
 val samplePostAggregates = PostAggregates(
     id = 56195,
     post_id = 135129,
@@ -386,6 +402,27 @@ val sampleCommunityAggregates = CommunityAggregates(
 val sampleCommunityView = CommunityView(
     community = sampleCommunitySafe,
     subscribed = SubscribedType.NotSubscribed,
+    blocked = false,
+    counts = sampleCommunityAggregates,
+)
+
+val sampleCommunityNoBannerView = CommunityView(
+    community = sampleCommunityNoBannerSafe,
+    subscribed = SubscribedType.NotSubscribed,
+    blocked = false,
+    counts = sampleCommunityAggregates,
+)
+
+val sampleCommunityViewSubscribed = CommunityView(
+    community = sampleCommunitySafe,
+    subscribed = SubscribedType.Subscribed,
+    blocked = false,
+    counts = sampleCommunityAggregates,
+)
+
+val sampleCommunityNoBannerViewSubscribed = CommunityView(
+    community = sampleCommunityNoBannerSafe,
+    subscribed = SubscribedType.Subscribed,
     blocked = false,
     counts = sampleCommunityAggregates,
 )

--- a/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
@@ -139,6 +139,7 @@ fun PictrsUrlImage(
 fun PictrsBannerImage(
     url: String,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
 ) {
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
@@ -146,7 +147,7 @@ fun PictrsBannerImage(
             .crossfade(true)
             .build(),
         placeholder = painterResource(R.drawable.ic_launcher_foreground),
-        contentDescription = null,
+        contentDescription = contentDescription,
         contentScale = ContentScale.FillWidth,
         modifier = modifier.fillMaxWidth(),
     )

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -3,6 +3,8 @@
 package com.jerboa.ui.components.community
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
@@ -15,7 +17,10 @@ import androidx.navigation.compose.rememberNavController
 import com.jerboa.datatypes.CommunityView
 import com.jerboa.datatypes.SortType
 import com.jerboa.datatypes.SubscribedType
+import com.jerboa.datatypes.sampleCommunityNoBannerView
+import com.jerboa.datatypes.sampleCommunityNoBannerViewSubscribed
 import com.jerboa.datatypes.sampleCommunityView
+import com.jerboa.datatypes.sampleCommunityViewSubscribed
 import com.jerboa.ui.components.common.IconAndTextDrawerItem
 import com.jerboa.ui.components.common.LargerCircularIcon
 import com.jerboa.ui.components.common.PictrsBannerImage
@@ -29,46 +34,44 @@ fun CommunityTopSection(
     modifier: Modifier = Modifier,
     onClickFollowCommunity: (communityView: CommunityView) -> Unit,
 ) {
+    val scrollState = rememberScrollState()
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .verticalScroll(scrollState),
     ) {
-        Box(
-            modifier = modifier
-                .fillMaxWidth(),
-            contentAlignment = Alignment.Center,
-        ) {
-            communityView.community.banner?.also {
-                PictrsBannerImage(
-                    url = it,
-                    modifier = Modifier.height(DRAWER_BANNER_SIZE),
-                )
-            }
-            communityView.community.icon?.also {
-                LargerCircularIcon(icon = it)
-            }
-        }
-        Column(
-            modifier = Modifier.padding(MEDIUM_PADDING),
-            verticalArrangement = Arrangement.spacedBy(MEDIUM_PADDING),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = communityView.community.title,
-                    style = MaterialTheme.typography.titleLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
-            Row {
-                Text(
-                    text = "${communityView.counts.users_active_month} users / month",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onBackground.muted,
-                )
-            }
-            Row {
+        LargeTopAppBar(
+            title = {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+
+                ) {
+                    communityView.community.banner?.also { bannerUrl ->
+                        PictrsBannerImage(
+                            url = bannerUrl,
+                            modifier = Modifier.height(DRAWER_BANNER_SIZE),
+                            contentDescription = "Banner image for ${communityView.community.title}",
+                        )
+                    } ?: Text(
+                        text = communityView.community.title,
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    communityView.community.icon?.also { icon ->
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomStart)
+                                .padding(start = SMALL_PADDING, bottom = SMALL_PADDING),
+                        ) {
+                            LargerCircularIcon(icon = icon)
+                        }
+                    }
+                }
+            },
+            scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
+            actions = {
                 when (communityView.subscribed) {
                     SubscribedType.Subscribed -> {
                         OutlinedButton(
@@ -84,6 +87,7 @@ fun CommunityTopSection(
                             )
                         }
                     }
+
                     SubscribedType.NotSubscribed -> {
                         Button(
                             onClick = { onClickFollowCommunity(communityView) },
@@ -100,6 +104,20 @@ fun CommunityTopSection(
                         }
                     }
                 }
+            },
+        )
+
+        Column(
+            modifier = Modifier.padding(MEDIUM_PADDING),
+            verticalArrangement = Arrangement.spacedBy(MEDIUM_PADDING),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Row {
+                Text(
+                    text = "${communityView.counts.users_active_month} users / month",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground.muted,
+                )
             }
         }
     }
@@ -110,6 +128,33 @@ fun CommunityTopSection(
 fun CommunityTopSectionPreview() {
     CommunityTopSection(
         communityView = sampleCommunityView,
+        onClickFollowCommunity = {},
+    )
+}
+
+@Preview
+@Composable
+fun CommunityTopSectionNoBannerPreview() {
+    CommunityTopSection(
+        communityView = sampleCommunityNoBannerView,
+        onClickFollowCommunity = {},
+    )
+}
+
+@Preview
+@Composable
+fun CommunitySubscribedTopSectionPreview() {
+    CommunityTopSection(
+        communityView = sampleCommunityViewSubscribed,
+        onClickFollowCommunity = {},
+    )
+}
+
+@Preview
+@Composable
+fun CommunitySubscribedTopSectionNoBannerPreview() {
+    CommunityTopSection(
+        communityView = sampleCommunityNoBannerViewSubscribed,
         onClickFollowCommunity = {},
     )
 }

--- a/app/src/test/java/com/jerboa/ExampleUnitTest.kt
+++ b/app/src/test/java/com/jerboa/ExampleUnitTest.kt
@@ -58,7 +58,6 @@ class ExampleUnitTest {
             auth = null,
         )
         val out = api.getPost(form.serializeToMap()).body()!!
-        println(out.comments)
         assertNotNull(out)
     }
 


### PR DESCRIPTION
Right now on the web UI (in mobile and desktop) a community icon optionally appears on the bottom left, while the banner is centered:



<img src="https://github.com/dessalines/jerboa/assets/556288/226476c3-3f13-475e-b9f0-eac9d9b58110" width="200" > <img src="https://github.com/dessalines/jerboa/assets/556288/cb4362a4-6e87-4471-a9e7-47afc53585eb" width="200" > <img src="https://github.com/dessalines/jerboa/assets/556288/978e2fdb-8c17-4a5e-a38d-d96372ef1ef6" width="200" >

but meanwhile in jerboa the community icon is centered as well, which generally obscures the middle of the banner picture: 

<img src="https://github.com/dessalines/jerboa/assets/556288/6f169de1-83cd-426a-92b1-7e7324765699" width="200" >
<img src="https://github.com/dessalines/jerboa/assets/556288/2e3d62de-7c5d-419f-9517-914c878815ff" width="200" >

I would propose changing the jerboa UI to match web mobile & desktop, and have the community icon optionally appear bottom left justified with the community banner centered.

Creating this MR to propose the idea and then let me see if I can get this building locally to actually see if it works. 