### PR TITLE
Show link dialog on long press

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -15,6 +15,7 @@ import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import android.util.Patterns
+import android.webkit.MimeTypeMap
 import android.widget.Toast
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -58,7 +59,9 @@ import com.jerboa.ui.components.home.SiteViewModel
 import com.jerboa.ui.components.person.UserTab
 import com.jerboa.ui.theme.SMALL_PADDING
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.ocpsoft.prettytime.PrettyTime
 import java.io.IOException
 import java.io.InputStream
@@ -879,6 +882,23 @@ fun saveBitmap(
 
         throw e
     }
+}
+
+suspend fun saveImage(url: String, context: Context) {
+    Toast.makeText(context, "Saving image...", Toast.LENGTH_SHORT).show()
+
+    val fileName = Uri.parse(url).pathSegments.last()
+
+    val extension = MimeTypeMap.getFileExtensionFromUrl(url)
+    val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+
+    withContext(Dispatchers.IO) {
+        URL(url).openStream().use {
+            saveBitmap(context, it, mimeType, fileName)
+        }
+    }
+
+    Toast.makeText(context, "Saved image", Toast.LENGTH_SHORT).show()
 }
 
 @OptIn(ExperimentalComposeUiApi::class)

--- a/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
@@ -364,7 +364,7 @@ fun PostLinkOptionsDialog(
 
                 IconAndTextDrawerItem(
                     icon = Icons.Filled.OpenInBrowser,
-                    text = "Open in browser",
+                    text = stringResource(R.string.link_dialog_open_in_browser),
                     onClick = {
                         onOpenInBrowser()
                         onDismissRequest()
@@ -372,7 +372,7 @@ fun PostLinkOptionsDialog(
                 )
                 IconAndTextDrawerItem(
                     icon = Icons.Filled.Share,
-                    text = "Share link",
+                    text = stringResource(R.string.link_dialog_share_link),
                     onClick = {
                         val sendIntent: Intent = Intent().apply {
                             action = Intent.ACTION_SEND
@@ -388,10 +388,10 @@ fun PostLinkOptionsDialog(
                 )
                 IconAndTextDrawerItem(
                     icon = Icons.Outlined.ContentCopy,
-                    text = "Copy link",
+                    text = stringResource(R.string.link_dialog_copy_link),
                     onClick = {
                         clipboardManager.setText(AnnotatedString(url))
-                        Toast.makeText(context, "URL copied to clipboard", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(context, context.resources.getString(R.string.link_dialog_toast_url_copied), Toast.LENGTH_SHORT).show()
                         onDismissRequest()
                     },
                 )
@@ -401,7 +401,7 @@ fun PostLinkOptionsDialog(
 
                     IconAndTextDrawerItem(
                         icon = Icons.Outlined.Download,
-                        text = "Download image",
+                        text = stringResource(R.string.link_dialog_download_image),
                         onClick = {
                             coroutineScope.launch {
                                 saveImage(url, context)

--- a/app/src/main/java/com/jerboa/ui/components/common/ImageViewerDialog.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/ImageViewerDialog.kt
@@ -1,10 +1,6 @@
 package com.jerboa.ui.components.common
 
-import android.content.Context
-import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
-import android.webkit.MimeTypeMap
-import android.widget.Toast
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -43,13 +39,10 @@ import coil.ImageLoader
 import coil.compose.rememberAsyncImagePainter
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
-import com.jerboa.saveBitmap
-import kotlinx.coroutines.Dispatchers
+import com.jerboa.saveImage
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import net.engawapg.lib.zoomable.rememberZoomState
 import net.engawapg.lib.zoomable.zoomable
-import java.net.URL
 
 const val backFadeTime = 300
 
@@ -134,29 +127,12 @@ fun ImageViewerDialog(url: String, onBackRequest: () -> Unit) {
 
                 BarIcon(icon = Icons.Outlined.Download, name = "Download") {
                     coroutineScope.launch {
-                        SaveImage(url, context)
+                        saveImage(url, context)
                     }
                 }
             }
         }
     }
-}
-
-suspend fun SaveImage(url: String, context: Context) {
-    Toast.makeText(context, "Saving image...", Toast.LENGTH_SHORT).show()
-
-    val fileName = Uri.parse(url).pathSegments.last()
-
-    val extension = MimeTypeMap.getFileExtensionFromUrl(url)
-    val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-
-    withContext(Dispatchers.IO) {
-        URL(url).openStream().use {
-            saveBitmap(context, it, mimeType, fileName)
-        }
-    }
-
-    Toast.makeText(context, "Saved image", Toast.LENGTH_SHORT).show()
 }
 
 @Composable

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -816,7 +816,6 @@ fun PreviewLinkNoThumbnailPostListing() {
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostListing(
     postView: PostView,
@@ -1026,6 +1025,7 @@ fun PostListing(
             },
             onPostClick = onPostClick,
             onPostLinkClick = onPostLinkClick,
+            onPostLinkLongClick = { showLinkDialog = it },
             onCommunityClick = onCommunityClick,
             onPersonClick = onPersonClick,
             isModerator = isModerator,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -1,6 +1,5 @@
 package com.jerboa.ui.components.post
 
-import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
@@ -18,15 +17,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
-import androidx.compose.material.icons.filled.OpenInBrowser
-import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.BookmarkBorder
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
 import androidx.compose.material.icons.outlined.CommentsDisabled
-import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material.icons.outlined.Forum
@@ -48,7 +43,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,7 +55,6 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.startActivity
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.flowlayout.FlowCrossAxisAlignment
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
@@ -85,7 +78,6 @@ import com.jerboa.hostName
 import com.jerboa.isImage
 import com.jerboa.isSameInstance
 import com.jerboa.nsfwCheck
-import com.jerboa.saveImage
 import com.jerboa.ui.components.common.ActionBarButton
 import com.jerboa.ui.components.common.CircularIcon
 import com.jerboa.ui.components.common.CommentOrPostNodeHeader
@@ -95,6 +87,7 @@ import com.jerboa.ui.components.common.ImageViewerDialog
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.PictrsThumbnailImage
 import com.jerboa.ui.components.common.PictrsUrlImage
+import com.jerboa.ui.components.common.PostLinkOptionsDialog
 import com.jerboa.ui.components.common.PreviewLines
 import com.jerboa.ui.components.common.ScoreAndTime
 import com.jerboa.ui.components.common.SimpleTopAppBar
@@ -115,7 +108,6 @@ import com.jerboa.ui.theme.POST_LINK_PIC_SIZE
 import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XXL_PADDING
 import com.jerboa.ui.theme.muted
-import kotlinx.coroutines.launch
 
 @Composable
 fun PostHeaderLine(
@@ -854,78 +846,15 @@ fun PostListing(
         )
     }
 
-    val clipboardManager = LocalClipboardManager.current
-    val context = LocalContext.current
-    val coroutineScope = rememberCoroutineScope()
-
     var showLinkDialog by remember { mutableStateOf<String?>(null) }
 
     if (showLinkDialog != null) {
         val url = showLinkDialog!!
-        val isImage = isImage(url)
 
-        AlertDialog(
+        PostLinkOptionsDialog(
+            url = url,
             onDismissRequest = { showLinkDialog = null },
-            confirmButton = {},
-            text = {
-                Column {
-                    Text(
-                        text = url,
-                        modifier = Modifier
-                            .padding(bottom = 15.dp),
-                        color = MaterialTheme.colorScheme.primary,
-                    )
-
-                    IconAndTextDrawerItem(
-                        icon = Icons.Filled.OpenInBrowser,
-                        text = "Open in browser",
-                        onClick = {
-                            onPostLinkClick(url)
-                            showLinkDialog = null
-                        },
-                    )
-                    IconAndTextDrawerItem(
-                        icon = Icons.Filled.Share,
-                        text = "Share link",
-                        onClick = {
-                            val sendIntent: Intent = Intent().apply {
-                                action = Intent.ACTION_SEND
-                                putExtra(Intent.EXTRA_TEXT, url)
-                                type = "text/plain"
-                            }
-
-                            val shareIntent = Intent.createChooser(sendIntent, null)
-                            startActivity(context, shareIntent, null)
-
-                            showLinkDialog = null
-                        },
-                    )
-                    IconAndTextDrawerItem(
-                        icon = Icons.Outlined.ContentCopy,
-                        text = "Copy link",
-                        onClick = {
-                            clipboardManager.setText(AnnotatedString(url))
-                            Toast.makeText(context, "URL copied to clipboard", Toast.LENGTH_SHORT).show()
-                            showLinkDialog = null
-                        },
-                    )
-
-                    if (isImage) {
-                        Divider(modifier = Modifier.padding(vertical = 20.dp))
-
-                        IconAndTextDrawerItem(
-                            icon = Icons.Outlined.Download,
-                            text = "Download image",
-                            onClick = {
-                                coroutineScope.launch {
-                                    saveImage(url, context)
-                                }
-                                showLinkDialog = null
-                            },
-                        )
-                    }
-                }
-            },
+            onOpenInBrowser = { onPostLinkClick(url) },
         )
     }
 

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -873,7 +873,6 @@ fun PostListing(
                     Text(
                         text = url,
                         modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
                             .padding(bottom = 15.dp),
                         color = MaterialTheme.colorScheme.primary,
                     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,4 +288,9 @@
     <string name="bottomBar_label_profile">Profile</string>
     <string name="look_and_feel_show_action_bar_for_comments">Show action bar by default for comments</string>
     <string name="look_and_feel_show_voting_arrows_list_view">Show voting arrows in list view</string>
+    <string name="link_dialog_open_in_browser">Open in browser</string>
+    <string name="link_dialog_share_link">Share link</string>
+    <string name="link_dialog_copy_link">Copy link</string>
+    <string name="link_dialog_download_image">Download image</string>
+    <string name="link_dialog_toast_url_copied">URL copied to clipboard</string>
 </resources>


### PR DESCRIPTION
When long pressing a post thumbnail or image a dialog will show containing actions related to the post's link, similar to Boost. If the link is an image, an option to download it will be added.

![image](https://github.com/dessalines/jerboa/assets/3885705/92f2138f-4f59-4376-a579-1158991b541f)
