### PR TITLE
Change color of account name to adapt to light/dark mode

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -57,7 +57,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -392,7 +391,7 @@ fun AvatarAndAccountName(myPerson: PersonSafe?) {
         }
         PersonName(
             person = myPerson,
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onSurface,
         )
     }
 }


### PR DESCRIPTION
Resolves #476 

Previously, when using light mode, the name of the account being used (that defaulted to "Anonymous") was very difficult to see since it was white text on a light background. This change makes the text use the color of the other sidebar items, which adapts to a different color depending on what theme the user is using.