### PR TITLE
Changed icons for "Go to comment" and "Copy permalink" in CommmentOptionsDialog

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -22,11 +22,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.outlined.Block
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Flag
+import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Person
@@ -676,7 +676,7 @@ fun CommentOptionsDialog(
             Column {
                 IconAndTextDrawerItem(
                     text = stringResource(R.string.comment_node_goto_comment),
-                    icon = Icons.Outlined.Link,
+                    icon = Icons.Outlined.Forum,
                     onClick = onCommentLinkClick,
                 )
                 IconAndTextDrawerItem(
@@ -694,7 +694,7 @@ fun CommentOptionsDialog(
                 )
                 IconAndTextDrawerItem(
                     text = stringResource(R.string.comment_node_copy_permalink),
-                    icon = Icons.Outlined.ContentCopy,
+                    icon = Icons.Outlined.Link,
                     onClick = {
                         val permalink = commentView.comment.ap_id
                         localClipboardManager.setText(AnnotatedString(permalink))


### PR DESCRIPTION
Changed icons for "Go to comment" and "Copy permalink" in CommmentOptionsDialog to "Icons.Outlined.Forum" and "Icons.Outlined.Link"

Closes #779 