### PR TITLE
Make comment up/down vote consistent after you vote

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -565,7 +565,7 @@ fun CommentFooterLine(
                 item = commentView,
                 type = VoteType.Upvote,
                 onVoteClick = onUpvoteClick,
-                showNumber = (instantScores.downvotes != 0),
+                showNumber = (instantScores.myVote?.let { it != 0 } ?: let { false }),
                 account = account,
             )
             if (enableDownVotes) {
@@ -575,6 +575,7 @@ fun CommentFooterLine(
                     item = commentView,
                     type = VoteType.Downvote,
                     onVoteClick = onDownvoteClick,
+                    showNumber = (instantScores.myVote?.let { it != 0 } ?: let { false }),
                     account = account,
                 )
             }

--- a/app/src/main/java/com/jerboa/ui/components/common/VoteHelpers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/VoteHelpers.kt
@@ -27,11 +27,7 @@ fun <T> VoteGeneric(
     }
 
     val votesStr = if (showNumber) {
-        if (type == VoteType.Downvote && votes == 0) {
-            null
-        } else {
-            votes.toString()
-        }
+        votes.toString()
     } else {
         null
     }


### PR DESCRIPTION
this fixes https://github.com/dessalines/jerboa/issues/662

it makes it so for a comment you don't see the upvote/downvote specific count unless you vote - and then if you upvote or downvote you'll see both specific counts.

currently as #662 describes you only see this when you downvote, if you upvote you don't see it. 