### PR TITLE
Implement !community@instance and @user@instance links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
 
     // optional - Test helpers
     testImplementation "androidx.room:room-testing:2.5.1"
+    testImplementation  "pl.pragmatists:JUnitParams:1.1.1"
 
     // optional - Paging 3 Integration
     implementation "androidx.room:room-paging:2.5.1"

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -423,6 +423,14 @@ fun parseUrl(url: String): String? {
 fun openLink(url: String, ctx: Context, useCustomTab: Boolean, usePrivateTab: Boolean) {
     val url = parseUrl(url) ?: return
 
+    if (url.startsWith("@")) {
+        Toast.makeText(ctx, "User info links not yet supported", Toast.LENGTH_SHORT).show()
+        return
+    } else if (url.startsWith("!")) {
+        Toast.makeText(ctx, "Community links not yet supported", Toast.LENGTH_SHORT).show()
+        return
+    }
+
     if (useCustomTab) {
         val intent = CustomTabsIntent.Builder()
             .build().apply {

--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -2,6 +2,9 @@ package com.jerboa.ui.components.common
 
 import android.content.Context
 import android.os.Build
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.util.TypedValue
 import android.view.View
@@ -27,11 +30,93 @@ import com.jerboa.openLink
 import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonConfiguration
+import io.noties.markwon.MarkwonPlugin
+import io.noties.markwon.MarkwonVisitor
+import io.noties.markwon.SpannableBuilder
+import io.noties.markwon.core.CorePlugin
+import io.noties.markwon.core.CorePlugin.OnTextAddedListener
+import io.noties.markwon.core.CoreProps
 import io.noties.markwon.ext.strikethrough.StrikethroughPlugin
 import io.noties.markwon.ext.tables.TablePlugin
 import io.noties.markwon.html.HtmlPlugin
 import io.noties.markwon.image.coil.CoilImagesPlugin
 import io.noties.markwon.linkify.LinkifyPlugin
+import org.commonmark.node.Link
+import java.util.regex.Pattern
+
+/**
+ * pattern that matches all valid communities; intended to be loose
+ */
+const val communityPatternFragment: String = """[a-zA-Z0-9_]{3,}"""
+
+/**
+ * pattern to match all valid instances
+ */
+const val instancePatternFragment: String =
+    """([a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]\.)+[a-zA-Z]{2,}"""
+
+/**
+ * pattern to match all valid usernames
+ */
+const val userPatternFragment: String = """[a-zA-Z0-9_]{3,}"""
+
+/**
+ * Pattern to match lemmy's unique community pattern, e.g. !commmunity[@instance]
+ */
+val lemmyCommunityPattern: Pattern =
+    Pattern.compile("(?:^|\\s)!($communityPatternFragment)(?:@($instancePatternFragment))?\\b")
+
+/**
+ * Pattern to match lemmy's unique user pattern, e.g. @user[@instance]
+ */
+val lemmyUserPattern: Pattern =
+    Pattern.compile("(?:^|\\s)@($userPatternFragment)(?:@($instancePatternFragment))?\\b")
+
+/**
+ * Plugin to turn Lemmy-specific URIs into clickable links.
+ */
+class LemmyLinkPlugin : AbstractMarkwonPlugin() {
+    override fun configure(registry: MarkwonPlugin.Registry) {
+        registry.require(CorePlugin::class.java) { it.addOnTextAddedListener(LemmyTextAddedListener()) }
+    }
+
+    private class LemmyTextAddedListener : OnTextAddedListener {
+        override fun onTextAdded(visitor: MarkwonVisitor, text: String, start: Int) {
+            // we will be using the link that is used by markdown (instead of directly applying URLSpan)
+            val spanFactory = visitor.configuration().spansFactory().get(
+                Link::class.java,
+            ) ?: return
+
+            // don't re-use builder (thread safety achieved for
+            // render calls from different threads and ... better performance)
+            val builder = SpannableStringBuilder(text)
+            if (addLinks(builder)) {
+                // target URL span specifically
+                val spans = builder.getSpans(0, builder.length, URLSpan::class.java)
+                if (!spans.isNullOrEmpty()) {
+                    val renderProps = visitor.renderProps()
+                    val spannableBuilder = visitor.builder()
+                    for (span in spans) {
+                        CoreProps.LINK_DESTINATION[renderProps] = span.url
+                        SpannableBuilder.setSpans(
+                            spannableBuilder,
+                            spanFactory.getSpans(visitor.configuration(), renderProps),
+                            start + builder.getSpanStart(span),
+                            start + builder.getSpanEnd(span),
+                        )
+                    }
+                }
+            }
+        }
+
+        fun addLinks(text: Spannable): Boolean {
+            val communityLinkAdded = Linkify.addLinks(text, lemmyCommunityPattern, null)
+            val userLinkAdded = Linkify.addLinks(text, lemmyUserPattern, null)
+
+            return communityLinkAdded || userLinkAdded
+        }
+    }
+}
 
 object MarkdownHelper {
     private var markwon: Markwon? = null
@@ -44,7 +129,9 @@ object MarkdownHelper {
 
         markwon = Markwon.builder(context)
             .usePlugin(CoilImagesPlugin.create(context, loader))
+            // email urls interfere with lemmy links
             .usePlugin(LinkifyPlugin.create(Linkify.WEB_URLS))
+            .usePlugin(LemmyLinkPlugin())
             .usePlugin(StrikethroughPlugin.create())
             .usePlugin(TablePlugin.create(context))
             .usePlugin(HtmlPlugin.create())

--- a/app/src/test/java/com/jerboa/ui/components/common/LemmyLinkPluginTest.kt
+++ b/app/src/test/java/com/jerboa/ui/components/common/LemmyLinkPluginTest.kt
@@ -1,0 +1,70 @@
+package com.jerboa.ui.components.common
+
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(JUnitParamsRunner::class)
+class LemmyLinkPluginTest {
+    @Test
+    @Parameters(method = "communitySuccessCases")
+    fun testCommunityValid(pattern: String, community: String, instance: String?) {
+        val matcher = lemmyCommunityPattern.matcher(pattern)
+
+        assertTrue(matcher.find())
+        assertEquals(community, matcher.group(1))
+        assertEquals(instance, matcher.group(2))
+    }
+
+    @Test
+    @Parameters(
+        value = [
+            "a!community",
+            "!!community@instance.ml",
+            "!co",
+        ],
+    )
+    fun testCommunityInvalid(pattern: String) {
+        assertFalse(lemmyCommunityPattern.matcher(pattern).find())
+    }
+
+    @Test
+    @Parameters(method = "userSuccessCases")
+    fun testUserValid(pattern: String, user: String, instance: String?) {
+        val matcher = lemmyUserPattern.matcher(pattern)
+
+        assertTrue(matcher.find())
+        assertEquals(user, matcher.group(1))
+        assertEquals(instance, matcher.group(2))
+    }
+
+    @Test
+    @Parameters(
+        value = [
+            "a@user",
+            "!@user@instance.ml",
+            "@co",
+        ],
+    )
+    fun testUserInvalid(pattern: String) {
+        assertFalse(lemmyUserPattern.matcher(pattern).find())
+    }
+
+    fun communitySuccessCases() = listOf(
+        listOf("!community", "community", null),
+        listOf(" !community.", "community", null),
+        listOf("!community@instance.ml", "community", "instance.ml"),
+        listOf("!community@instance.ml!", "community", "instance.ml"),
+    )
+
+    fun userSuccessCases() = listOf(
+        listOf("@user", "user", null),
+        listOf(" @user.", "user", null),
+        listOf("@user@instance.ml", "user", "instance.ml"),
+        listOf("@user@instance.ml!", "user", "instance.ml"),
+    )
+}


### PR DESCRIPTION
They merely pop up a toast saying it's unimplemented, but the links are being created and handled.

Fixes #556.

Partial fix for #526 since short forms of lemmy links can be handled separately from other links.

Related to #454.