### PR TITLE
Reduce stuttering in post listings

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -64,7 +64,7 @@ fun HomeActivity(
     val postListState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
     val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
     val ctx = LocalContext.current
     val account = getCurrentAccount(accountViewModel)
 

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -1,10 +1,10 @@
 package com.jerboa.ui.components.post
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
@@ -28,6 +28,8 @@ import com.jerboa.isScrolledToEnd
 import com.jerboa.ui.components.common.simpleVerticalScrollbar
 import com.jerboa.ui.components.home.Tagline
 import com.jerboa.ui.theme.SMALL_PADDING
+
+const val listingChunkSize = 10
 
 @Composable
 fun PostListings(
@@ -55,6 +57,13 @@ fun PostListings(
     taglines: List<Tagline>?,
     postViewMode: PostViewMode,
 ) {
+    val remainingCount by remember {
+        derivedStateOf { posts.size % listingChunkSize }
+    }
+    val chunkCount by remember {
+        derivedStateOf { posts.size.floorDiv(listingChunkSize) + if (remainingCount > 0) 1 else 0 }
+    }
+
     SwipeRefresh(
         state = rememberSwipeRefreshState(loading),
         onRefresh = onSwipeRefresh,
@@ -74,34 +83,39 @@ fun PostListings(
                 contentAboveListings()
             }
 
-            // List of items
-            items(
-                posts,
-                key = { postView ->
-                    postView.post.id
-                },
-            ) { postView ->
-                PostListing(
-                    postView = postView,
-                    onUpvoteClick = onUpvoteClick,
-                    onDownvoteClick = onDownvoteClick,
-                    onPostClick = onPostClick,
-                    onPostLinkClick = onPostLinkClick,
-                    onSaveClick = onSaveClick,
-                    onCommunityClick = onCommunityClick,
-                    onEditPostClick = onEditPostClick,
-                    onDeletePostClick = onDeletePostClick,
-                    onReportClick = onReportClick,
-                    onPersonClick = onPersonClick,
-                    onBlockCommunityClick = onBlockCommunityClick,
-                    onBlockCreatorClick = onBlockCreatorClick,
-                    isModerator = false,
-                    showCommunityName = showCommunityName,
-                    fullBody = false,
-                    account = account, // TODO can't know with many posts
-                    postViewMode = postViewMode,
-                )
-                Divider(modifier = Modifier.padding(bottom = SMALL_PADDING))
+            for (chunkIdx in 0 until chunkCount) {
+                item {
+                    Column {
+                        val count =
+                            if (chunkIdx < chunkCount - 1) listingChunkSize else remainingCount
+
+                        for (i in 0 until count) {
+                            val index = (chunkIdx * listingChunkSize) + i
+
+                            PostListing(
+                                postView = posts[index],
+                                onUpvoteClick = onUpvoteClick,
+                                onDownvoteClick = onDownvoteClick,
+                                onPostClick = onPostClick,
+                                onPostLinkClick = onPostLinkClick,
+                                onSaveClick = onSaveClick,
+                                onCommunityClick = onCommunityClick,
+                                onEditPostClick = onEditPostClick,
+                                onDeletePostClick = onDeletePostClick,
+                                onReportClick = onReportClick,
+                                onPersonClick = onPersonClick,
+                                onBlockCommunityClick = onBlockCommunityClick,
+                                onBlockCreatorClick = onBlockCreatorClick,
+                                isModerator = false,
+                                showCommunityName = showCommunityName,
+                                fullBody = false,
+                                account = account, // TODO can't know with many posts
+                                postViewMode = postViewMode,
+                            )
+                            Divider(modifier = Modifier.padding(bottom = SMALL_PADDING))
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
I've managed to alleviate the constant stuttering every time a new post listing enters the screen by grouping a few posts into groups. This way the LazyColumn only has to create and destroy components much less often, reducing the feeling of stuttering.

This of course means that, whenever a new group must be created or removed, the stutter is more noticeable. However, this stutter doesn't seem to scale linearly with the amount of items per chunk and it's only slightly more noticeable than the stutter caused by every single item, so I think the trade is worth it.
If we decide that this is a good way to do it, it should be possible to make the same improvements to the comment nodes.

The current chunk size is set to 10 as a completely arbitrary number, we could play around with it to see what works best or even set it to the amount of items returned in a single post fetch call.

When/if #411 is implemented we could probably get away with grouping an entire page into a single chunk, making the experience completely stutter free.

I have also disabled the home top bar coming in and out as you scroll because it was a huge cause of lag, however this was only for testing purposes and I imagine we might wanna re-enable it later.

Fixes #445 somewhat.