### PR TITLE
Fix bug with pictrs url query param rewriting

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -447,11 +447,14 @@ fun pictrsImageThumbnail(src: String, thumbnailSize: Int): String {
     }
 
     val host = split[0]
+    var path = split[1]
     // eliminate the query param portion of the path so we can replace it later
     // without this, we'd end up with something like host/path?thumbnail=...?thumbnail=...
-    val path = split[1].replaceAfter('?', "")
+    if ("?" in path) {
+        path = path.replaceAfter('?', "").dropLast(1)
+    }
 
-    return "$host/pictrs/image/${path}thumbnail=$thumbnailSize&format=webp"
+    return "$host/pictrs/image/$path?thumbnail=$thumbnailSize&format=webp"
 }
 
 fun isImage(url: String): Boolean {

--- a/app/src/test/java/com/jerboa/UtilsKtTest.kt
+++ b/app/src/test/java/com/jerboa/UtilsKtTest.kt
@@ -121,7 +121,14 @@ class UtilsKtTest {
         assertEquals(
             "http://localhost:8535/pictrs/image/file.png?thumbnail=3&format=webp",
             pictrsImageThumbnail(
-                "http://localhost:8535/pictrs/image/file.png?thumbnail=3&format=webp",
+                "http://localhost:8535/pictrs/image/file.png",
+                3,
+            ),
+        )
+        assertEquals(
+            "http://localhost:8535/pictrs/image/file.png?thumbnail=3&format=webp",
+            pictrsImageThumbnail(
+                "http://localhost:8535/pictrs/image/file.png?thumbnail=256&format=jpg",
                 3,
             ),
         )


### PR DESCRIPTION
Apparently I broke stuff by trying to be fancy. I'm not really a fan of parsing the URL like this though, but at least there are test cases for it now.