### PR TITLE
Comment action bar fixes

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -318,7 +318,7 @@ fun CommentMentionNode(
 
     var viewSource by remember { mutableStateOf(false) }
     var isExpanded by remember { mutableStateOf(true) }
-    var isActionBarExpanded by remember { mutableStateOf(false) }
+    var isActionBarExpanded by remember { mutableStateOf(true) }
 
     Column(
         modifier = Modifier.padding(horizontal = LARGE_PADDING),
@@ -353,7 +353,9 @@ fun CommentMentionNode(
                     comment = personMentionView.comment,
                     viewSource = viewSource,
                     onClick = {},
-                    onLongClick = {},
+                    onLongClick = {
+                        isActionBarExpanded = !isActionBarExpanded
+                    },
                 )
                 AnimatedVisibility(
                     visible = isActionBarExpanded,

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
@@ -316,7 +316,7 @@ fun CommentReplyNode(
 
     var viewSource by remember { mutableStateOf(false) }
     var isExpanded by remember { mutableStateOf(true) }
-    var isActionBarExpanded by remember { mutableStateOf(false) }
+    var isActionBarExpanded by remember { mutableStateOf(true) }
 
     Column(
         modifier = Modifier.padding(horizontal = LARGE_PADDING),
@@ -351,7 +351,9 @@ fun CommentReplyNode(
                     comment = commentReplyView.comment,
                     viewSource = viewSource,
                     onClick = {},
-                    onLongClick = {},
+                    onLongClick = {
+                        isActionBarExpanded = !isActionBarExpanded
+                    },
                 )
                 AnimatedVisibility(
                     visible = isActionBarExpanded,

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -547,7 +547,7 @@ fun UserTabs(
                             account = account,
                             moderators = listOf(),
                             isCollapsedByParent = false,
-                            showActionBarByDefault = appSettingsViewModel.appSettings.value?.showCommentActionBarByDefault ?: true,
+                            showActionBarByDefault = true,
                             enableDownVotes = enableDownVotes,
                             showAvatar = showAvatar,
                         )


### PR DESCRIPTION
The "Show action bar by default for comments" setting now only affects comment trees in post listing views, not single comments in the user's inbox (replies/mentions), saved comments, or profile comments. This gives them convenient access to the action bar for single comments they're likely to want to interact with.

Also allow user to toggle action bar visibility for inbox replies and mentions by long tapping on the comment body (not just the comment header), which makes this behaviour consistent with long tapping on comments in normal post listings.