### PR TITLE
Add linkify plugin to markwon

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     // Markdown support
     implementation 'io.noties.markwon:core:4.6.2'
     implementation 'io.noties.markwon:image-coil:4.6.2'
+    implementation 'io.noties.markwon:linkify:4.6.2'
 
     // Accompanist
     implementation 'com.google.accompanist:accompanist-pager:0.30.1'

--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -20,8 +20,12 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.res.ResourcesCompat
 import coil.ImageLoader
 import com.jerboa.R
+import com.jerboa.openLink
+import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
+import io.noties.markwon.MarkwonConfiguration
 import io.noties.markwon.image.coil.CoilImagesPlugin
+import io.noties.markwon.linkify.LinkifyPlugin
 
 object MarkdownHelper {
     private var markwon: Markwon? = null
@@ -34,6 +38,14 @@ object MarkdownHelper {
 
         markwon = Markwon.builder(context)
             .usePlugin(CoilImagesPlugin.create(context, loader))
+            .usePlugin(LinkifyPlugin.create())
+            .usePlugin(object : AbstractMarkwonPlugin() {
+                override fun configureConfiguration(builder: MarkwonConfiguration.Builder) {
+                    builder.linkResolver { view, link ->
+                        link?.let { openLink(link, view.context) }
+                    }
+                }
+            })
             .build()
     }
 


### PR DESCRIPTION
This adds the linkify plugin to markwon. This will allow links to be automatically detected and made clickable, even if that link isn't formatted as a markdown link. I also added a second plugin to configure links rendered by markwon to be opened using our `openLink` function, intended for future use like custom tabs, special handling of detected fediverse links, etc.