### PR TITLE
Handle /c/community@host URLs

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -383,13 +383,14 @@ fun LazyListState.isScrolledToEnd(): Boolean {
  * Parses a "url" and returns a spec-compliant Url:
  *
  * - https://host/path - leave as-is
+ * - http://host/path - leave as-is
  * - /c/community -> https://currentInstance/c/community
  * - /c/community@instance -> https://instance/c/community
  * - !community@instance -> https://instance/c/community
  * - @user@instance -> https://instance/u/user
  */
 fun parseUrl(url: String): String? {
-    if (url.startsWith("https://")) {
+    if (url.startsWith("https://") || url.startsWith("http://")) {
         return url
     } else if (url.startsWith("/c/")) {
         if (url.count({ c -> c == '@' }) == 1) {

--- a/app/src/test/java/com/jerboa/UtilsKtTest.kt
+++ b/app/src/test/java/com/jerboa/UtilsKtTest.kt
@@ -142,6 +142,7 @@ class UtilsKtTest {
     fun testParseUrl() {
         val cases = mapOf(
             "https://feddit.de" to "https://feddit.de",
+            "http://example.com" to "http://example.com",
             "/c/community" to "https://${API.currentInstance}/c/community",
             "/c/community@instance.ml" to "https://instance.ml/c/community",
             "!community@instance.ml" to "https://instance.ml/c/community",

--- a/app/src/test/java/com/jerboa/UtilsKtTest.kt
+++ b/app/src/test/java/com/jerboa/UtilsKtTest.kt
@@ -1,6 +1,7 @@
 package com.jerboa
 
 import androidx.compose.ui.unit.dp
+import com.jerboa.api.API
 import com.jerboa.datatypes.api.GetUnreadCountResponse
 import com.jerboa.ui.theme.SMALL_PADDING
 import org.junit.Assert.*
@@ -135,5 +136,20 @@ class UtilsKtTest {
         assertEquals("1M", siFormat(1000000))
         assertEquals("1.2M", siFormat(1234500))
         assertEquals("12M", siFormat(12345000))
+    }
+
+    @Test
+    fun testParseUrl() {
+        val cases = mapOf(
+            "https://feddit.de" to "https://feddit.de",
+            "/c/community" to "https://${API.currentInstance}/c/community",
+            "/c/community@instance.ml" to "https://instance.ml/c/community",
+            "!community@instance.ml" to "https://instance.ml/c/community",
+            "!community" to "https://${API.currentInstance}/c/community",
+            "/u/user@instance.ml" to "https://instance.ml/u/user",
+            "@user@instance.ml" to "https://instance.ml/u/user",
+        )
+
+        cases.forEach { (url, exp) -> assertEquals(exp, parseUrl(url)) }
     }
 }


### PR DESCRIPTION
This is a partial fix to #556, but it at least prevents crashing when an unknown URL type is encountered. There is still some work to do, since the markdown plugin interprets the following as mailto: urls:

- @user@instance
- !community@instance

I'm not sure what the supported URL types are intended to be, so I didn't bother implementing a plugin.