### PR TITLE
fix(thumbnails): prevent incorrect formatting on URLs without query parameters

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -500,7 +500,7 @@ fun pictrsImageThumbnail(src: String, thumbnailSize: Int): String {
     val host = split[0]
     // eliminate the query param portion of the path so we can replace it later
     // without this, we'd end up with something like host/path?thumbnail=...?thumbnail=...
-    val path = split[1].replaceAfter('?', "")
+    val path = split[1].replaceAfter('?', "", "${split[1]}?")
 
     return "$host/pictrs/image/${path}thumbnail=$thumbnailSize&format=webp"
 }


### PR DESCRIPTION
This fixes an issue where if the URL did not previously contain query parameters, it would incorrectly format the URL without a trailing `?`.
Before:
![image](https://github.com/dessalines/jerboa/assets/31761843/f9c9f859-c667-4c58-a516-0fbc2b581e56)

After:
![image](https://github.com/dessalines/jerboa/assets/31761843/4fbc5d49-1e07-456e-b2da-23538138e1f9)
