### PR TITLE
Navigation Enhancements x2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     implementation 'com.google.accompanist:accompanist-pager-indicators:0.30.1'
     implementation 'com.google.accompanist:accompanist-flowlayout:0.30.1'
     implementation "com.google.accompanist:accompanist-permissions:0.30.1"
+    implementation "com.google.accompanist:accompanist-navigation-animation:0.30.1"
 
     // LiveData
     implementation 'androidx.compose.runtime:runtime-livedata:1.4.3'

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -285,9 +285,6 @@ class MainActivity : ComponentActivity() {
                         // Only necessary for community deeplinks
                         composable(
                             route = Route.COMMUNITY_FROM_URL,
-                            deepLinks = listOf(
-                                navDeepLink { uriPattern = Route.COMMUNITY_FROM_URL },
-                            ),
                             arguments = listOf(
                                 navArgument(Route.CommunityFromUrlArgs.NAME) {
                                     type = Route.CommunityFromUrlArgs.NAME_TYPE
@@ -331,6 +328,36 @@ class MainActivity : ComponentActivity() {
                                 communityViewModel = communityViewModel,
                                 navController = CommunitySideBarNavController(navController),
                             )
+                        }
+                    }
+
+                    // TODO: Make community sidebar a tab within the community activity so that
+                    //  both the community and the sidebar can use the same view model.
+                    // HACK: Deep linking to nested navigation composable isn't allowed. Community
+                    //  urls opened within the app (for eg. from within the comments) don't need this
+                    //  hack because `openUrl(...)` parses the url and navigates using the app route.
+                    //  This hack is only needed to open community urls from outside the app.
+                    composable(
+                        route = "redirect/${Route.COMMUNITY_FROM_URL}",
+                        deepLinks = listOf(
+                            navDeepLink { uriPattern = Route.COMMUNITY_FROM_URL },
+                        ),
+                        arguments = listOf(
+                            navArgument(Route.CommunityFromUrlArgs.NAME) {
+                                type = Route.CommunityFromUrlArgs.NAME_TYPE
+                            },
+                            navArgument(Route.CommunityFromUrlArgs.INSTANCE) {
+                                type = Route.CommunityFromUrlArgs.INSTANCE_TYPE
+                            },
+                        ),
+                    ) {
+                        val args = Route.CommunityFromUrlArgs(it)
+                        val route = Route.CommunityFromUrlArgs.makeRoute(
+                            instance = args.instance,
+                            name = args.name
+                        )
+                        navController.navigate(route) {
+                            popUpTo(0)
                         }
                     }
 

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -164,9 +164,6 @@ class MainActivity : ComponentActivity() {
                 val privateMessageReplyDependencyContainer = dependencyContainer<PrivateMessageReplyDependencies>()
 
                 AnimatedNavHost(
-                    // Do not provide a route for this NavHost.
-                    // DefaultBackButton requires the route to be null to conclude the the stack is
-                    // no more popable.
                     navController = navController,
                     startDestination = Route.HOME,
                     enterTransition = { enterTransition },
@@ -304,7 +301,7 @@ class MainActivity : ComponentActivity() {
                                 remember(it) { navController.getBackStackEntry(communityGraph) },
                             )
                             val args = Route.CommunityFromUrlArgs(it)
-                            val qualifiedName = "${args.name}@{$args.instance}"
+                            val qualifiedName = "${args.name}@${args.instance}"
                             CommunityActivity(
                                 communityArg = Either.Right(qualifiedName),
                                 communityViewModel = communityViewModel,

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -708,10 +708,26 @@ fun siFormat(num: Int): String {
 fun fetchInitialData(
     account: Account?,
     siteViewModel: SiteViewModel,
-    homeViewModel: HomeViewModel,
 ) {
     if (account != null) {
         API.changeLemmyInstance(account.instance)
+        siteViewModel.fetchUnreadCounts(GetUnreadCount(auth = account.jwt))
+    } else {
+        API.changeLemmyInstance(DEFAULT_INSTANCE)
+    }
+
+    siteViewModel.getSite(
+        GetSite(
+            auth = account?.jwt,
+        ),
+    )
+}
+
+fun fetchHomePosts(
+    account: Account?,
+    homeViewModel: HomeViewModel,
+) {
+    if (account != null) {
         homeViewModel.resetPage()
         homeViewModel.getPosts(
             GetPosts(
@@ -720,10 +736,8 @@ fun fetchInitialData(
                 auth = account.jwt,
             ),
         )
-        siteViewModel.fetchUnreadCounts(GetUnreadCount(auth = account.jwt))
     } else {
         Log.d("jerboa", "Fetching posts for anonymous user")
-        API.changeLemmyInstance(DEFAULT_INSTANCE)
         homeViewModel.resetPage()
         homeViewModel.getPosts(
             GetPosts(
@@ -732,12 +746,6 @@ fun fetchInitialData(
             ),
         )
     }
-
-    siteViewModel.getSite(
-        GetSite(
-            auth = account?.jwt,
-        ),
-    )
 }
 
 fun imageInputStreamFromUri(ctx: Context, uri: Uri): InputStream {

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -53,6 +53,7 @@ import com.jerboa.api.ApiState
 import com.jerboa.api.DEFAULT_INSTANCE
 import com.jerboa.datatypes.types.*
 import com.jerboa.db.Account
+import com.jerboa.nav.Route
 import com.jerboa.ui.components.home.HomeViewModel
 import com.jerboa.ui.components.home.SiteViewModel
 import com.jerboa.ui.components.person.UserTab
@@ -372,11 +373,13 @@ fun openLink(url: String, navController: NavController, useCustomTab: Boolean, u
     val parsedUrl = parseUrl(url) ?: return
 
     looksLikeUserUrl(parsedUrl)?.let { it ->
-        navController.navigate("${it.first}/u/${it.second}")
+        val route = Route.ProfileFromUrlArgs.makeRoute(instance = it.first, name = it.second)
+        navController.navigate(route)
         return
     }
     looksLikeCommunityUrl(parsedUrl)?.let { it ->
-        navController.navigate("${it.first}/c/${it.second}")
+        val route = Route.CommunityFromUrlArgs.makeRoute(instance = it.first, name = it.second)
+        navController.navigate(route)
         return
     }
 

--- a/app/src/main/java/com/jerboa/nav/DefaultNavigations.kt
+++ b/app/src/main/java/com/jerboa/nav/DefaultNavigations.kt
@@ -1,0 +1,97 @@
+package com.jerboa.nav
+
+import androidx.navigation.NavController
+import com.jerboa.ui.components.comment.edit.CommentEditDependencies
+import com.jerboa.ui.components.comment.edit.ToCommentEdit
+import com.jerboa.ui.components.comment.reply.CommentReplyDependencies
+import com.jerboa.ui.components.comment.reply.ToCommentReply
+import com.jerboa.ui.components.community.ToCommunity
+import com.jerboa.ui.components.community.list.CommunityListDependencies
+import com.jerboa.ui.components.community.list.ToCommunityList
+import com.jerboa.ui.components.community.sidebar.ToCommunitySideBar
+import com.jerboa.ui.components.home.ToHome
+import com.jerboa.ui.components.home.ToSiteSideBar
+import com.jerboa.ui.components.login.ToLogin
+import com.jerboa.ui.components.person.ToProfile
+import com.jerboa.ui.components.post.ToComment
+import com.jerboa.ui.components.post.ToPost
+import com.jerboa.ui.components.post.create.CreatePostDependencies
+import com.jerboa.ui.components.post.create.ToCreatePost
+import com.jerboa.ui.components.post.edit.PostEditDependencies
+import com.jerboa.ui.components.post.edit.ToPostEdit
+import com.jerboa.ui.components.privatemessage.PrivateMessageReplyDependencies
+import com.jerboa.ui.components.privatemessage.ToPrivateMessageReply
+import com.jerboa.ui.components.report.ToCommentReport
+import com.jerboa.ui.components.report.ToPostReport
+import com.jerboa.ui.components.settings.ToAbout
+import com.jerboa.ui.components.settings.ToAccountSettings
+import com.jerboa.ui.components.settings.ToLookAndFeel
+import com.jerboa.ui.components.settings.ToSettings
+
+fun NavController.toLogin() = ToLogin { navigate(Route.LOGIN) }
+
+fun NavController.toHome() = ToHome {
+    navigate(Route.HOME) {
+        popUpTo(0)
+    }
+}
+
+fun NavController.toCommunity() = ToCommunity { id ->
+    navigate(Route.CommunityFromIdArgs.makeRoute(id = "$id"))
+}
+
+fun NavController.toCommunitySideBar() = ToCommunitySideBar { navigate(Route.COMMUNITY_SIDEBAR) }
+
+fun NavController.toProfile() = ToProfile { id, saved ->
+    navigate(Route.ProfileFromIdArgs.makeRoute(id = "$id", saved = "$saved"))
+}
+
+fun NavController.toCommunityList(
+    container: DependencyContainer<CommunityListDependencies>,
+) = ToCommunityList(container) { navigate(Route.COMMUNITY_LIST) }
+
+fun NavController.toCreatePost(
+    container: DependencyContainer<CreatePostDependencies>,
+) = ToCreatePost(container) { navigate(Route.CREATE_POST) }
+
+fun NavController.toPost() = ToPost { id ->
+    navigate(Route.PostArgs.makeRoute(id = "$id"))
+}
+
+fun NavController.toComment() = ToComment { id ->
+    navigate(Route.CommentArgs.makeRoute(id = "$id"))
+}
+
+fun NavController.toCommentReply(
+    container: DependencyContainer<CommentReplyDependencies>,
+) = ToCommentReply(container) { navigate(Route.COMMENT_REPLY) }
+
+fun NavController.toSiteSideBar() = ToSiteSideBar { navigate(Route.SITE_SIDEBAR) }
+
+fun NavController.toCommentEdit(
+    container: DependencyContainer<CommentEditDependencies>,
+) = ToCommentEdit(container) { navigate(Route.COMMENT_EDIT) }
+
+fun NavController.toPostEdit(
+    container: DependencyContainer<PostEditDependencies>,
+) = ToPostEdit(container) { navigate(Route.POST_EDIT) }
+
+fun NavController.toPrivateMessageReply(
+    container: DependencyContainer<PrivateMessageReplyDependencies>,
+) = ToPrivateMessageReply(container) { navigate(Route.PRIVATE_MESSAGE_REPLY) }
+
+fun NavController.toCommentReport() = ToCommentReport { id ->
+    navigate(Route.CommentReportArgs.makeRoute(id = "$id"))
+}
+
+fun NavController.toPostReport() = ToPostReport { id ->
+    navigate(Route.PostReportArgs.makeRoute(id = "$id"))
+}
+
+fun NavController.toSettings() = ToSettings { navigate(Route.SETTINGS) }
+
+fun NavController.toAccountSettings() = ToAccountSettings { navigate(Route.ACCOUNT_SETTINGS) }
+
+fun NavController.toLookAndFeel() = ToLookAndFeel { navigate(Route.LOOK_AND_FEEL) }
+
+fun NavController.toAbout() = ToAbout { navigate(Route.ABOUT) }

--- a/app/src/main/java/com/jerboa/nav/DefaultTransitions.kt
+++ b/app/src/main/java/com/jerboa/nav/DefaultTransitions.kt
@@ -1,0 +1,9 @@
+package com.jerboa.nav
+
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+
+val enterTransition = slideInHorizontally { it }
+val exitTransition = slideOutHorizontally { -it }
+val popEnterTransition = slideInHorizontally { -it }
+val popExitTransition = slideOutHorizontally { it }

--- a/app/src/main/java/com/jerboa/nav/DependencyContainer.kt
+++ b/app/src/main/java/com/jerboa/nav/DependencyContainer.kt
@@ -1,0 +1,26 @@
+package com.jerboa.nav
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+
+class DependencyContainer<D : ViewModel> : ViewModel(), ViewModelProvider.Factory {
+    internal var dependencies: D? = null
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        dependencies?.let {
+            dependencies = null
+            if (modelClass.isAssignableFrom(it.javaClass)) {
+                return it as T
+            }
+        }
+        return super.create(modelClass)
+    }
+}
+
+@Composable
+fun <D : ViewModel> dependencyContainer(): DependencyContainer<D> {
+    return viewModel()
+}

--- a/app/src/main/java/com/jerboa/nav/NavControllerWrapper.kt
+++ b/app/src/main/java/com/jerboa/nav/NavControllerWrapper.kt
@@ -1,0 +1,11 @@
+package com.jerboa.nav
+
+import androidx.navigation.NavController
+
+abstract class NavControllerWrapper {
+    protected abstract val navController: NavController
+
+    fun canPop() = navController.previousBackStackEntry != null
+
+    fun navigateUp() = navController.navigateUp()
+}

--- a/app/src/main/java/com/jerboa/nav/NavControllerWrapper.kt
+++ b/app/src/main/java/com/jerboa/nav/NavControllerWrapper.kt
@@ -1,5 +1,14 @@
 package com.jerboa.nav
 
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 
 abstract class NavControllerWrapper {
@@ -8,4 +17,12 @@ abstract class NavControllerWrapper {
     fun canPop() = navController.previousBackStackEntry != null
 
     fun navigateUp() = navController.navigateUp()
+}
+
+// https://stackoverflow.com/a/69533584/13390651
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PaddingValues.bottomIfKeyboardNotOpen(): State<Dp> {
+    val bottomPadding = if (WindowInsets.isImeVisible) 0.dp else calculateBottomPadding()
+    return rememberUpdatedState(bottomPadding)
 }

--- a/app/src/main/java/com/jerboa/nav/NavigateImplementations.kt
+++ b/app/src/main/java/com/jerboa/nav/NavigateImplementations.kt
@@ -1,0 +1,17 @@
+package com.jerboa.nav
+
+import androidx.lifecycle.ViewModel
+
+class NavigateWithNoArgsAndDependencies(
+    val navigate: () -> Unit,
+)
+
+class NavigateWithNoArgs<D : ViewModel>(
+    private val container: DependencyContainer<D>,
+    private val navigateToDestination: () -> Unit,
+) {
+    fun navigate(dependencies: D) {
+        container.dependencies = dependencies
+        navigateToDestination()
+    }
+}

--- a/app/src/main/java/com/jerboa/nav/Routes.kt
+++ b/app/src/main/java/com/jerboa/nav/Routes.kt
@@ -91,7 +91,7 @@ class Route {
             val INSTANCE_TYPE = NavType.StringType
 
             const val NAME = "name"
-            val NAME_TYPE = NavType.IntType
+            val NAME_TYPE = NavType.StringType
 
             fun makeRoute(instance: String, name: String) = "$instance/c/$name"
             internal val route by lazy { makeRoute(instance = "{$INSTANCE}", name = "{$NAME}") }
@@ -128,7 +128,7 @@ class Route {
             val INSTANCE_TYPE = NavType.StringType
 
             const val NAME = "name"
-            val NAME_TYPE = NavType.IntType
+            val NAME_TYPE = NavType.StringType
 
             fun makeRoute(instance: String, name: String) = "$instance/u/$name"
             internal val route by lazy { makeRoute(instance = "{$INSTANCE}", name = "{$NAME}") }

--- a/app/src/main/java/com/jerboa/nav/Routes.kt
+++ b/app/src/main/java/com/jerboa/nav/Routes.kt
@@ -1,0 +1,189 @@
+package com.jerboa.nav
+
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavType
+
+enum class HomeTab {
+    Feed, Search, Inbox, Saved, Profile;
+
+    fun needsLogin() = this == Inbox || this == Saved || this == Profile
+}
+
+class Route {
+    companion object {
+        const val LOGIN = "login"
+        const val INBOX = "inbox"
+
+        val HOME = HomeArgs.route
+        val COMMUNITY_FROM_ID = CommunityFromIdArgs.route
+        val COMMUNITY_FROM_URL = CommunityFromUrlArgs.route
+
+        const val COMMUNITY_SIDEBAR = "communitySidebar"
+
+        val PROFILE_FROM_ID = ProfileFromIdArgs.route
+        val PROFILE_FROM_URL = ProfileFromUrlArgs.route
+
+        const val COMMUNITY_LIST = "communityList"
+        const val CREATE_POST = "createPost"
+
+        val POST = PostArgs.route
+        val COMMENT = CommentArgs.route
+
+        const val COMMENT_REPLY = "commentReply"
+        const val SITE_SIDEBAR = "siteSidebar"
+        const val COMMENT_EDIT = "commentEdit"
+        const val POST_EDIT = "postEdit"
+        const val PRIVATE_MESSAGE_REPLY = "privateMessageReply"
+
+        val COMMENT_REPORT = CommentReportArgs.route
+        val POST_REPORT = PostReportArgs.route
+
+        const val SETTINGS = "settings"
+        const val LOOK_AND_FEEL = "lookAndFeel"
+        const val ACCOUNT_SETTINGS = "accountSettings"
+        const val ABOUT = "about"
+    }
+
+    class HomeArgs(val tab: HomeTab) {
+        constructor(navBackStackEntry: NavBackStackEntry) :
+            this(
+                when (navBackStackEntry.arguments?.getString(TAB)?.lowercase()) {
+                    HomeTab.Feed.name.lowercase() -> HomeTab.Feed
+                    HomeTab.Search.name.lowercase() -> HomeTab.Search
+                    HomeTab.Inbox.name.lowercase() -> HomeTab.Inbox
+                    HomeTab.Saved.name.lowercase() -> HomeTab.Saved
+                    HomeTab.Profile.name.lowercase() -> HomeTab.Profile
+                    else -> TAB_DEFAULT
+                },
+            )
+
+        companion object {
+            const val TAB = "tab"
+            val TAB_TYPE = NavType.StringType
+            val TAB_DEFAULT = HomeTab.Feed
+
+            fun makeRoute(tab: String) = "home?tab=$tab"
+            internal val route by lazy { makeRoute(tab = "{$TAB}") }
+        }
+    }
+
+    class CommunityFromIdArgs(val id: Int) {
+        constructor(navBackStackEntry: NavBackStackEntry) :
+            this(id = navBackStackEntry.arguments?.getInt(ID)!!)
+
+        companion object {
+            const val ID = "id"
+            val ID_TYPE = NavType.IntType
+
+            fun makeRoute(id: String) = "community/$id"
+            internal val route by lazy { makeRoute(id = "{$ID}") }
+        }
+    }
+
+    class CommunityFromUrlArgs(val instance: String, val name: String) {
+        constructor(navBackStackEntry: NavBackStackEntry) : this(
+            instance = navBackStackEntry.arguments?.getString(INSTANCE)!!,
+            name = navBackStackEntry.arguments?.getString(NAME)!!,
+        )
+
+        companion object {
+            const val INSTANCE = "instance"
+            val INSTANCE_TYPE = NavType.StringType
+
+            const val NAME = "name"
+            val NAME_TYPE = NavType.IntType
+
+            fun makeRoute(instance: String, name: String) = "$instance/c/$name"
+            internal val route by lazy { makeRoute(instance = "{$INSTANCE}", name = "{$NAME}") }
+        }
+    }
+
+    class ProfileFromIdArgs(val id: Int, val saved: Boolean) {
+        constructor(navBackStackEntry: NavBackStackEntry) : this(
+            id = navBackStackEntry.arguments?.getInt(ID)!!,
+            saved = navBackStackEntry.arguments?.getBoolean(SAVED)!!,
+        )
+
+        companion object {
+            const val ID = "id"
+            val ID_TYPE = NavType.IntType
+
+            const val SAVED = "saved"
+            val SAVED_TYPE = NavType.BoolType
+            const val SAVED_DEFAULT = false
+
+            fun makeRoute(id: String, saved: String) = "profile/$id?saved=$saved"
+            internal val route by lazy { makeRoute(id = "{$ID}", saved = "{$SAVED}") }
+        }
+    }
+
+    class ProfileFromUrlArgs(val instance: String, val name: String) {
+        constructor(navBackStackEntry: NavBackStackEntry) : this(
+            instance = navBackStackEntry.arguments?.getString(INSTANCE)!!,
+            name = navBackStackEntry.arguments?.getString(NAME)!!,
+        )
+
+        companion object {
+            const val INSTANCE = "instance"
+            val INSTANCE_TYPE = NavType.StringType
+
+            const val NAME = "name"
+            val NAME_TYPE = NavType.IntType
+
+            fun makeRoute(instance: String, name: String) = "$instance/u/$name"
+            internal val route by lazy { makeRoute(instance = "{$INSTANCE}", name = "{$NAME}") }
+        }
+    }
+
+    class PostArgs(val id: Int) {
+        constructor(navBackStackEntry: NavBackStackEntry) :
+            this(id = navBackStackEntry.arguments?.getInt(ID)!!)
+
+        companion object {
+            const val ID = "id"
+            val ID_TYPE = NavType.IntType
+
+            fun makeRoute(id: String) = "post/$id"
+            internal val route by lazy { makeRoute(id = "{$ID}") }
+        }
+    }
+
+    class CommentArgs(val id: Int) {
+        constructor(navBackStackEntry: NavBackStackEntry) :
+            this(id = navBackStackEntry.arguments?.getInt(ID)!!)
+
+        companion object {
+            const val ID = "id"
+            val ID_TYPE = NavType.IntType
+
+            fun makeRoute(id: String) = "comment/$id"
+            internal val route by lazy { makeRoute(id = "{$ID}") }
+        }
+    }
+
+    class CommentReportArgs(val id: Int) {
+        constructor(navBackStackEntry: NavBackStackEntry) :
+            this(id = navBackStackEntry.arguments?.getInt(ID)!!)
+
+        companion object {
+            const val ID = "id"
+            val ID_TYPE = NavType.IntType
+
+            fun makeRoute(id: String) = "commentReport/$id"
+            internal val route by lazy { makeRoute(id = "{$ID}") }
+        }
+    }
+
+    class PostReportArgs(val id: Int) {
+        constructor(navBackStackEntry: NavBackStackEntry) :
+            this(id = navBackStackEntry.arguments?.getInt(ID)!!)
+
+        companion object {
+            const val ID = "id"
+            val ID_TYPE = NavType.IntType
+
+            fun makeRoute(id: String) = "postReport/$id"
+            internal val route by lazy { makeRoute(id = "{$ID}") }
+        }
+    }
+}

--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEdit.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEdit.kt
@@ -15,16 +15,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.db.Account
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.MarkdownTextField
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommentEditHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     onSaveClick: () -> Unit,
     loading: Boolean,
 ) {
@@ -51,18 +51,7 @@ fun CommentEditHeader(
                 }
             }
         },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.comment_edit_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditActivity.kt
@@ -9,25 +9,29 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.api.ApiState
+import com.jerboa.datatypes.types.CommentView
 import com.jerboa.db.AccountViewModel
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.getCurrentAccount
-import com.jerboa.ui.components.person.PersonProfileViewModel
-import com.jerboa.ui.components.post.PostViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommentEditActivity(
+    commentView: CommentView,
+    onCommentEdit: OnCommentEdit?,
     accountViewModel: AccountViewModel,
-    navController: NavController,
-    commentEditViewModel: CommentEditViewModel,
-    personProfileViewModel: PersonProfileViewModel,
-    postViewModel: PostViewModel,
+    navController: CommentEditNavController,
 ) {
     Log.d("jerboa", "got to comment edit activity")
 
     val account = getCurrentAccount(accountViewModel = accountViewModel)
+
+    val commentEditViewModel: CommentEditViewModel = viewModel()
+    InitializeRoute {
+        commentEditViewModel.initialize(commentView)
+    }
 
     var content by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue(commentEditViewModel.commentView.value?.comment?.content.orEmpty())) }
 
@@ -48,12 +52,12 @@ fun CommentEditActivity(
                         account?.also { acct ->
                             commentEditViewModel.editComment(
                                 content = content.text,
-                                navController = navController,
-                                focusManager = focusManager,
                                 account = acct,
-                                personProfileViewModel = personProfileViewModel,
-                                postViewModel = postViewModel,
-                            )
+                            ) { cv ->
+                                focusManager.clearFocus()
+                                onCommentEdit?.invoke(cv)
+                                navController.navigateUp()
+                            }
                         }
                     },
                 )

--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditNavController.kt
@@ -1,0 +1,20 @@
+package com.jerboa.ui.components.comment.edit
+
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavController
+import com.jerboa.datatypes.types.CommentView
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgs
+
+typealias OnCommentEdit = (CommentView) -> Unit
+
+class CommentEditDependencies(
+    val commentView: CommentView,
+    val onCommentEdit: OnCommentEdit?,
+) : ViewModel()
+
+typealias ToCommentEdit = NavigateWithNoArgs<CommentEditDependencies>
+
+class CommentEditNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditViewModel.kt
@@ -3,10 +3,8 @@ package com.jerboa.ui.components.comment.edit
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.focus.FocusManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
@@ -14,8 +12,6 @@ import com.jerboa.datatypes.types.CommentResponse
 import com.jerboa.datatypes.types.CommentView
 import com.jerboa.datatypes.types.EditComment
 import com.jerboa.db.Account
-import com.jerboa.ui.components.person.PersonProfileViewModel
-import com.jerboa.ui.components.post.PostViewModel
 import kotlinx.coroutines.launch
 
 class CommentEditViewModel : ViewModel() {
@@ -33,11 +29,8 @@ class CommentEditViewModel : ViewModel() {
 
     fun editComment(
         content: String,
-        navController: NavController,
-        focusManager: FocusManager,
         account: Account,
-        personProfileViewModel: PersonProfileViewModel,
-        postViewModel: PostViewModel,
+        onSuccess: OnCommentEdit,
     ) {
         viewModelScope.launch {
             commentView.value?.also { cv ->
@@ -52,18 +45,15 @@ class CommentEditViewModel : ViewModel() {
                     apiWrapper(
                         API.getInstance().editComment(form),
                     )
-                focusManager.clearFocus()
 
                 // Update all the views which might have your comment
                 when (val res = editCommentRes) {
                     is ApiState.Success -> {
-                        personProfileViewModel.updateComment(res.data.comment_view)
-                        postViewModel.updateComment(res.data.comment_view)
+                        onSuccess(res.data.comment_view)
                     }
 
                     else -> {}
                 }
-                navController.navigateUp()
             }
         }
     }

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
@@ -15,8 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.datatypes.sampleCommentView
 import com.jerboa.datatypes.types.CommentReplyView
@@ -24,9 +22,11 @@ import com.jerboa.datatypes.types.CommentView
 import com.jerboa.datatypes.types.PersonMentionView
 import com.jerboa.datatypes.types.PostView
 import com.jerboa.db.Account
+import com.jerboa.nav.NavControllerWrapper
 import com.jerboa.ui.components.comment.CommentNodeHeader
 import com.jerboa.ui.components.comment.mentionnode.CommentMentionNodeHeader
 import com.jerboa.ui.components.comment.replynode.CommentReplyNodeHeader
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.MarkdownTextField
 import com.jerboa.ui.components.post.PostNodeHeader
 import com.jerboa.ui.theme.LARGE_PADDING
@@ -35,7 +35,7 @@ import com.jerboa.ui.theme.MEDIUM_PADDING
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommentReplyHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     onSendClick: () -> Unit,
     loading: Boolean,
 ) {
@@ -62,18 +62,7 @@ fun CommentReplyHeader(
                 }
             }
         },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.comment_reply_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyActivity.kt
@@ -12,25 +12,23 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.api.ApiState
 import com.jerboa.db.AccountViewModel
 import com.jerboa.isModerator
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.home.SiteViewModel
-import com.jerboa.ui.components.person.PersonProfileViewModel
-import com.jerboa.ui.components.post.PostViewModel
 
 @Composable
 fun CommentReplyActivity(
-    commentReplyViewModel: CommentReplyViewModel,
     accountViewModel: AccountViewModel,
-    personProfileViewModel: PersonProfileViewModel,
-    postViewModel: PostViewModel,
     siteViewModel: SiteViewModel,
-    navController: NavController,
+    replyItem: ReplyItem,
+    onCommentReply: OnCommentReply?,
     isModerator: Boolean,
+    navController: CommentReplyNavController,
 ) {
     Log.d("jerboa", "got to comment reply activity")
 
@@ -40,6 +38,11 @@ fun CommentReplyActivity(
             TextFieldValue
             (""),
         )
+    }
+
+    val commentReplyViewModel: CommentReplyViewModel = viewModel()
+    InitializeRoute {
+        commentReplyViewModel.initialize(replyItem)
     }
 
     val focusManager = LocalFocusManager.current
@@ -58,11 +61,11 @@ fun CommentReplyActivity(
                         commentReplyViewModel.createComment(
                             content = reply.text,
                             account = acct,
-                            navController = navController,
-                            focusManager = focusManager,
-                            personProfileViewModel = personProfileViewModel,
-                            postViewModel = postViewModel,
-                        )
+                        ) { cv ->
+                            focusManager.clearFocus()
+                            onCommentReply?.invoke(cv)
+                            navController.navigateUp()
+                        }
                     }
                 },
             )
@@ -80,7 +83,7 @@ fun CommentReplyActivity(
                                 reply = reply,
                                 onReplyChange = { reply = it },
                                 onPersonClick = { personId ->
-                                    navController.navigate(route = "profile/$personId")
+                                    navController.toProfile.navigate(personId)
                                 },
                                 isModerator = isModerator,
                                 modifier = Modifier
@@ -95,7 +98,7 @@ fun CommentReplyActivity(
                             reply = reply,
                             onReplyChange = { reply = it },
                             onPersonClick = { personId ->
-                                navController.navigate(route = "profile/$personId")
+                                navController.toProfile.navigate(personId)
                             },
                             isModerator = isModerator,
                             modifier = Modifier
@@ -110,7 +113,7 @@ fun CommentReplyActivity(
                                 reply = reply,
                                 onReplyChange = { reply = it },
                                 onPersonClick = { personId ->
-                                    navController.navigate(route = "profile/$personId")
+                                    navController.toProfile.navigate(personId)
                                 },
                                 modifier = Modifier
                                     .padding(padding)
@@ -125,7 +128,7 @@ fun CommentReplyActivity(
                                 reply = reply,
                                 onReplyChange = { reply = it },
                                 onPersonClick = { personId ->
-                                    navController.navigate(route = "profile/$personId")
+                                    navController.toProfile.navigate(personId)
                                 },
                                 modifier = Modifier
                                     .padding(padding)

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyNavController.kt
@@ -1,0 +1,23 @@
+package com.jerboa.ui.components.comment.reply
+
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavController
+import com.jerboa.datatypes.types.CommentView
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgs
+import com.jerboa.ui.components.person.ToProfile
+
+typealias OnCommentReply = (CommentView) -> Unit
+
+class CommentReplyDependencies(
+    val replyItem: ReplyItem,
+    val isModerator: Boolean,
+    val onCommentReply: OnCommentReply?,
+) : ViewModel()
+
+typealias ToCommentReply = NavigateWithNoArgs<CommentReplyDependencies>
+
+class CommentReplyNavController(
+    override val navController: NavController,
+    val toProfile: ToProfile,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyViewModel.kt
@@ -3,10 +3,8 @@ package com.jerboa.ui.components.comment.reply
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.focus.FocusManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
@@ -17,8 +15,6 @@ import com.jerboa.datatypes.types.CreateComment
 import com.jerboa.datatypes.types.PersonMentionView
 import com.jerboa.datatypes.types.PostView
 import com.jerboa.db.Account
-import com.jerboa.ui.components.person.PersonProfileViewModel
-import com.jerboa.ui.components.post.PostViewModel
 import kotlinx.coroutines.launch
 
 sealed class ReplyItem {
@@ -44,10 +40,7 @@ class CommentReplyViewModel : ViewModel() {
     fun createComment(
         content: String,
         account: Account,
-        navController: NavController,
-        focusManager: FocusManager,
-        personProfileViewModel: PersonProfileViewModel,
-        postViewModel: PostViewModel,
+        onSuccess: OnCommentReply,
     ) {
         val reply = replyItem!! // This should have been initialized
         val (postId, commentParentId) = when (reply) {
@@ -80,20 +73,7 @@ class CommentReplyViewModel : ViewModel() {
             when (val res = createCommentRes) {
                 is ApiState.Success -> {
                     val commentView = res.data.comment_view
-
-                    focusManager.clearFocus()
-
-                    // Add to all the views which might have your comment
-                    postViewModel.appendComment(commentView)
-                    when (val personDetailsRes = personProfileViewModel.personDetailsRes) {
-                        is ApiState.Success -> {
-                            if (account.id == personDetailsRes.data.person_view.person.id) {
-                                personProfileViewModel.insertComment(commentView)
-                            }
-                        }
-                        else -> {}
-                    }
-                    navController.navigateUp()
+                    onSuccess(commentView)
                 }
                 else -> {}
             }

--- a/app/src/main/java/com/jerboa/ui/components/common/DefaultBackButton.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/DefaultBackButton.kt
@@ -1,0 +1,36 @@
+package com.jerboa.ui.components.common
+
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import com.jerboa.R
+import com.jerboa.nav.NavControllerWrapper
+
+@Composable
+fun DefaultBackButton(navController: NavControllerWrapper) {
+    val canPop = remember { navController.canPop() }
+
+    // This is required so that the back button does not disappear while transitioning.
+    var clicked by remember { mutableStateOf(false) }
+
+    if (canPop || clicked) {
+        IconButton(onClick = {
+            if (!clicked) {
+                navController.navigateUp()
+                clicked = true
+            }
+        }) {
+            Icon(
+                imageVector = Icons.Outlined.ArrowBack,
+                contentDescription = stringResource(R.string.topAppBar_back),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/jerboa/ui/components/common/DefaultBackButton.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/DefaultBackButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
@@ -17,16 +16,8 @@ import com.jerboa.nav.NavControllerWrapper
 fun DefaultBackButton(navController: NavControllerWrapper) {
     val canPop = remember { navController.canPop() }
 
-    // This is required so that the back button does not disappear while transitioning.
-    var clicked by remember { mutableStateOf(false) }
-
-    if (canPop || clicked) {
-        IconButton(onClick = {
-            if (!clicked) {
-                navController.navigateUp()
-                clicked = true
-            }
-        }) {
+    if (canPop) {
+        IconButton(onClick = navController::navigateUp) {
             Icon(
                 imageVector = Icons.Outlined.ArrowBack,
                 contentDescription = stringResource(R.string.topAppBar_back),

--- a/app/src/main/java/com/jerboa/ui/components/common/InitializeRoute.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InitializeRoute.kt
@@ -1,0 +1,26 @@
+package com.jerboa.ui.components.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+fun InitializeRoute(initializationBlock: suspend CoroutineScope.() -> Unit) {
+    // rememberSaveable persists this information across navigations
+    var initialized by rememberSaveable { mutableStateOf(false) }
+
+    // LaunchedEffect runs everytime we navigate. Therefore we need a guard.
+    if (!initialized) {
+        LaunchedEffect(Unit) {
+            this.initializationBlock()
+
+            // The effects might get cancelled sometimes and the initialization wouldn't have happened.
+            // Therefore this has to be inside the effect and after the initialization block.
+            initialized = true
+        }
+    }
+}

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -10,14 +10,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.datatypes.sampleCommunityView
 import com.jerboa.datatypes.types.CommunityView
 import com.jerboa.datatypes.types.SortType
 import com.jerboa.datatypes.types.SubscribedType
 import com.jerboa.getLocalizedSortingTypeName
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.IconAndTextDrawerItem
 import com.jerboa.ui.components.common.LargerCircularIcon
 import com.jerboa.ui.components.common.PictrsBannerImage
@@ -127,7 +126,7 @@ fun CommunityHeader(
     onBlockCommunityClick: () -> Unit,
     onClickRefresh: () -> Unit,
     selectedSortType: SortType,
-    navController: NavController = rememberNavController(),
+    navController: CommunityNavController,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
@@ -168,7 +167,9 @@ fun CommunityHeader(
                 showMoreOptions = false
                 onBlockCommunityClick()
             },
-            navController = navController,
+            onClickShowCommunitySideBar = {
+                navController.toCommunitySideBar.navigate()
+            },
         )
     }
 
@@ -180,14 +181,7 @@ fun CommunityHeader(
                 selectedSortType = selectedSortType,
             )
         },
-        navigationIcon = {
-            IconButton(onClick = { navController.popBackStack() }) {
-                Icon(
-                    Icons.Outlined.ArrowBack,
-                    contentDescription = stringResource(R.string.community_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
         actions = {
             IconButton(onClick = {
                 showSortOptions = !showSortOptions
@@ -232,7 +226,7 @@ fun CommunityMoreDialog(
     onDismissRequest: () -> Unit,
     onBlockCommunityClick: () -> Unit,
     onClickRefresh: () -> Unit,
-    navController: NavController,
+    onClickShowCommunitySideBar: () -> Unit,
 ) {
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -250,7 +244,7 @@ fun CommunityMoreDialog(
                     text = stringResource(R.string.community_community_info),
                     icon = Icons.Outlined.Info,
                     onClick = {
-                        navController.navigate("communitySidebar")
+                        onClickShowCommunitySideBar()
                         onDismissRequest()
                     },
                 )

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
+import arrow.core.Either
 import com.jerboa.R
 import com.jerboa.VoteType
 import com.jerboa.api.ApiState
@@ -36,33 +36,32 @@ import com.jerboa.datatypes.types.BlockPerson
 import com.jerboa.datatypes.types.CreatePostLike
 import com.jerboa.datatypes.types.DeletePost
 import com.jerboa.datatypes.types.FollowCommunity
+import com.jerboa.datatypes.types.GetCommunity
 import com.jerboa.datatypes.types.GetPosts
 import com.jerboa.datatypes.types.SavePost
 import com.jerboa.datatypes.types.SubscribedType
 import com.jerboa.db.AccountViewModel
 import com.jerboa.db.AppSettingsViewModel
-import com.jerboa.loginFirstToast
 import com.jerboa.newVote
 import com.jerboa.scrollToTop
 import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
-import com.jerboa.ui.components.common.BottomAppBarAll
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.common.getPostViewMode
-import com.jerboa.ui.components.community.list.CommunityListViewModel
 import com.jerboa.ui.components.home.SiteViewModel
 import com.jerboa.ui.components.post.PostListings
-import com.jerboa.ui.components.post.edit.PostEditViewModel
+import com.jerboa.ui.components.post.create.CreatePostDependencies
+import com.jerboa.ui.components.post.edit.PostEditDependencies
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun CommunityActivity(
-    navController: NavController,
+    communityArg: Either<Int, String>,
+    navController: CommunityNavController,
     communityViewModel: CommunityViewModel,
-    communityListViewModel: CommunityListViewModel,
     siteViewModel: SiteViewModel,
-    postEditViewModel: PostEditViewModel,
     accountViewModel: AccountViewModel,
     appSettingsViewModel: AppSettingsViewModel,
     showVotingArrowsInListView: Boolean,
@@ -75,6 +74,27 @@ fun CommunityActivity(
     val ctx = LocalContext.current
     val account = getCurrentAccount(accountViewModel)
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+
+    InitializeRoute {
+        val communityId = communityArg.fold({ it }, { null })
+        val communityName = communityArg.fold({ null }, { it })
+        communityViewModel.getCommunity(
+            form = GetCommunity(
+                id = communityId,
+                name = communityName,
+                auth = account?.jwt,
+            ),
+        )
+        communityViewModel.getPosts(
+            form = GetPosts(
+                community_id = communityId,
+                community_name = communityName,
+                page = communityViewModel.page,
+                sort = communityViewModel.sortType,
+                auth = account?.jwt,
+            ),
+        )
+    }
 
     val loading = communityViewModel.postsRes == ApiState.Loading || communityViewModel.fetchingMore
 
@@ -224,7 +244,7 @@ fun CommunityActivity(
                                 }
                             },
                             onPostClick = { postView ->
-                                navController.navigate(route = "post/${postView.post.id}")
+                                navController.toPost.navigate(postView.post.id)
                             },
                             onSaveClick = { postView ->
                                 account?.also { acct ->
@@ -238,8 +258,12 @@ fun CommunityActivity(
                                 }
                             },
                             onEditPostClick = { postView ->
-                                postEditViewModel.initialize(postView)
-                                navController.navigate("postEdit")
+                                navController.toPostEdit.navigate(
+                                    PostEditDependencies(
+                                        postView = postView,
+                                        onPostEdit = communityViewModel::updatePost,
+                                    ),
+                                )
                             },
                             onDeletePostClick = { postView ->
                                 account?.also { acct ->
@@ -253,13 +277,13 @@ fun CommunityActivity(
                                 }
                             },
                             onReportClick = { postView ->
-                                navController.navigate("postReport/${postView.post.id}")
+                                navController.toPostReport.navigate(postView.post.id)
                             },
                             onCommunityClick = { community ->
-                                navController.navigate(route = "community/${community.id}")
+                                navController.toCommunity.navigate(community.id)
                             },
                             onPersonClick = { personId ->
-                                navController.navigate(route = "profile/$personId")
+                                navController.toProfile.navigate(personId)
                             },
                             onBlockCommunityClick = {
                                 when (val communityRes = communityViewModel.communityRes) {
@@ -330,8 +354,9 @@ fun CommunityActivity(
                     FloatingActionButton(
                         onClick = {
                             account?.also {
-                                communityListViewModel.selectCommunity(communityRes.data.community_view.community)
-                                navController.navigate("createPost")
+                                navController.toCreatePost.navigate(
+                                    CreatePostDependencies(communityRes.data.community_view.community),
+                                )
                             }
                         },
                     ) {
@@ -344,35 +369,6 @@ fun CommunityActivity(
 
                 else -> {}
             }
-        },
-        bottomBar = {
-            BottomAppBarAll(
-                showBottomNav = appSettingsViewModel.appSettings.value?.showBottomNav,
-                screen = "communityList",
-                unreadCount = siteViewModel.getUnreadCountTotal(),
-                onClickProfile = {
-                    account?.id?.also {
-                        navController.navigate(route = "profile/$it")
-                    } ?: run {
-                        loginFirstToast(ctx)
-                    }
-                },
-                onClickInbox = {
-                    account?.also {
-                        navController.navigate(route = "inbox")
-                    } ?: run {
-                        loginFirstToast(ctx)
-                    }
-                },
-                onClickSaved = {
-                    account?.id?.also {
-                        navController.navigate(route = "profile/$it?saved=${true}")
-                    } ?: run {
-                        loginFirstToast(ctx)
-                    }
-                },
-                navController = navController,
-            )
         },
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityNavController.kt
@@ -1,0 +1,25 @@
+package com.jerboa.ui.components.community
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.community.sidebar.ToCommunitySideBar
+import com.jerboa.ui.components.person.ToProfile
+import com.jerboa.ui.components.post.ToPost
+import com.jerboa.ui.components.post.create.ToCreatePost
+import com.jerboa.ui.components.post.edit.ToPostEdit
+import com.jerboa.ui.components.report.ToPostReport
+
+class ToCommunity(
+    val navigate: (communityId: Int) -> Unit,
+)
+
+class CommunityNavController(
+    override val navController: NavController,
+    val toPostEdit: ToPostEdit,
+    val toCreatePost: ToCreatePost,
+    val toCommunitySideBar: ToCommunitySideBar,
+    val toPost: ToPost,
+    val toPostReport: ToPostReport,
+    val toCommunity: ToCommunity,
+    val toProfile: ToProfile,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityList.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityList.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.datatypes.sampleCommunityView
 import com.jerboa.datatypes.types.*
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.simpleVerticalScrollbar
 import com.jerboa.ui.components.community.CommunityLinkLarger
 import com.jerboa.ui.components.community.CommunityLinkLargerWithUserCount
@@ -33,7 +33,7 @@ import com.jerboa.ui.components.community.CommunityLinkLargerWithUserCount
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommunityListHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     search: String,
     onSearchChange: (search: String) -> Unit,
 ) {
@@ -55,18 +55,7 @@ fun CommunityListHeader(
                 )
             }
         },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.community_list_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListNavController.kt
@@ -1,0 +1,21 @@
+package com.jerboa.ui.components.community.list
+
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavController
+import com.jerboa.datatypes.types.Community
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgs
+import com.jerboa.ui.components.community.ToCommunity
+
+typealias OnSelectCommunity = (Community) -> Unit
+
+class CommunityListDependencies(
+    val onSelectCommunity: OnSelectCommunity? = null,
+) : ViewModel()
+
+typealias ToCommunityList = NavigateWithNoArgs<CommunityListDependencies>
+
+class CommunityListNavController(
+    override val navController: NavController,
+    val toCommunity: ToCommunity,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/community/sidebar/CommunitySideBarNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/sidebar/CommunitySideBarNavController.kt
@@ -1,0 +1,11 @@
+package com.jerboa.ui.components.community.sidebar
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgsAndDependencies
+
+typealias ToCommunitySideBar = NavigateWithNoArgsAndDependencies
+
+class CommunitySideBarNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/community/sidebar/CommunitySidebarActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/sidebar/CommunitySidebarActivity.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
 import com.jerboa.api.ApiState
 import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
@@ -16,7 +15,7 @@ import com.jerboa.ui.components.community.CommunityViewModel
 @Composable
 fun CommunitySidebarActivity(
     communityViewModel: CommunityViewModel,
-    navController: NavController,
+    navController: CommunitySideBarNavController,
 ) {
     Log.d("jerboa", "got to community sidebar activity")
 

--- a/app/src/main/java/com/jerboa/ui/components/home/FeedActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/FeedActivity.kt
@@ -1,0 +1,369 @@
+package com.jerboa.ui.components.home
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.jerboa.R
+import com.jerboa.VoteType
+import com.jerboa.api.ApiState
+import com.jerboa.datatypes.types.BlockCommunity
+import com.jerboa.datatypes.types.BlockPerson
+import com.jerboa.datatypes.types.CreatePostLike
+import com.jerboa.datatypes.types.DeletePost
+import com.jerboa.datatypes.types.GetPosts
+import com.jerboa.datatypes.types.SavePost
+import com.jerboa.db.Account
+import com.jerboa.db.AccountViewModel
+import com.jerboa.db.AppSettingsViewModel
+import com.jerboa.newVote
+import com.jerboa.scrollToTop
+import com.jerboa.ui.components.common.ApiEmptyText
+import com.jerboa.ui.components.common.ApiErrorText
+import com.jerboa.ui.components.common.LoadingBar
+import com.jerboa.ui.components.common.getCurrentAccount
+import com.jerboa.ui.components.common.getPostViewMode
+import com.jerboa.ui.components.post.PostListings
+import com.jerboa.ui.components.post.create.CreatePostDependencies
+import com.jerboa.ui.components.post.edit.PostEditDependencies
+import kotlinx.coroutines.CoroutineScope
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FeedActivity(
+    navController: FeedNavController,
+    homeViewModel: HomeViewModel,
+    accountViewModel: AccountViewModel,
+    siteViewModel: SiteViewModel,
+    appSettingsViewModel: AppSettingsViewModel,
+    drawerState: DrawerState,
+    showVotingArrowsInListView: Boolean,
+) {
+    Log.d("jerboa", "got to home activity")
+
+    val scope = rememberCoroutineScope()
+    val postListState = rememberLazyListState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+    val ctx = LocalContext.current
+    val account = getCurrentAccount(accountViewModel)
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            MainTopBar(
+                scope = scope,
+                postListState = postListState,
+                drawerState = drawerState,
+                homeViewModel = homeViewModel,
+                appSettingsViewModel = appSettingsViewModel,
+                account = account,
+                navController = navController,
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        content = { padding ->
+            MainPostListingsContent(
+                padding = padding,
+                homeViewModel = homeViewModel,
+                siteViewModel = siteViewModel,
+                appSettingsViewModel = appSettingsViewModel,
+                account = account,
+                ctx = ctx,
+                navController = navController,
+                postListState = postListState,
+                showVotingArrowsInListView = showVotingArrowsInListView,
+            )
+        },
+        floatingActionButtonPosition = FabPosition.End,
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+                    account?.also {
+                        navController.toCreatePost.navigate(
+                            CreatePostDependencies(selectedCommunity = null),
+                        )
+                    } ?: run {
+                        navController.toLogin.navigate()
+                    }
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Add,
+                    contentDescription = stringResource(R.string.floating_createPost),
+                )
+            }
+        },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MainTopBar(
+    scope: CoroutineScope,
+    postListState: LazyListState,
+    drawerState: DrawerState,
+    homeViewModel: HomeViewModel,
+    appSettingsViewModel: AppSettingsViewModel,
+    account: Account?,
+    navController: FeedNavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
+    Column {
+        HomeHeader(
+            scope = scope,
+            scrollBehavior = scrollBehavior,
+            drawerState = drawerState,
+            selectedSortType = homeViewModel.sortType,
+            selectedListingType = homeViewModel.listingType,
+            selectedPostViewMode = getPostViewMode(appSettingsViewModel),
+            onClickShowSiteInfo = { navController.toSiteSideBar.navigate() },
+            onClickSortType = { sortType ->
+                scrollToTop(scope, postListState)
+                homeViewModel.updateSortType(sortType)
+                homeViewModel.resetPage()
+                homeViewModel.getPosts(
+                    GetPosts(
+                        page = homeViewModel.page,
+                        sort = homeViewModel.sortType,
+                        type_ = homeViewModel.listingType,
+                        auth = account?.jwt,
+                    ),
+                )
+            },
+            onClickListingType = { listingType ->
+                scrollToTop(scope, postListState)
+                homeViewModel.updateListingType(listingType)
+                homeViewModel.resetPage()
+                homeViewModel.getPosts(
+                    GetPosts(
+                        page = homeViewModel.page,
+                        sort = homeViewModel.sortType,
+                        type_ = homeViewModel.listingType,
+                        auth = account?.jwt,
+                    ),
+                )
+            },
+            onClickPostViewMode = {
+                appSettingsViewModel.updatedPostViewMode(it.ordinal)
+            },
+            onClickRefresh = {
+                scrollToTop(scope, postListState)
+                homeViewModel.resetPage()
+                homeViewModel.getPosts(
+                    GetPosts(
+                        page = homeViewModel.page,
+                        sort = homeViewModel.sortType,
+                        type_ = homeViewModel.listingType,
+                        auth = account?.jwt,
+                    ),
+                )
+            },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun MainPostListingsContent(
+    homeViewModel: HomeViewModel,
+    siteViewModel: SiteViewModel,
+    account: Account?,
+    ctx: Context,
+    navController: FeedNavController,
+    padding: PaddingValues,
+    postListState: LazyListState,
+    appSettingsViewModel: AppSettingsViewModel,
+    showVotingArrowsInListView: Boolean,
+) {
+    when (val siteRes = siteViewModel.siteRes) {
+        ApiState.Loading ->
+            LoadingBar(padding)
+
+        ApiState.Empty -> ApiEmptyText()
+        is ApiState.Failure -> ApiErrorText(siteRes.msg)
+        is ApiState.Success -> {
+            // TODO can be removed with 0.18.0 release
+            if (siteRes.data.taglines !== null) {
+                Taglines(siteRes.data.taglines)
+            }
+        }
+    }
+
+    val loading = homeViewModel.postsRes == ApiState.Loading || homeViewModel.fetchingMore
+
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = loading,
+        onRefresh = {
+            homeViewModel.resetPage()
+            homeViewModel.getPosts(
+                GetPosts(
+                    page = homeViewModel.page,
+                    sort = homeViewModel.sortType,
+                    type_ = homeViewModel.listingType,
+                    auth = account?.jwt,
+                ),
+            )
+        },
+    )
+
+    Box(modifier = Modifier.pullRefresh(pullRefreshState)) {
+        PullRefreshIndicator(loading, pullRefreshState, Modifier.align(Alignment.TopCenter))
+        // Can't be in ApiState.Loading, because of infinite scrolling
+        if (loading) {
+            LoadingBar(padding = padding)
+        }
+        when (val postsRes = homeViewModel.postsRes) {
+            ApiState.Empty -> ApiEmptyText()
+            is ApiState.Failure -> ApiErrorText(postsRes.msg)
+            is ApiState.Success -> {
+                PostListings(
+                    listState = postListState,
+                    padding = padding,
+                    posts = postsRes.data.posts,
+                    postViewMode = getPostViewMode(appSettingsViewModel),
+                    onUpvoteClick = { postView ->
+                        account?.also { acct ->
+                            homeViewModel.likePost(
+                                CreatePostLike(
+                                    post_id = postView.post.id,
+                                    score = newVote(
+                                        currentVote = postView.my_vote,
+                                        voteType = VoteType.Upvote,
+                                    ),
+                                    auth = acct.jwt,
+                                ),
+                            )
+                        }
+                    },
+                    onDownvoteClick = { postView ->
+                        account?.also { acct ->
+                            homeViewModel.likePost(
+                                CreatePostLike(
+                                    post_id = postView.post.id,
+                                    score = newVote(
+                                        currentVote = postView.my_vote,
+                                        voteType = VoteType.Downvote,
+                                    ),
+                                    auth = acct.jwt,
+                                ),
+                            )
+                        }
+                    },
+                    onPostClick = { postView ->
+                        navController.toPost.navigate(postView.post.id)
+                    },
+                    onSaveClick = { postView ->
+                        account?.also { acct ->
+                            homeViewModel.savePost(
+                                SavePost(
+                                    post_id = postView.post.id,
+                                    save = !postView.saved,
+                                    auth = acct.jwt,
+                                ),
+                            )
+                        }
+                    },
+                    onBlockCommunityClick = { community ->
+                        account?.also { acct ->
+                            homeViewModel.blockCommunity(
+                                BlockCommunity(
+                                    community_id = community.id,
+                                    auth = acct.jwt,
+                                    block = true,
+                                ),
+                                ctx = ctx,
+                            )
+                        }
+                    },
+                    onBlockCreatorClick = { creator ->
+                        account?.also { acct ->
+                            homeViewModel.blockPerson(
+                                BlockPerson(
+                                    person_id = creator.id,
+                                    block = true,
+                                    auth = acct.jwt,
+                                ),
+                                ctx = ctx,
+                            )
+                        }
+                    },
+                    onEditPostClick = { postView ->
+                        navController.toPostEdit.navigate(
+                            PostEditDependencies(
+                                postView = postView,
+                                onPostEdit = homeViewModel::updatePost,
+                            ),
+                        )
+                    },
+                    onDeletePostClick = { postView ->
+                        account?.also { acct ->
+                            homeViewModel.deletePost(
+                                DeletePost(
+                                    post_id = postView.post.id,
+                                    deleted = !postView.post.deleted,
+                                    auth = acct.jwt,
+                                ),
+                            )
+                        }
+                    },
+                    onReportClick = { postView ->
+                        navController.toPostReport.navigate(postView.post.id)
+                    },
+                    onCommunityClick = { community ->
+                        navController.toCommunity.navigate(community.id)
+                    },
+                    onPersonClick = { personId ->
+                        navController.toProfile.navigate(personId)
+                    },
+                    isScrolledToEnd = {
+                        homeViewModel.nextPage()
+                        homeViewModel.appendPosts(
+                            GetPosts(
+                                page = homeViewModel.page,
+                                sort = homeViewModel.sortType,
+                                type_ = homeViewModel.listingType,
+                                auth = account?.jwt,
+                            ),
+                        )
+                    },
+                    account = account,
+                    enableDownVotes = siteViewModel.enableDownvotes(),
+                    showAvatar = siteViewModel.showAvatar(),
+                    showVotingArrowsInListView = showVotingArrowsInListView,
+                )
+            }
+
+            else -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/jerboa/ui/components/home/FeedNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/FeedNavController.kt
@@ -1,0 +1,39 @@
+package com.jerboa.ui.components.home
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgsAndDependencies
+import com.jerboa.ui.components.community.ToCommunity
+import com.jerboa.ui.components.login.ToLogin
+import com.jerboa.ui.components.person.ToProfile
+import com.jerboa.ui.components.post.ToPost
+import com.jerboa.ui.components.post.create.ToCreatePost
+import com.jerboa.ui.components.post.edit.ToPostEdit
+import com.jerboa.ui.components.report.ToPostReport
+import com.jerboa.ui.components.settings.ToSettings
+
+typealias ToHome = NavigateWithNoArgsAndDependencies
+typealias ToSiteSideBar = NavigateWithNoArgsAndDependencies
+
+class FeedNavController(
+    override val navController: NavController,
+    val toPostEdit: ToPostEdit,
+    val toCommunity: ToCommunity,
+    val toProfile: ToProfile,
+    val toSettings: ToSettings,
+    val toCreatePost: ToCreatePost,
+    val toPost: ToPost,
+    val toPostReport: ToPostReport,
+    val toLogin: ToLogin,
+    val toSiteSideBar: ToSiteSideBar,
+) : NavControllerWrapper()
+
+typealias BottomNavigation = NavigateWithNoArgsAndDependencies
+
+class BottomNavController(
+    val toFeed: BottomNavigation,
+    val toSearch: BottomNavigation,
+    val toInbox: BottomNavigation,
+    val toSaved: BottomNavigation,
+    val toProfile: BottomNavigation,
+)

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -59,8 +59,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.PostViewMode
 import com.jerboa.R
 import com.jerboa.api.ApiState
@@ -99,8 +97,8 @@ import kotlinx.coroutines.launch
 fun Drawer(
     siteRes: ApiState<GetSiteResponse>,
     unreadCount: Int,
-    navController: NavController = rememberNavController(),
     accountViewModel: AccountViewModel,
+    onAddAccountClick: () -> Unit,
     onSwitchAccountClick: (account: Account) -> Unit,
     onSignOutClick: () -> Unit,
     onClickListingType: (ListingType) -> Unit,
@@ -134,7 +132,7 @@ fun Drawer(
         unreadCount = unreadCount,
         myUserInfo = myUserInfo,
         showAccountAddMode = showAccountAddMode,
-        navController = navController,
+        onAddAccountClick = onAddAccountClick,
         onSwitchAccountClick = onSwitchAccountClick,
         onSignOutClick = onSignOutClick,
         onClickListingType = onClickListingType,
@@ -150,8 +148,8 @@ fun Drawer(
 @Composable
 fun DrawerContent(
     showAccountAddMode: Boolean,
-    navController: NavController,
     accountViewModel: AccountViewModel,
+    onAddAccountClick: () -> Unit,
     onSwitchAccountClick: (account: Account) -> Unit,
     onSignOutClick: () -> Unit,
     onClickListingType: (ListingType) -> Unit,
@@ -171,7 +169,7 @@ fun DrawerContent(
     ) {
         DrawerAddAccountMode(
             accountViewModel = accountViewModel,
-            navController = navController,
+            onAddAccountClick = onAddAccountClick,
             onSwitchAccountClick = onSwitchAccountClick,
             onSignOutClick = onSignOutClick,
         )
@@ -326,8 +324,8 @@ fun DrawerItemsMainPreview() {
 
 @Composable
 fun DrawerAddAccountMode(
-    navController: NavController = rememberNavController(),
     accountViewModel: AccountViewModel?,
+    onAddAccountClick: () -> Unit,
     onSwitchAccountClick: (account: Account) -> Unit,
     onSignOutClick: () -> Unit,
 ) {
@@ -339,7 +337,7 @@ fun DrawerAddAccountMode(
         IconAndTextDrawerItem(
             text = stringResource(R.string.home_add_account),
             icon = Icons.Outlined.Add,
-            onClick = { navController.navigate(route = "login") },
+            onClick = onAddAccountClick,
         )
         accountsWithoutCurrent?.forEach {
             IconAndTextDrawerItem(
@@ -365,6 +363,7 @@ fun DrawerAddAccountModePreview() {
         onSignOutClick = {},
         onSwitchAccountClick = {},
         accountViewModel = null,
+        onAddAccountClick = { },
     )
 }
 
@@ -467,10 +466,10 @@ fun HomeHeader(
     onClickListingType: (ListingType) -> Unit,
     onClickRefresh: () -> Unit,
     onClickPostViewMode: (PostViewMode) -> Unit,
+    onClickShowSiteInfo: () -> Unit,
     selectedSortType: SortType,
     selectedListingType: ListingType,
     selectedPostViewMode: PostViewMode,
-    navController: NavController,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
@@ -524,7 +523,7 @@ fun HomeHeader(
                 showMoreOptions = false
                 showPostViewModeOptions = !showPostViewModeOptions
             },
-            navController = navController,
+            onClickShowSiteInfo = onClickShowSiteInfo,
         )
     }
 
@@ -604,7 +603,7 @@ fun HomeHeaderPreview() {
         selectedSortType = SortType.Hot,
         selectedListingType = ListingType.All,
         selectedPostViewMode = PostViewMode.Card,
-        navController = rememberNavController(),
+        onClickShowSiteInfo = {},
         scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
     )
 }
@@ -612,7 +611,7 @@ fun HomeHeaderPreview() {
 @Composable
 fun HomeMoreDialog(
     onDismissRequest: () -> Unit,
-    navController: NavController,
+    onClickShowSiteInfo: () -> Unit,
     onClickRefresh: () -> Unit,
     onClickShowPostViewModeDialog: () -> Unit,
 ) {
@@ -640,7 +639,7 @@ fun HomeMoreDialog(
                     text = stringResource(R.string.home_site_info),
                     icon = Icons.Outlined.Info,
                     onClick = {
-                        navController.navigate("siteSidebar")
+                        onClickShowSiteInfo()
                         onDismissRequest()
                     },
                 )

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -2,6 +2,7 @@ package com.jerboa.ui.components.home
 
 import android.content.Context
 import android.util.Log
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DrawerState
@@ -38,6 +39,7 @@ import com.jerboa.fetchHomePosts
 import com.jerboa.fetchInitialData
 import com.jerboa.nav.HomeTab
 import com.jerboa.nav.Route
+import com.jerboa.nav.bottomIfKeyboardNotOpen
 import com.jerboa.ui.components.common.BottomAppBarAll
 import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.getCurrentAccount
@@ -129,10 +131,18 @@ fun HomeActivity(
             Scaffold(
                 snackbarHost = { SnackbarHost(snackbarHostState) },
                 content = { padding ->
+                    // Since we have 2 nested scaffolds, the bottom navigation bar from this scaffold
+                    // hides some content from the nested scaffold. We apply the bottom padding to
+                    // prevent this. However when the keyboard is opened, the bottom navigation bar
+                    // isn't visible and hence this padding also should not be applied. An alternative
+                    // is to apply .imePadding() to this scaffold to make the bottom navigation bar
+                    // also to move up when the keyboard opens.
+                    val bottomPadding by padding.bottomIfKeyboardNotOpen()
+
                     NavHost(
                         navController = bottomNavController,
                         startDestination = HomeTab.Feed.name,
-                        modifier = Modifier.padding(bottom = padding.calculateBottomPadding()),
+                        modifier = Modifier.navigationBarsPadding().padding(bottom = bottomPadding),
                     ) {
                         composable(HomeTab.Feed.name) {
                             FeedActivity(

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -2,78 +2,65 @@ package com.jerboa.ui.components.home
 
 import android.content.Context
 import android.util.Log
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FabPosition
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
-import com.jerboa.R
-import com.jerboa.VoteType
-import com.jerboa.api.ApiState
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import arrow.core.Either
 import com.jerboa.closeDrawer
-import com.jerboa.datatypes.types.BlockCommunity
-import com.jerboa.datatypes.types.BlockPerson
-import com.jerboa.datatypes.types.CreatePostLike
-import com.jerboa.datatypes.types.DeletePost
 import com.jerboa.datatypes.types.GetPosts
-import com.jerboa.datatypes.types.SavePost
-import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
 import com.jerboa.db.AppSettingsViewModel
+import com.jerboa.fetchHomePosts
 import com.jerboa.fetchInitialData
-import com.jerboa.loginFirstToast
-import com.jerboa.newVote
-import com.jerboa.scrollToTop
-import com.jerboa.ui.components.common.ApiEmptyText
-import com.jerboa.ui.components.common.ApiErrorText
+import com.jerboa.nav.HomeTab
+import com.jerboa.nav.Route
 import com.jerboa.ui.components.common.BottomAppBarAll
-import com.jerboa.ui.components.common.LoadingBar
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.getCurrentAccount
-import com.jerboa.ui.components.common.getPostViewMode
-import com.jerboa.ui.components.post.PostListings
-import com.jerboa.ui.components.post.edit.PostEditViewModel
+import com.jerboa.ui.components.community.list.CommunityListActivity
+import com.jerboa.ui.components.community.list.CommunityListNavController
+import com.jerboa.ui.components.inbox.InboxActivity
+import com.jerboa.ui.components.inbox.InboxNavController
+import com.jerboa.ui.components.person.PersonProfileActivity
+import com.jerboa.ui.components.person.PersonProfileNavController
 import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeActivity(
-    navController: NavController,
-    homeViewModel: HomeViewModel,
     accountViewModel: AccountViewModel,
     siteViewModel: SiteViewModel,
-    postEditViewModel: PostEditViewModel,
     appSettingsViewModel: AppSettingsViewModel,
     showVotingArrowsInListView: Boolean,
+    selectTabArg: HomeTab,
+    feedNavController: FeedNavController,
+    communityListNavController: CommunityListNavController,
+    inboxNavController: InboxNavController,
+    savedAndProfileNavController: PersonProfileNavController,
 ) {
     Log.d("jerboa", "got to home activity")
 
@@ -84,98 +71,129 @@ fun HomeActivity(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
     val ctx = LocalContext.current
     val account = getCurrentAccount(accountViewModel)
+    val bottomNavController = rememberNavController()
+
+    // The bottomNavController remembers which route to show. Therefore, the selectedTab also
+    // has to be persisted across navigations to ensure that the tab selected is also the route
+    // being shown.
+    var selectedTab by rememberSaveable { mutableStateOf(selectTabArg) }
+    LaunchedEffect(account) {
+        // Required for the inbox deeplink.
+        if (selectedTab.needsLogin() && account == null) {
+            selectedTab = Route.HomeArgs.TAB_DEFAULT
+        }
+    }
+
+    val onSelectTab = { tab: HomeTab ->
+        if (tab.needsLogin() && account == null) {
+            feedNavController.toLogin.navigate()
+        } else {
+            selectedTab = tab
+            bottomNavController.navigate(tab.name) {
+                popUpTo(0) // To make back button close the app.
+            }
+        }
+    }
+
+    val homeViewModel: HomeViewModel = viewModel()
+    InitializeRoute {
+        fetchHomePosts(account, homeViewModel)
+    }
 
     ModalNavigationDrawer(
+        gesturesEnabled = selectedTab == HomeTab.Feed,
         drawerState = drawerState,
         drawerContent = {
             ModalDrawerSheet(
                 content = {
                     MainDrawer(
                         siteViewModel = siteViewModel,
-                        navController = navController,
                         accountViewModel = accountViewModel,
                         homeViewModel = homeViewModel,
                         scope = scope,
                         drawerState = drawerState,
                         ctx = ctx,
+                        navController = feedNavController,
+                        bottomNavController = BottomNavController(
+                            toFeed = BottomNavigation { onSelectTab(HomeTab.Feed) },
+                            toSearch = BottomNavigation { onSelectTab(HomeTab.Search) },
+                            toInbox = BottomNavigation { onSelectTab(HomeTab.Inbox) },
+                            toSaved = BottomNavigation { onSelectTab(HomeTab.Saved) },
+                            toProfile = BottomNavigation { onSelectTab(HomeTab.Profile) },
+                        ),
                     )
                 },
             )
         },
         content = {
             Scaffold(
-                modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
                 snackbarHost = { SnackbarHost(snackbarHostState) },
-                topBar = {
-                    MainTopBar(
-                        scope = scope,
-                        postListState = postListState,
-                        drawerState = drawerState,
-                        homeViewModel = homeViewModel,
-                        appSettingsViewModel = appSettingsViewModel,
-                        account = account,
-                        navController = navController,
-                        scrollBehavior = scrollBehavior,
-                    )
-                },
                 content = { padding ->
-                    MainPostListingsContent(
-                        padding = padding,
-                        homeViewModel = homeViewModel,
-                        siteViewModel = siteViewModel,
-                        postEditViewModel = postEditViewModel,
-                        appSettingsViewModel = appSettingsViewModel,
-                        account = account,
-                        ctx = ctx,
-                        navController = navController,
-                        postListState = postListState,
-                        showVotingArrowsInListView = showVotingArrowsInListView,
-                    )
-                },
-                floatingActionButtonPosition = FabPosition.End,
-                floatingActionButton = {
-                    FloatingActionButton(
-                        onClick = {
-                            account?.also {
-                                navController.navigate("createPost")
-                            } ?: run {
-                                loginFirstToast(ctx)
-                            }
-                        },
+                    NavHost(
+                        navController = bottomNavController,
+                        startDestination = HomeTab.Feed.name,
+                        modifier = Modifier.padding(bottom = padding.calculateBottomPadding()),
                     ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Add,
-                            contentDescription = stringResource(R.string.floating_createPost),
-                        )
+                        composable(HomeTab.Feed.name) {
+                            FeedActivity(
+                                accountViewModel = accountViewModel,
+                                siteViewModel = siteViewModel,
+                                appSettingsViewModel = appSettingsViewModel,
+                                drawerState = drawerState,
+                                navController = feedNavController,
+                                homeViewModel = homeViewModel,
+                                showVotingArrowsInListView = showVotingArrowsInListView,
+                            )
+                        }
+
+                        composable(HomeTab.Search.name) {
+                            CommunityListActivity(
+                                accountViewModel = accountViewModel,
+                                siteViewModel = siteViewModel,
+                                onSelectCommunity = null,
+                                navController = communityListNavController,
+                            )
+                        }
+
+                        composable(HomeTab.Inbox.name) {
+                            InboxActivity(
+                                accountViewModel = accountViewModel,
+                                siteViewModel = siteViewModel,
+                                navController = inboxNavController,
+                            )
+                        }
+
+                        composable(HomeTab.Saved.name) {
+                            PersonProfileActivity(
+                                personArg = Either.Left(account!!.id),
+                                savedMode = true,
+                                accountViewModel = accountViewModel,
+                                siteViewModel = siteViewModel,
+                                appSettingsViewModel = appSettingsViewModel,
+                                showVotingArrowsInListView = showVotingArrowsInListView,
+                                navController = savedAndProfileNavController,
+                            )
+                        }
+
+                        composable(HomeTab.Profile.name) {
+                            PersonProfileActivity(
+                                personArg = Either.Left(account!!.id),
+                                savedMode = false,
+                                accountViewModel = accountViewModel,
+                                siteViewModel = siteViewModel,
+                                appSettingsViewModel = appSettingsViewModel,
+                                showVotingArrowsInListView = showVotingArrowsInListView,
+                                navController = savedAndProfileNavController,
+                            )
+                        }
                     }
                 },
                 bottomBar = {
                     BottomAppBarAll(
                         showBottomNav = appSettingsViewModel.appSettings.value?.showBottomNav,
-                        screen = "home",
-                        unreadCount = siteViewModel.getUnreadCountTotal(),
-                        onClickProfile = {
-                            account?.id?.also {
-                                navController.navigate(route = "profile/$it")
-                            } ?: run {
-                                loginFirstToast(ctx)
-                            }
-                        },
-                        onClickInbox = {
-                            account?.also {
-                                navController.navigate(route = "inbox")
-                            } ?: run {
-                                loginFirstToast(ctx)
-                            }
-                        },
-                        onClickSaved = {
-                            account?.id?.also {
-                                navController.navigate(route = "profile/$it?saved=${true}")
-                            } ?: run {
-                                loginFirstToast(ctx)
-                            }
-                        },
-                        navController = navController,
+                        selectedTab = selectedTab,
+                        unreadCounts = siteViewModel.getUnreadCountTotal(),
+                        onSelect = onSelectTab,
                     )
                 },
             )
@@ -183,183 +201,11 @@ fun HomeActivity(
     )
 }
 
-@OptIn(ExperimentalMaterialApi::class)
-@Composable
-fun MainPostListingsContent(
-    homeViewModel: HomeViewModel,
-    siteViewModel: SiteViewModel,
-    postEditViewModel: PostEditViewModel,
-    account: Account?,
-    ctx: Context,
-    navController: NavController,
-    padding: PaddingValues,
-    postListState: LazyListState,
-    appSettingsViewModel: AppSettingsViewModel,
-    showVotingArrowsInListView: Boolean,
-) {
-    when (val siteRes = siteViewModel.siteRes) {
-        ApiState.Loading ->
-            LoadingBar(padding)
-
-        ApiState.Empty -> ApiEmptyText()
-        is ApiState.Failure -> ApiErrorText(siteRes.msg)
-        is ApiState.Success -> {
-            // TODO can be removed with 0.18.0 release
-            if (siteRes.data.taglines !== null) {
-                Taglines(siteRes.data.taglines)
-            }
-        }
-    }
-
-    val loading = homeViewModel.postsRes == ApiState.Loading || homeViewModel.fetchingMore
-
-    val pullRefreshState = rememberPullRefreshState(
-        refreshing = loading,
-        onRefresh = {
-            homeViewModel.resetPage()
-            homeViewModel.getPosts(
-                GetPosts(
-                    page = homeViewModel.page,
-                    sort = homeViewModel.sortType,
-                    type_ = homeViewModel.listingType,
-                    auth = account?.jwt,
-                ),
-            )
-        },
-    )
-
-    Box(modifier = Modifier.pullRefresh(pullRefreshState)) {
-        PullRefreshIndicator(loading, pullRefreshState, Modifier.align(Alignment.TopCenter))
-        // Can't be in ApiState.Loading, because of infinite scrolling
-        if (loading) {
-            LoadingBar(padding = padding)
-        }
-        when (val postsRes = homeViewModel.postsRes) {
-            ApiState.Empty -> ApiEmptyText()
-            is ApiState.Failure -> ApiErrorText(postsRes.msg)
-            is ApiState.Success -> {
-                PostListings(
-                    listState = postListState,
-                    padding = padding,
-                    posts = postsRes.data.posts,
-                    postViewMode = getPostViewMode(appSettingsViewModel),
-                    onUpvoteClick = { postView ->
-                        account?.also { acct ->
-                            homeViewModel.likePost(
-                                CreatePostLike(
-                                    post_id = postView.post.id,
-                                    score = newVote(
-                                        currentVote = postView.my_vote,
-                                        voteType = VoteType.Upvote,
-                                    ),
-                                    auth = acct.jwt,
-                                ),
-                            )
-                        }
-                    },
-                    onDownvoteClick = { postView ->
-                        account?.also { acct ->
-                            homeViewModel.likePost(
-                                CreatePostLike(
-                                    post_id = postView.post.id,
-                                    score = newVote(
-                                        currentVote = postView.my_vote,
-                                        voteType = VoteType.Downvote,
-                                    ),
-                                    auth = acct.jwt,
-                                ),
-                            )
-                        }
-                    },
-                    onPostClick = { postView ->
-                        navController.navigate(route = "post/${postView.post.id}")
-                    },
-                    onSaveClick = { postView ->
-                        account?.also { acct ->
-                            homeViewModel.savePost(
-                                SavePost(
-                                    post_id = postView.post.id,
-                                    save = !postView.saved,
-                                    auth = acct.jwt,
-                                ),
-                            )
-                        }
-                    },
-                    onBlockCommunityClick = { community ->
-                        account?.also { acct ->
-                            homeViewModel.blockCommunity(
-                                BlockCommunity(
-                                    community_id = community.id,
-                                    auth = acct.jwt,
-                                    block = true,
-                                ),
-                                ctx = ctx,
-                            )
-                        }
-                    },
-                    onBlockCreatorClick = { creator ->
-                        account?.also { acct ->
-                            homeViewModel.blockPerson(
-                                BlockPerson(
-                                    person_id = creator.id,
-                                    block = true,
-                                    auth = acct.jwt,
-                                ),
-                                ctx = ctx,
-                            )
-                        }
-                    },
-                    onEditPostClick = { postView ->
-                        postEditViewModel.initialize(postView)
-                        navController.navigate("postEdit")
-                    },
-                    onDeletePostClick = { postView ->
-                        account?.also { acct ->
-                            homeViewModel.deletePost(
-                                DeletePost(
-                                    post_id = postView.post.id,
-                                    deleted = !postView.post.deleted,
-                                    auth = acct.jwt,
-                                ),
-                            )
-                        }
-                    },
-                    onReportClick = { postView ->
-                        navController.navigate("postReport/${postView.post.id}")
-                    },
-                    onCommunityClick = { community ->
-                        navController.navigate(route = "community/${community.id}")
-                    },
-                    onPersonClick = { personId ->
-                        navController.navigate(route = "profile/$personId")
-                    },
-                    isScrolledToEnd = {
-                        homeViewModel.nextPage()
-                        homeViewModel.appendPosts(
-                            GetPosts(
-                                page = homeViewModel.page,
-                                sort = homeViewModel.sortType,
-                                type_ = homeViewModel.listingType,
-                                auth = account?.jwt,
-                            ),
-                        )
-                    },
-                    account = account,
-                    enableDownVotes = siteViewModel.enableDownvotes(),
-                    showAvatar = siteViewModel.showAvatar(),
-                    showVotingArrowsInListView = showVotingArrowsInListView,
-                )
-            }
-
-            else -> {}
-        }
-    }
-}
-
 @Composable
 fun MainDrawer(
     siteViewModel: SiteViewModel,
-    navController: NavController,
+    navController: FeedNavController,
+    bottomNavController: BottomNavController,
     accountViewModel: AccountViewModel,
     homeViewModel: HomeViewModel,
     scope: CoroutineScope,
@@ -373,8 +219,8 @@ fun MainDrawer(
         siteRes = siteViewModel.siteRes,
         unreadCount = siteViewModel.getUnreadCountTotal(),
         accountViewModel = accountViewModel,
-        navController = navController,
         isOpen = drawerState.isOpen,
+        onAddAccountClick = { navController.toLogin.navigate() },
         onSwitchAccountClick = { acct ->
             accountViewModel.removeCurrent()
             accountViewModel.setCurrent(acct.id)
@@ -382,6 +228,10 @@ fun MainDrawer(
             fetchInitialData(
                 account = acct,
                 siteViewModel = siteViewModel,
+            )
+
+            fetchHomePosts(
+                account = acct,
                 homeViewModel = homeViewModel,
             )
 
@@ -400,6 +250,9 @@ fun MainDrawer(
                     fetchInitialData(
                         account = updatedList.getOrNull(0),
                         siteViewModel = siteViewModel,
+                    )
+                    fetchHomePosts(
+                        account = updatedList.getOrNull(0),
                         homeViewModel = homeViewModel,
                     )
 
@@ -421,102 +274,32 @@ fun MainDrawer(
             closeDrawer(scope, drawerState)
         },
         onCommunityClick = { community ->
-            navController.navigate(route = "community/${community.id}")
+            navController.toCommunity.navigate(community.id)
             closeDrawer(scope, drawerState)
         },
         onClickProfile = {
             account?.id?.also {
-                navController.navigate(route = "profile/$it")
+                bottomNavController.toProfile.navigate()
                 closeDrawer(scope, drawerState)
             }
         },
         onClickSaved = {
             account?.id?.also {
-                navController.navigate(route = "profile/$it?saved=${true}")
+                bottomNavController.toSaved.navigate()
                 closeDrawer(scope, drawerState)
             }
         },
         onClickInbox = {
-            account?.also {
-                navController.navigate(route = "inbox")
-            } ?: run {
-                loginFirstToast(ctx)
-            }
+            bottomNavController.toInbox.navigate()
             closeDrawer(scope, drawerState)
         },
         onClickSettings = {
-            navController.navigate(route = "settings")
+            navController.toSettings.navigate()
             closeDrawer(scope, drawerState)
         },
         onClickCommunities = {
-            navController.navigate(route = "communityList")
+            bottomNavController.toSearch.navigate()
             closeDrawer(scope, drawerState)
         },
     )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun MainTopBar(
-    scope: CoroutineScope,
-    postListState: LazyListState,
-    drawerState: DrawerState,
-    homeViewModel: HomeViewModel,
-    appSettingsViewModel: AppSettingsViewModel,
-    account: Account?,
-    navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
-) {
-    Column {
-        HomeHeader(
-            scope = scope,
-            scrollBehavior = scrollBehavior,
-            drawerState = drawerState,
-            navController = navController,
-            selectedSortType = homeViewModel.sortType,
-            selectedListingType = homeViewModel.listingType,
-            selectedPostViewMode = getPostViewMode(appSettingsViewModel),
-            onClickSortType = { sortType ->
-                scrollToTop(scope, postListState)
-                homeViewModel.updateSortType(sortType)
-                homeViewModel.resetPage()
-                homeViewModel.getPosts(
-                    GetPosts(
-                        page = homeViewModel.page,
-                        sort = homeViewModel.sortType,
-                        type_ = homeViewModel.listingType,
-                        auth = account?.jwt,
-                    ),
-                )
-            },
-            onClickListingType = { listingType ->
-                scrollToTop(scope, postListState)
-                homeViewModel.updateListingType(listingType)
-                homeViewModel.resetPage()
-                homeViewModel.getPosts(
-                    GetPosts(
-                        page = homeViewModel.page,
-                        sort = homeViewModel.sortType,
-                        type_ = homeViewModel.listingType,
-                        auth = account?.jwt,
-                    ),
-                )
-            },
-            onClickPostViewMode = {
-                appSettingsViewModel.updatedPostViewMode(it.ordinal)
-            },
-            onClickRefresh = {
-                scrollToTop(scope, postListState)
-                homeViewModel.resetPage()
-                homeViewModel.getPosts(
-                    GetPosts(
-                        page = homeViewModel.page,
-                        sort = homeViewModel.sortType,
-                        type_ = homeViewModel.listingType,
-                        auth = account?.jwt,
-                    ),
-                )
-            },
-        )
-    }
 }

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -67,10 +67,8 @@ fun HomeActivity(
     Log.d("jerboa", "got to home activity")
 
     val scope = rememberCoroutineScope()
-    val postListState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
     val drawerState = rememberDrawerState(DrawerValue.Closed)
-    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
     val ctx = LocalContext.current
     val account = getCurrentAccount(accountViewModel)
     val bottomNavController = rememberNavController()
@@ -78,14 +76,7 @@ fun HomeActivity(
     // The bottomNavController remembers which route to show. Therefore, the selectedTab also
     // has to be persisted across navigations to ensure that the tab selected is also the route
     // being shown.
-    var selectedTab by rememberSaveable { mutableStateOf(selectTabArg) }
-    LaunchedEffect(account) {
-        // Required for the inbox deeplink.
-        if (selectedTab.needsLogin() && account == null) {
-            selectedTab = Route.HomeArgs.TAB_DEFAULT
-        }
-    }
-
+    var selectedTab by rememberSaveable { mutableStateOf(Route.HomeArgs.TAB_DEFAULT) }
     val onSelectTab = { tab: HomeTab ->
         if (tab.needsLogin() && account == null) {
             feedNavController.toLogin.navigate()
@@ -99,6 +90,7 @@ fun HomeActivity(
 
     val homeViewModel: HomeViewModel = viewModel()
     InitializeRoute {
+        onSelectTab(selectTabArg)
         fetchHomePosts(account, homeViewModel)
     }
 
@@ -141,7 +133,7 @@ fun HomeActivity(
 
                     NavHost(
                         navController = bottomNavController,
-                        startDestination = HomeTab.Feed.name,
+                        startDestination = Route.HomeArgs.TAB_DEFAULT.name,
                         modifier = Modifier.navigationBarsPadding().padding(bottom = bottomPadding),
                     ) {
                         composable(HomeTab.Feed.name) {

--- a/app/src/main/java/com/jerboa/ui/components/home/sidebar/SiteSideBarNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/sidebar/SiteSideBarNavController.kt
@@ -1,0 +1,8 @@
+package com.jerboa.ui.components.home.sidebar
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+
+class SiteSideBarNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/home/sidebar/SiteSidebarActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/sidebar/SiteSidebarActivity.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
 import com.jerboa.api.ApiState
 import com.jerboa.ui.components.common.ApiEmptyText
 import com.jerboa.ui.components.common.ApiErrorText
@@ -16,7 +15,7 @@ import com.jerboa.ui.components.home.SiteViewModel
 @Composable
 fun SiteSidebarActivity(
     siteViewModel: SiteViewModel,
-    navController: NavController,
+    navController: SiteSideBarNavController,
 ) {
     Log.d("jerboa", "got to site sidebar activity")
 

--- a/app/src/main/java/com/jerboa/ui/components/inbox/Inbox.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/Inbox.kt
@@ -4,7 +4,6 @@ package com.jerboa.ui.components.inbox
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -21,16 +20,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.UnreadOrAll
 import com.jerboa.getLocalizedUnreadOrAllName
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.UnreadOrAllOptionsDialog
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InboxHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     selectedUnreadOrAll: UnreadOrAll,
     onClickUnreadOrAll: (UnreadOrAll) -> Unit,
     onClickMarkAllAsRead: () -> Unit,
@@ -58,14 +58,7 @@ fun InboxHeader(
                 selectedUnreadOrAll = selectedUnreadOrAll,
             )
         },
-        navigationIcon = {
-            IconButton(onClick = { navController.popBackStack() }) {
-                Icon(
-                    Icons.Outlined.ArrowBack,
-                    contentDescription = stringResource(R.string.inbox_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
         actions = {
             IconButton(onClick = {
                 showUnreadOrAllOptions = !showUnreadOrAllOptions

--- a/app/src/main/java/com/jerboa/ui/components/inbox/InboxNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/InboxNavController.kt
@@ -1,0 +1,25 @@
+package com.jerboa.ui.components.inbox
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgsAndDependencies
+import com.jerboa.ui.components.comment.reply.ToCommentReply
+import com.jerboa.ui.components.community.ToCommunity
+import com.jerboa.ui.components.person.ToProfile
+import com.jerboa.ui.components.post.ToComment
+import com.jerboa.ui.components.post.ToPost
+import com.jerboa.ui.components.privatemessage.ToPrivateMessageReply
+import com.jerboa.ui.components.report.ToCommentReport
+
+typealias ToInbox = NavigateWithNoArgsAndDependencies
+
+class InboxNavController(
+    override val navController: NavController,
+    val toCommentReply: ToCommentReply,
+    val toPrivateMessageReply: ToPrivateMessageReply,
+    val toProfile: ToProfile,
+    val toCommentReport: ToCommentReport,
+    val toComment: ToComment,
+    val toPost: ToPost,
+    val toCommunity: ToCommunity,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.*
@@ -29,13 +28,14 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.jerboa.DEFAULT_LEMMY_INSTANCES
 import com.jerboa.R
 import com.jerboa.datatypes.types.Login
 import com.jerboa.db.Account
+import com.jerboa.nav.NavControllerWrapper
 import com.jerboa.onAutofill
+import com.jerboa.ui.components.common.DefaultBackButton
 
 @Composable
 fun MyTextField(
@@ -204,7 +204,7 @@ fun LoginFormPreview() {
 
 @Composable
 fun LoginHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     accounts: List<Account>? = null,
 ) {
     TopAppBar(
@@ -213,24 +213,14 @@ fun LoginHeader(
                 text = stringResource(R.string.login_login),
             )
         },
-        navigationIcon = {
-            IconButton(
-                enabled = !accounts.isNullOrEmpty(),
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                Icon(
-                    Icons.Outlined.ArrowBack,
-                    contentDescription = stringResource(R.string.login_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
     )
 }
 
 @Preview
 @Composable
 fun LoginHeaderPreview() {
-    LoginHeader()
+    LoginHeader(object : NavControllerWrapper() {
+        override val navController = rememberNavController()
+    })
 }

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginActivity.kt
@@ -15,24 +15,23 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.db.AccountViewModel
-import com.jerboa.ui.components.home.HomeViewModel
 import com.jerboa.ui.components.home.SiteViewModel
 
 @Composable
 fun LoginActivity(
-    navController: NavController,
-    loginViewModel: LoginViewModel,
+    navController: LoginNavController,
     accountViewModel: AccountViewModel,
     siteViewModel: SiteViewModel,
-    homeViewModel: HomeViewModel,
 ) {
     Log.d("jerboa", "Got to login activity")
 
     val snackbarHostState = remember { SnackbarHostState() }
     val accounts by accountViewModel.allAccounts.observeAsState()
     val ctx = LocalContext.current
+
+    val loginViewModel: LoginViewModel = viewModel()
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -50,14 +49,14 @@ fun LoginActivity(
                     .imePadding(),
                 onClickLogin = { form, instance ->
                     loginViewModel.login(
-                        navController = navController,
                         form = form,
                         instance = instance.trim(),
                         ctx = ctx,
                         accountViewModel = accountViewModel,
                         siteViewModel = siteViewModel,
-                        homeViewModel = homeViewModel,
-                    )
+                    ) {
+                        navController.toHome.navigate()
+                    }
                 },
             )
         },

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginNavController.kt
@@ -1,0 +1,13 @@
+package com.jerboa.ui.components.login
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgsAndDependencies
+import com.jerboa.ui.components.home.ToHome
+
+typealias ToLogin = NavigateWithNoArgsAndDependencies
+
+class LoginNavController(
+    override val navController: NavController,
+    val toHome: ToHome,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -8,19 +8,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.R
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
 import com.jerboa.api.retrofitErrorHandler
-import com.jerboa.datatypes.types.GetPosts
 import com.jerboa.datatypes.types.GetSite
 import com.jerboa.datatypes.types.Login
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
 import com.jerboa.serializeToMap
-import com.jerboa.ui.components.home.HomeViewModel
 import com.jerboa.ui.components.home.SiteViewModel
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -33,11 +30,10 @@ class LoginViewModel : ViewModel() {
     fun login(
         instance: String,
         form: Login,
-        navController: NavController,
         accountViewModel: AccountViewModel,
         siteViewModel: SiteViewModel,
-        homeViewModel: HomeViewModel,
         ctx: Context,
+        onSuccess: () -> Unit,
     ) {
         val originalInstance = API.currentInstance
         val api = API.changeLemmyInstance(instance)
@@ -104,16 +100,6 @@ class LoginViewModel : ViewModel() {
                         defaultSortType = luv.local_user.default_sort_type.ordinal,
                     )
 
-                    homeViewModel.resetPage()
-                    homeViewModel.getPosts(
-                        GetPosts(
-                            type_ = luv.local_user.default_listing_type,
-                            sort = luv.local_user.default_sort_type,
-                            page = homeViewModel.page,
-                            auth = account.jwt,
-                        ),
-                    )
-
                     // Remove the default account
                     accountViewModel.removeCurrent()
 
@@ -121,8 +107,7 @@ class LoginViewModel : ViewModel() {
                     accountViewModel.insert(account)
 
                     loading = false
-
-                    navController.navigate(route = "home")
+                    onSuccess()
                 }
 
                 else -> {}

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -28,14 +28,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.datatypes.samplePersonView
 import com.jerboa.datatypes.types.PersonView
 import com.jerboa.datatypes.types.SortType
 import com.jerboa.getLocalizedSortingTypeName
+import com.jerboa.nav.NavControllerWrapper
 import com.jerboa.personNameShown
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.DotSpacer
 import com.jerboa.ui.components.common.IconAndTextDrawerItem
 import com.jerboa.ui.components.common.ImageViewerDialog
@@ -159,7 +159,7 @@ fun PersonProfileHeader(
     onBlockPersonClick: () -> Unit,
     onReportPersonClick: () -> Unit,
     selectedSortType: SortType,
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
@@ -214,14 +214,7 @@ fun PersonProfileHeader(
                 selectedSortType = selectedSortType,
             )
         },
-        navigationIcon = {
-            IconButton(onClick = { navController.popBackStack() }) {
-                Icon(
-                    Icons.Outlined.ArrowBack,
-                    contentDescription = stringResource(R.string.person_profile_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
         actions = {
             IconButton(onClick = {
                 showSortOptions = !showSortOptions

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -90,15 +90,16 @@ fun PersonProfileActivity(
         val personName = personArg.fold({ null }, { it })
 
         personProfileViewModel.resetPage()
+        personProfileViewModel.updateSavedOnly(savedMode)
         personProfileViewModel.getPersonDetails(
             GetPersonDetails(
                 person_id = personId,
                 username = personName,
                 sort = SortType.New,
+                saved_only = savedMode,
                 auth = account?.jwt,
             ),
         )
-        personProfileViewModel.updateSavedOnly(savedMode)
     }
 
     Scaffold(

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileNavController.kt
@@ -1,0 +1,34 @@
+package com.jerboa.ui.components.person
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.Route
+import com.jerboa.ui.components.comment.edit.ToCommentEdit
+import com.jerboa.ui.components.comment.reply.ToCommentReply
+import com.jerboa.ui.components.community.ToCommunity
+import com.jerboa.ui.components.post.ToComment
+import com.jerboa.ui.components.post.ToPost
+import com.jerboa.ui.components.post.edit.ToPostEdit
+import com.jerboa.ui.components.report.ToCommentReport
+import com.jerboa.ui.components.report.ToPostReport
+
+class ToProfile(
+    private val navigateToDestination: (profileId: Int, saved: Boolean) -> Unit,
+) {
+    fun navigate(profileId: Int, saved: Boolean = Route.ProfileFromIdArgs.SAVED_DEFAULT) {
+        navigateToDestination(profileId, saved)
+    }
+}
+
+class PersonProfileNavController(
+    override val navController: NavController,
+    val toCommentEdit: ToCommentEdit,
+    val toCommentReply: ToCommentReply,
+    val toPostEdit: ToPostEdit,
+    val toCommentReport: ToCommentReport,
+    val toPostReport: ToPostReport,
+    val toCommunity: ToCommunity,
+    val toPost: ToPost,
+    val toProfile: ToProfile,
+    val toComment: ToComment,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -75,6 +75,7 @@ import com.jerboa.db.Account
 import com.jerboa.hostName
 import com.jerboa.isImage
 import com.jerboa.isSameInstance
+import com.jerboa.nav.NavControllerWrapper
 import com.jerboa.nsfwCheck
 import com.jerboa.ui.components.common.ActionBarButton
 import com.jerboa.ui.components.common.CircularIcon
@@ -1250,7 +1251,9 @@ fun PostListingCard(
 @Preview
 @Composable
 fun PostListingHeaderPreview() {
-    val navController = rememberNavController()
+    val navController = object : NavControllerWrapper() {
+        override val navController = rememberNavController()
+    }
     SimpleTopAppBar("Post", navController)
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/post/PostNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostNavController.kt
@@ -1,0 +1,32 @@
+package com.jerboa.ui.components.post
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.comment.edit.ToCommentEdit
+import com.jerboa.ui.components.comment.reply.ToCommentReply
+import com.jerboa.ui.components.community.ToCommunity
+import com.jerboa.ui.components.person.ToProfile
+import com.jerboa.ui.components.post.edit.ToPostEdit
+import com.jerboa.ui.components.report.ToCommentReport
+import com.jerboa.ui.components.report.ToPostReport
+
+class PostNavController(
+    override val navController: NavController,
+    val toCommentEdit: ToCommentEdit,
+    val toCommentReply: ToCommentReply,
+    val toPostEdit: ToPostEdit,
+    val toCommunity: ToCommunity,
+    val toPostReport: ToPostReport,
+    val toProfile: ToProfile,
+    val toPost: ToPost,
+    val toComment: ToComment,
+    val toCommentReport: ToCommentReport,
+) : NavControllerWrapper()
+
+class ToPost(
+    val navigate: (postId: Int) -> Unit,
+)
+
+class ToComment(
+    val navigate: (commentId: Int) -> Unit,
+)

--- a/app/src/main/java/com/jerboa/ui/components/post/create/CreatePost.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/create/CreatePost.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material.icons.outlined.ArrowDropDown
-import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Send
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -34,15 +33,20 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.datatypes.sampleCommunity
 import com.jerboa.datatypes.types.Community
 import com.jerboa.db.Account
+import com.jerboa.nav.dependencyContainer
 import com.jerboa.ui.components.common.CircularIcon
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.MarkdownTextField
 import com.jerboa.ui.components.common.PickImage
+import com.jerboa.ui.components.community.list.CommunityListDependencies
+import com.jerboa.ui.components.community.list.OnSelectCommunity
+import com.jerboa.ui.components.community.list.ToCommunityList
+import com.jerboa.ui.components.post.ToPost
 import com.jerboa.ui.theme.ICON_SIZE
 import com.jerboa.ui.theme.MEDIUM_PADDING
 import com.jerboa.ui.theme.THUMBNAIL_SIZE
@@ -53,7 +57,7 @@ import com.jerboa.validateUrl
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreatePostHeader(
-    navController: NavController = rememberNavController(),
+    navController: CreatePostNavController,
     onCreatePostClick: () -> Unit,
     formValid: Boolean,
     loading: Boolean,
@@ -88,17 +92,8 @@ fun CreatePostHeader(
             }
         },
         navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                // Todo add are you sure cancel dialog
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.create_post_close),
-                )
-            }
+            // Todo add are you sure cancel dialog
+            DefaultBackButton(navController)
         },
     )
 }
@@ -114,7 +109,8 @@ fun CreatePostBody(
     onPickedImage: (image: Uri) -> Unit,
     image: Uri? = null,
     community: Community? = null,
-    navController: NavController = rememberNavController(),
+    onSelectCommunity: OnSelectCommunity,
+    navController: CreatePostNavController,
     formValid: (valid: Boolean) -> Unit,
     account: Account?,
     padding: PaddingValues,
@@ -233,7 +229,9 @@ fun CreatePostBody(
                     .height(60.dp)
                     .fillMaxWidth()
                     .clickable {
-                        navController.navigate("communityList?select=true")
+                        navController.toCommunityList.navigate(
+                            CommunityListDependencies(onSelectCommunity = onSelectCommunity),
+                        )
                     },
             )
         }
@@ -247,6 +245,11 @@ fun CreatePostHeaderPreview() {
         onCreatePostClick = {},
         formValid = true,
         loading = false,
+        navController = CreatePostNavController(
+            rememberNavController(),
+            ToPost { },
+            ToCommunityList(dependencyContainer()) { },
+        ),
     )
 }
 
@@ -267,6 +270,12 @@ fun CreatePostBodyPreview() {
         padding = PaddingValues(),
         suggestedTitle = null,
         suggestedTitleLoading = false,
+        navController = CreatePostNavController(
+            rememberNavController(),
+            ToPost { },
+            ToCommunityList(dependencyContainer()) { },
+        ),
+        onSelectCommunity = { },
     )
 }
 
@@ -286,5 +295,11 @@ fun CreatePostBodyPreviewNoCommunity() {
         suggestedTitleLoading = false,
         account = null,
         padding = PaddingValues(),
+        navController = CreatePostNavController(
+            rememberNavController(),
+            ToPost { },
+            ToCommunityList(dependencyContainer()) { },
+        ),
+        onSelectCommunity = { },
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue

--- a/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostNavController.kt
@@ -1,0 +1,24 @@
+package com.jerboa.ui.components.post.create
+
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavController
+import com.jerboa.datatypes.types.Community
+import com.jerboa.datatypes.types.PostView
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgs
+import com.jerboa.ui.components.community.list.ToCommunityList
+import com.jerboa.ui.components.post.ToPost
+
+typealias OnCreatePost = (PostView) -> Unit
+
+class CreatePostDependencies(
+    val selectedCommunity: Community?,
+) : ViewModel()
+
+typealias ToCreatePost = NavigateWithNoArgs<CreatePostDependencies>
+
+class CreatePostNavController(
+    override val navController: NavController,
+    val toPost: ToPost,
+    val toCommunityList: ToCommunityList,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostViewModel.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
+import com.jerboa.datatypes.types.Community
 import com.jerboa.datatypes.types.CreatePost
 import com.jerboa.datatypes.types.GetSiteMetadata
 import com.jerboa.datatypes.types.GetSiteMetadataResponse
@@ -17,6 +17,12 @@ import com.jerboa.serializeToMap
 import kotlinx.coroutines.launch
 
 class CreatePostViewModel : ViewModel() {
+    var selectedCommunity by mutableStateOf<Community?>(null)
+
+    fun initialize(inCommunity: Community?) {
+        selectedCommunity = inCommunity
+    }
+
     var createPostRes: ApiState<PostResponse> by mutableStateOf(ApiState.Empty)
         private set
     var siteMetadataRes: ApiState<GetSiteMetadataResponse> by mutableStateOf(ApiState.Empty)
@@ -24,7 +30,7 @@ class CreatePostViewModel : ViewModel() {
 
     fun createPost(
         form: CreatePost,
-        navController: NavController,
+        onSuccess: (postId: Int) -> Unit,
     ) {
         viewModelScope.launch {
             createPostRes = ApiState.Loading
@@ -35,8 +41,7 @@ class CreatePostViewModel : ViewModel() {
 
             when (val postRes = createPostRes) {
                 is ApiState.Success -> {
-                    navController.popBackStack()
-                    navController.navigate(route = "post/${postRes.data.post_view.post.id}")
+                    onSuccess(postRes.data.post_view.post.id)
                 }
                 else -> {}
             }

--- a/app/src/main/java/com/jerboa/ui/components/post/edit/PostEdit.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/edit/PostEdit.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -20,10 +19,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.db.Account
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.MarkdownTextField
 import com.jerboa.ui.components.common.PickImage
 import com.jerboa.ui.theme.MEDIUM_PADDING
@@ -33,7 +31,7 @@ import com.jerboa.validateUrl
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditPostHeader(
-    navController: NavController = rememberNavController(),
+    navController: PostEditNavController,
     onEditPostClick: () -> Unit,
     formValid: Boolean,
     loading: Boolean,
@@ -63,17 +61,8 @@ fun EditPostHeader(
             }
         },
         navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                // Todo add are you sure cancel dialog
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.post_edit_close),
-                )
-            }
+            // Todo add are you sure cancel dialog
+            DefaultBackButton(navController)
         },
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/post/edit/PostEditActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/edit/PostEditActivity.kt
@@ -16,30 +16,25 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.api.ApiState
 import com.jerboa.api.uploadPictrsImage
 import com.jerboa.datatypes.types.EditPost
+import com.jerboa.datatypes.types.PostView
 import com.jerboa.db.AccountViewModel
 import com.jerboa.imageInputStreamFromUri
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.getCurrentAccount
-import com.jerboa.ui.components.community.CommunityViewModel
-import com.jerboa.ui.components.home.HomeViewModel
-import com.jerboa.ui.components.person.PersonProfileViewModel
-import com.jerboa.ui.components.post.PostViewModel
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PostEditActivity(
     accountViewModel: AccountViewModel,
-    postEditViewModel: PostEditViewModel,
-    navController: NavController,
-    postViewModel: PostViewModel,
-    personProfileViewModel: PersonProfileViewModel,
-    communityViewModel: CommunityViewModel,
-    homeViewModel: HomeViewModel,
+    navController: PostEditNavController,
+    postView: PostView,
+    onPostEdit: OnPostEdit?,
 ) {
     Log.d("jerboa", "got to post edit activity")
 
@@ -47,13 +42,17 @@ fun PostEditActivity(
     val account = getCurrentAccount(accountViewModel = accountViewModel)
     val scope = rememberCoroutineScope()
 
-    val pv = postEditViewModel.postView
-    var name by rememberSaveable { mutableStateOf(pv?.post?.name.orEmpty()) }
-    var url by rememberSaveable { mutableStateOf(pv?.post?.url.orEmpty()) }
+    val postEditViewModel: PostEditViewModel = viewModel()
+    InitializeRoute {
+        postEditViewModel.initialize(postView)
+    }
+
+    var name by rememberSaveable { mutableStateOf(postView.post.name.orEmpty()) }
+    var url by rememberSaveable { mutableStateOf(postView.post.url.orEmpty()) }
     var body by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(
             TextFieldValue(
-                pv?.post?.body.orEmpty(),
+                postView.post.body.orEmpty(),
             ),
         )
     }
@@ -79,18 +78,16 @@ fun PostEditActivity(
 
                             postEditViewModel.editPost(
                                 form = EditPost(
-                                    post_id = pv!!.post.id,
+                                    post_id = postView.post.id,
                                     name = nameOut,
                                     url = urlOut,
                                     body = bodyOut,
                                     auth = acct.jwt,
                                 ),
-                                navController = navController,
-                                postViewModel = postViewModel,
-                                personProfileViewModel = personProfileViewModel,
-                                communityViewModel = communityViewModel,
-                                homeViewModel = homeViewModel,
-                            )
+                            ) { postView ->
+                                onPostEdit?.invoke(postView)
+                                navController.navigateUp()
+                            }
                         }
                     },
                 )

--- a/app/src/main/java/com/jerboa/ui/components/post/edit/PostEditNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/edit/PostEditNavController.kt
@@ -1,0 +1,20 @@
+package com.jerboa.ui.components.post.edit
+
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavController
+import com.jerboa.datatypes.types.PostView
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgs
+
+typealias OnPostEdit = (PostView) -> Unit
+
+class PostEditDependencies(
+    val postView: PostView,
+    val onPostEdit: OnPostEdit?,
+) : ViewModel()
+
+typealias ToPostEdit = NavigateWithNoArgs<PostEditDependencies>
+
+class PostEditNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/post/edit/PostEditViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/edit/PostEditViewModel.kt
@@ -5,17 +5,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
 import com.jerboa.datatypes.types.EditPost
 import com.jerboa.datatypes.types.PostResponse
 import com.jerboa.datatypes.types.PostView
-import com.jerboa.ui.components.community.CommunityViewModel
-import com.jerboa.ui.components.home.HomeViewModel
-import com.jerboa.ui.components.person.PersonProfileViewModel
-import com.jerboa.ui.components.post.PostViewModel
 import kotlinx.coroutines.launch
 
 class PostEditViewModel : ViewModel() {
@@ -32,11 +27,7 @@ class PostEditViewModel : ViewModel() {
 
     fun editPost(
         form: EditPost,
-        navController: NavController,
-        personProfileViewModel: PersonProfileViewModel,
-        postViewModel: PostViewModel,
-        communityViewModel: CommunityViewModel,
-        homeViewModel: HomeViewModel,
+        onSuccess: OnPostEdit,
     ) {
         viewModelScope.launch {
             editPostRes = ApiState.Loading
@@ -50,13 +41,7 @@ class PostEditViewModel : ViewModel() {
                     val post = res.data.post_view
                     postView = post
 
-                    // Update the other view models
-                    postViewModel.updatePost(post)
-                    personProfileViewModel.updatePost(post)
-                    communityViewModel.updatePost(post)
-                    homeViewModel.updatePost(post)
-
-                    navController.popBackStack()
+                    onSuccess(post)
                 }
                 else -> {}
             }

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReply.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.datatypes.samplePrivateMessageView
 import com.jerboa.datatypes.types.PrivateMessageView
 import com.jerboa.db.Account
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.MarkdownTextField
 import com.jerboa.ui.theme.LARGE_PADDING
 import com.jerboa.ui.theme.MEDIUM_PADDING
@@ -28,7 +28,7 @@ import com.jerboa.ui.theme.MEDIUM_PADDING
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PrivateMessageReplyHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     onSendClick: () -> Unit,
     loading: Boolean,
 ) {
@@ -55,18 +55,7 @@ fun PrivateMessageReplyHeader(
                 }
             }
         },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.private_message_reply_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyActivity.kt
@@ -14,19 +14,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.api.ApiState
+import com.jerboa.datatypes.types.PrivateMessageView
 import com.jerboa.db.AccountViewModel
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.home.SiteViewModel
 
 @Composable
 fun PrivateMessageReplyActivity(
-    privateMessageReplyViewModel: PrivateMessageReplyViewModel,
+    privateMessageView: PrivateMessageView,
     accountViewModel: AccountViewModel,
     siteViewModel: SiteViewModel,
-    navController: NavController,
+    navController: PrivateMessageReplyNavController,
 ) {
     Log.d("jerboa", "got to private message reply activity")
 
@@ -35,6 +37,11 @@ fun PrivateMessageReplyActivity(
     var reply by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
 
     val focusManager = LocalFocusManager.current
+
+    val privateMessageReplyViewModel: PrivateMessageReplyViewModel = viewModel()
+    InitializeRoute {
+        privateMessageReplyViewModel.initialize(privateMessageView)
+    }
 
     val loading = when (privateMessageReplyViewModel.createMessageRes) {
         ApiState.Loading -> true
@@ -52,9 +59,10 @@ fun PrivateMessageReplyActivity(
                             privateMessageReplyViewModel.createPrivateMessage(
                                 content = reply.text,
                                 account = acct,
-                                navController,
-                                focusManager,
-                            )
+                            ) {
+                                focusManager.clearFocus()
+                                navController.navigateUp()
+                            }
                         }
                     },
                 )
@@ -70,7 +78,7 @@ fun PrivateMessageReplyActivity(
                             reply = reply,
                             onReplyChange = { reply = it },
                             onPersonClick = { personId ->
-                                navController.navigate(route = "profile/$personId")
+                                navController.toProfile.navigate(personId)
                             },
                             modifier = Modifier
                                 .padding(padding)

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyNavController.kt
@@ -1,0 +1,19 @@
+package com.jerboa.ui.components.privatemessage
+
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavController
+import com.jerboa.datatypes.types.PrivateMessageView
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgs
+import com.jerboa.ui.components.person.ToProfile
+
+class PrivateMessageReplyDependencies(
+    val privateMessageView: PrivateMessageView,
+) : ViewModel()
+
+typealias ToPrivateMessageReply = NavigateWithNoArgs<PrivateMessageReplyDependencies>
+
+class PrivateMessageReplyNavController(
+    override val navController: NavController,
+    val toProfile: ToProfile,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyViewModel.kt
@@ -3,10 +3,8 @@ package com.jerboa.ui.components.privatemessage
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.focus.FocusManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
@@ -32,8 +30,7 @@ class PrivateMessageReplyViewModel : ViewModel() {
     fun createPrivateMessage(
         content: String,
         account: Account,
-        navController: NavController,
-        focusManager: FocusManager,
+        onFinish: () -> Unit,
     ) {
         viewModelScope.launch {
             val form = CreatePrivateMessage(
@@ -45,8 +42,7 @@ class PrivateMessageReplyViewModel : ViewModel() {
             createMessageRes = ApiState.Loading
             createMessageRes = apiWrapper(API.getInstance().createPrivateMessage(form))
 
-            focusManager.clearFocus()
-            navController.navigateUp()
+            onFinish()
         }
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/report/CreateReport.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/CreateReport.kt
@@ -14,16 +14,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import com.jerboa.R
 import com.jerboa.db.Account
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.ui.components.common.DefaultBackButton
 import com.jerboa.ui.components.common.MarkdownTextField
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateReportHeader(
-    navController: NavController = rememberNavController(),
+    navController: NavControllerWrapper,
     onCreateClick: () -> Unit,
     loading: Boolean,
 ) {
@@ -50,18 +50,7 @@ fun CreateReportHeader(
                 }
             }
         },
-        navigationIcon = {
-            IconButton(
-                onClick = {
-                    navController.popBackStack()
-                },
-            ) {
-                Icon(
-                    Icons.Outlined.Close,
-                    contentDescription = stringResource(R.string.create_report_back),
-                )
-            }
-        },
+        navigationIcon = { DefaultBackButton(navController) },
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/report/CreateReportNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/CreateReportNavController.kt
@@ -1,0 +1,16 @@
+package com.jerboa.ui.components.report
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+
+class ToPostReport(
+    val navigate: (postId: Int) -> Unit,
+)
+
+class ToCommentReport(
+    val navigate: (commentId: Int) -> Unit,
+)
+
+class CreateReportNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/report/CreateReportViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/CreateReportViewModel.kt
@@ -5,10 +5,8 @@ import android.widget.Toast
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.focus.FocusManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
 import com.jerboa.R
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
@@ -48,8 +46,7 @@ class CreateReportViewModel : ViewModel() {
         reason: String,
         account: Account,
         ctx: Context,
-        navController: NavController,
-        focusManager: FocusManager,
+        onFinish: () -> Unit,
     ) {
         commentId?.also { cId ->
             viewModelScope.launch {
@@ -74,8 +71,7 @@ class CreateReportViewModel : ViewModel() {
                 }
 
                 Toast.makeText(ctx, message, Toast.LENGTH_SHORT).show()
-                focusManager.clearFocus()
-                navController.navigateUp()
+                onFinish()
             }
         }
     }
@@ -84,8 +80,7 @@ class CreateReportViewModel : ViewModel() {
         reason: String,
         account: Account,
         ctx: Context,
-        navController: NavController,
-        focusManager: FocusManager,
+        onFinish: () -> Unit,
     ) {
         postId?.also { pId ->
             viewModelScope.launch {
@@ -110,8 +105,7 @@ class CreateReportViewModel : ViewModel() {
                 }
 
                 Toast.makeText(ctx, message, Toast.LENGTH_SHORT).show()
-                focusManager.clearFocus()
-                navController.navigateUp()
+                onFinish()
             }
         }
     }

--- a/app/src/main/java/com/jerboa/ui/components/report/comment/CreateCommentReportActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/comment/CreateCommentReportActivity.kt
@@ -11,25 +11,33 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.api.ApiState
 import com.jerboa.db.AccountViewModel
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.report.CreateReportBody
 import com.jerboa.ui.components.report.CreateReportHeader
+import com.jerboa.ui.components.report.CreateReportNavController
 import com.jerboa.ui.components.report.CreateReportViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreateCommentReportActivity(
+    commentId: Int,
     accountViewModel: AccountViewModel,
-    navController: NavController,
-    createReportViewModel: CreateReportViewModel,
+    navController: CreateReportNavController,
 ) {
     Log.d("jerboa", "got to create comment report activity")
 
     val ctx = LocalContext.current
     val account = getCurrentAccount(accountViewModel = accountViewModel)
+
+    val createReportViewModel: CreateReportViewModel = viewModel()
+    InitializeRoute {
+        createReportViewModel.setCommentId(commentId)
+    }
+
     var reason by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
     val loading = when (createReportViewModel.commentReportRes) {
         ApiState.Loading -> true
@@ -47,10 +55,11 @@ fun CreateCommentReportActivity(
                         createReportViewModel.createCommentReport(
                             reason = reason.text,
                             ctx = ctx,
-                            navController = navController,
-                            focusManager = focusManager,
                             account = acct,
-                        )
+                        ) {
+                            focusManager.clearFocus()
+                            navController.navigateUp()
+                        }
                     }
                 },
             )

--- a/app/src/main/java/com/jerboa/ui/components/report/post/CreatePostReportActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/post/CreatePostReportActivity.kt
@@ -12,25 +12,33 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.navigation.NavController
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.api.ApiState
 import com.jerboa.db.AccountViewModel
+import com.jerboa.ui.components.common.InitializeRoute
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.report.CreateReportBody
 import com.jerboa.ui.components.report.CreateReportHeader
+import com.jerboa.ui.components.report.CreateReportNavController
 import com.jerboa.ui.components.report.CreateReportViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreatePostReportActivity(
+    postId: Int,
     accountViewModel: AccountViewModel,
-    navController: NavController,
-    createReportViewModel: CreateReportViewModel,
+    navController: CreateReportNavController,
 ) {
     Log.d("jerboa", "got to create post report activity")
 
     val ctx = LocalContext.current
     val account = getCurrentAccount(accountViewModel = accountViewModel)
+
+    val createReportViewModel: CreateReportViewModel = viewModel()
+    InitializeRoute {
+        createReportViewModel.setPostId(postId)
+    }
+
     var reason by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue("")) }
 
     val focusManager = LocalFocusManager.current
@@ -49,10 +57,11 @@ fun CreatePostReportActivity(
                         createReportViewModel.createPostReport(
                             reason = reason.text,
                             ctx = ctx,
-                            navController = navController,
-                            focusManager = focusManager,
                             account = acct,
-                        )
+                        ) {
+                            focusManager.clearFocus()
+                            navController.navigateUp()
+                        }
                     }
                 },
             )

--- a/app/src/main/java/com/jerboa/ui/components/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/SettingsActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
 import com.alorma.compose.settings.ui.SettingsMenuLink
 import com.jerboa.R
 import com.jerboa.db.AccountViewModel
@@ -26,7 +25,7 @@ import com.jerboa.ui.components.common.getCurrentAccount
 
 @Composable
 fun SettingsActivity(
-    navController: NavController,
+    navController: SettingsNavController,
     accountViewModel: AccountViewModel,
 ) {
     Log.d("jerboa", "Got to settings activity")
@@ -49,7 +48,7 @@ fun SettingsActivity(
                             contentDescription = null,
                         )
                     },
-                    onClick = { navController.navigate("lookAndFeel") },
+                    onClick = { navController.toLookAndFeel.navigate() },
                 )
                 account?.also { acct ->
                     SettingsMenuLink(
@@ -67,7 +66,7 @@ fun SettingsActivity(
                                 contentDescription = null,
                             )
                         },
-                        onClick = { navController.navigate("accountSettings") },
+                        onClick = { navController.toAccountSettings.navigate() },
                     )
                 }
                 SettingsMenuLink(
@@ -78,7 +77,7 @@ fun SettingsActivity(
                             contentDescription = null,
                         )
                     },
-                    onClick = { navController.navigate("about") },
+                    onClick = { navController.toAbout.navigate() },
                 )
             }
         },

--- a/app/src/main/java/com/jerboa/ui/components/settings/SettingsNavController.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/SettingsNavController.kt
@@ -1,0 +1,25 @@
+package com.jerboa.ui.components.settings
+
+import androidx.navigation.NavController
+import com.jerboa.nav.NavControllerWrapper
+import com.jerboa.nav.NavigateWithNoArgsAndDependencies
+
+typealias ToSettings = NavigateWithNoArgsAndDependencies
+typealias ToAccountSettings = NavigateWithNoArgsAndDependencies
+typealias ToLookAndFeel = NavigateWithNoArgsAndDependencies
+typealias ToAbout = NavigateWithNoArgsAndDependencies
+
+class SettingsNavController(
+    override val navController: NavController,
+    val toLookAndFeel: ToLookAndFeel,
+    val toAccountSettings: ToAccountSettings,
+    val toAbout: ToAbout,
+) : NavControllerWrapper()
+
+class LookAndFeelNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()
+
+class AccountSettingsNavController(
+    override val navController: NavController,
+) : NavControllerWrapper()

--- a/app/src/main/java/com/jerboa/ui/components/settings/about/AboutActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/about/AboutActivity.kt
@@ -30,6 +30,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.alorma.compose.settings.ui.SettingsMenuLink
 import com.jerboa.R
+import com.jerboa.nav.NavControllerWrapper
 import com.jerboa.openLink
 import com.jerboa.ui.components.common.SimpleTopAppBar
 
@@ -62,7 +63,12 @@ fun AboutActivity(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            SimpleTopAppBar(text = stringResource(R.string.settings_about_about), navController = navController)
+            SimpleTopAppBar(
+                text = stringResource(R.string.settings_about_about),
+                navController = object : NavControllerWrapper() {
+                    override val navController = navController
+                },
+            )
         },
         content = { padding ->
             Column(

--- a/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettingsActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/account/AccountSettingsActivity.kt
@@ -9,17 +9,17 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
 import com.jerboa.R
 import com.jerboa.db.AccountViewModel
 import com.jerboa.ui.components.common.SimpleTopAppBar
 import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.home.SiteViewModel
+import com.jerboa.ui.components.settings.AccountSettingsNavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountSettingsActivity(
-    navController: NavController,
+    navController: AccountSettingsNavController,
     accountSettingsViewModel: AccountSettingsViewModel,
     accountViewModel: AccountViewModel,
     siteViewModel: SiteViewModel,

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
 import com.alorma.compose.settings.storage.base.rememberFloatSettingState
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
@@ -33,11 +32,12 @@ import com.jerboa.db.AppSettings
 import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.db.DEFAULT_FONT_SIZE
 import com.jerboa.ui.components.common.SimpleTopAppBar
+import com.jerboa.ui.components.settings.LookAndFeelNavController
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LookAndFeelActivity(
-    navController: NavController,
+    navController: LookAndFeelNavController,
     appSettingsViewModel: AppSettingsViewModel,
 ) {
     Log.d("jerboa", "Got to lookAndFeel activity")


### PR DESCRIPTION
Continuing work done in #670

# Scoped view models
- All the view models that were declared in the activity are now scoped to the routes in which they are used. View models used by most of the routes (like SiteViewModel, AccountViewModel & AccountSettingsViewModel) are left untouched.
- This prevents sharing view models that lead to stale data & reloading the data when navigating back.
- Making the LaunchedEffect run only once per route. This helps ensure that the content isn't reset with new data when moving back from one route to another. Things like scroll position & filters are also retained.

Closes #704
Closes #402 
Closes #774

# Declarative navigation
- Moved all navigate calls to the MainActivity making it easy to see all the possible navigations (the full graph).
- Dependencies of a route are made explicit and compile safe.
- It's now possible to pass callbacks from one route to another. This is what made scoping view models a possibility in the first place. Here's a snippet from the code where replying to a post/comment should append the comment on success:
  ```kotlin
  navController.toCommentReply.navigate(
      CommentReplyDependencies(
          ReplyItem.PostItem(pv),
          isModerator = isModerator(
              pv.creator,
              postRes.data.moderators,
          ),
          onCommentReply = postViewModel::appendComment,
      ),
  )
  ```
- Any nav controllers that were passed to the view model have been brought out during this refactor to make it easier to test view models.

# Bottom navigation bar
- The bottom app bar is now only present in the home activity which uses a second nav host for the bottom navigation.
- Clicking on Inbox, Saved, Profile tabs & create post button now opens the login activity if user is not logged in.
- The inbox deeplink has been taken care of by redirecting to the home activity with the inbox tab as default. The default is reset to feed if the user is not logged in.

Closes #714
Closes #722 (Closes #719 similar)
Partially addresses #346 

# Screen transitions
- Added [Accompanist navigation animation](https://google.github.io/accompanist/navigation-animation/) as dependency.
- All the main navigations have a slide in and out transition by default.
- Removed the jerky fade in & out transition which was being cased by background set as transparent.

Closes #300 

# Other changes
- The back button auto hides/shows based on the nav stack state. So opening screens using deep links or the nested screens in the `HomeActivity` don't have a back button.
- Community & profiles open as separate screen instead of within the "search" tab.
- Fixed horizontal tab swipe in the profile activity which caused by the view not being big enough.

Closes #789 

I've tried not to modify any logic other than navigation. Let me know if anything is not working as expected.