### PR TITLE
Fix thumbnail links being treated as images. Fixes #815

### DIFF
--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -131,7 +131,7 @@ class MainActivity : ComponentActivity() {
             ) {
                 val navController = rememberNavController()
                 val ctx = LocalContext.current
-                var serverVersionOutdatedViewed = remember { mutableStateOf(false) }
+                val serverVersionOutdatedViewed = remember { mutableStateOf(false) }
 
                 MarkdownHelper.init(
                     navController,
@@ -183,6 +183,8 @@ class MainActivity : ComponentActivity() {
                             postEditViewModel = postEditViewModel,
                             appSettingsViewModel = appSettingsViewModel,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                         )
                     }
                     composable(
@@ -223,6 +225,8 @@ class MainActivity : ComponentActivity() {
                             appSettingsViewModel = appSettingsViewModel,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
                             siteViewModel = siteViewModel,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                         )
                     }
                     // Only necessary for community deeplinks
@@ -272,6 +276,8 @@ class MainActivity : ComponentActivity() {
                             appSettingsViewModel = appSettingsViewModel,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
                             siteViewModel = siteViewModel,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                         )
                     }
                     composable(
@@ -312,6 +318,8 @@ class MainActivity : ComponentActivity() {
                             appSettingsViewModel = appSettingsViewModel,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
                             siteViewModel = siteViewModel,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                         )
                     }
                     // Necessary for deep links
@@ -354,6 +362,8 @@ class MainActivity : ComponentActivity() {
                             appSettingsViewModel = appSettingsViewModel,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
                             siteViewModel = siteViewModel,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                         )
                     }
                     composable(
@@ -476,6 +486,8 @@ class MainActivity : ComponentActivity() {
                             commentReplyViewModel = commentReplyViewModel,
                             postEditViewModel = postEditViewModel,
                             navController = navController,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                             showCollapsedCommentContent = appSettings?.showCollapsedCommentContent ?: false,
                             showActionBarByDefault = appSettings?.showCommentActionBarByDefault ?: true,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
@@ -512,6 +524,8 @@ class MainActivity : ComponentActivity() {
                             commentReplyViewModel = commentReplyViewModel,
                             postEditViewModel = postEditViewModel,
                             navController = navController,
+                            useCustomTabs = appSettings?.useCustomTabs ?: true,
+                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                             showCollapsedCommentContent = appSettings?.showCollapsedCommentContent ?: false,
                             showActionBarByDefault = appSettings?.showCommentActionBarByDefault ?: true,
                             showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -66,6 +66,8 @@ fun CommunityActivity(
     accountViewModel: AccountViewModel,
     appSettingsViewModel: AppSettingsViewModel,
     showVotingArrowsInListView: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     Log.d("jerboa", "got to community activity")
 
@@ -317,6 +319,8 @@ fun CommunityActivity(
                             enableDownVotes = siteViewModel.enableDownvotes(),
                             showAvatar = siteViewModel.showAvatar(),
                             showVotingArrowsInListView = showVotingArrowsInListView,
+                            useCustomTabs = useCustomTabs,
+                            usePrivateTabs = usePrivateTabs,
                         )
                     }
                     else -> {}

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -78,6 +78,8 @@ fun HomeActivity(
     postEditViewModel: PostEditViewModel,
     appSettingsViewModel: AppSettingsViewModel,
     showVotingArrowsInListView: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     Log.d("jerboa", "got to home activity")
 
@@ -135,6 +137,8 @@ fun HomeActivity(
                         navController = navController,
                         postListState = postListState,
                         showVotingArrowsInListView = showVotingArrowsInListView,
+                        useCustomTabs = useCustomTabs,
+                        usePrivateTabs = usePrivateTabs,
                     )
                 },
                 floatingActionButtonPosition = FabPosition.End,
@@ -202,6 +206,8 @@ fun MainPostListingsContent(
     postListState: LazyListState,
     appSettingsViewModel: AppSettingsViewModel,
     showVotingArrowsInListView: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     when (val siteRes = siteViewModel.siteRes) {
         ApiState.Loading ->
@@ -358,6 +364,8 @@ fun MainPostListingsContent(
                     enableDownVotes = siteViewModel.enableDownvotes(),
                     showAvatar = siteViewModel.showAvatar(),
                     showVotingArrowsInListView = showVotingArrowsInListView,
+                    useCustomTabs = useCustomTabs,
+                    usePrivateTabs = usePrivateTabs,
                 )
             }
 

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -76,6 +76,8 @@ fun PersonProfileActivity(
     postEditViewModel: PostEditViewModel,
     appSettingsViewModel: AppSettingsViewModel,
     showVotingArrowsInListView: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     Log.d("jerboa", "got to person activity")
 
@@ -172,6 +174,8 @@ fun PersonProfileActivity(
                 showVotingArrowsInListView = showVotingArrowsInListView,
                 enableDownVotes = siteViewModel.enableDownvotes(),
                 showAvatar = siteViewModel.showAvatar(),
+                useCustomTabs = useCustomTabs,
+                usePrivateTabs = usePrivateTabs,
             )
         },
         bottomBar = {
@@ -228,6 +232,8 @@ fun UserTabs(
     showVotingArrowsInListView: Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     val tabTitles = if (savedMode) {
         listOf(
@@ -471,6 +477,8 @@ fun UserTabs(
                                     enableDownVotes = enableDownVotes,
                                     showAvatar = showAvatar,
                                     showVotingArrowsInListView = showVotingArrowsInListView,
+                                    useCustomTabs = useCustomTabs,
+                                    usePrivateTabs = usePrivateTabs,
                                 )
                             }
                         }
@@ -498,7 +506,7 @@ fun UserTabs(
                             val unExpandedComments = remember { mutableStateListOf<Int>() }
                             val commentsWithToggledActionBar = remember { mutableStateListOf<Int>() }
 
-                            var toggleExpanded = { commentId: Int ->
+                            val toggleExpanded = { commentId: Int ->
                                 if (unExpandedComments.contains(commentId)) {
                                     unExpandedComments.remove(commentId)
                                 } else {
@@ -506,7 +514,7 @@ fun UserTabs(
                                 }
                             }
 
-                            var toggleActionBar = { commentId: Int ->
+                            val toggleActionBar = { commentId: Int ->
                                 if (commentsWithToggledActionBar.contains(commentId)) {
                                     commentsWithToggledActionBar.remove(commentId)
                                 } else {

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -84,7 +84,6 @@ import com.jerboa.ui.components.common.simpleVerticalScrollbar
 import com.jerboa.ui.components.home.SiteViewModel
 import com.jerboa.ui.components.post.edit.PostEditViewModel
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun CommentsHeaderTitle(
     selectedSortType: CommentSortType,
@@ -117,6 +116,8 @@ fun PostActivity(
     commentReplyViewModel: CommentReplyViewModel,
     postEditViewModel: PostEditViewModel,
     navController: NavController,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
     showCollapsedCommentContent: Boolean,
     showActionBarByDefault: Boolean,
     showVotingArrowsInListView: Boolean,
@@ -367,6 +368,8 @@ fun PostActivity(
                                     enableDownVotes = siteViewModel.enableDownvotes(),
                                     showAvatar = siteViewModel.showAvatar(),
                                     showVotingArrowsInListView = showVotingArrowsInListView,
+                                    useCustomTabs = useCustomTabs,
+                                    usePrivateTabs = usePrivateTabs,
                                 )
                             }
 
@@ -394,7 +397,7 @@ fun PostActivity(
                                     val commentParentId = getCommentParentId(firstComment)
                                     val showContextButton = depth != null && depth > 0
 
-                                    var toggleExpanded = { commentId: Int ->
+                                    val toggleExpanded = { commentId: Int ->
                                         if (unExpandedComments.contains(commentId)) {
                                             unExpandedComments.remove(commentId)
                                         } else {
@@ -402,7 +405,7 @@ fun PostActivity(
                                         }
                                     }
 
-                                    var toggleActionBar = { commentId: Int ->
+                                    val toggleActionBar = { commentId: Int ->
                                         if (commentsWithToggledActionBar.contains(commentId)) {
                                             commentsWithToggledActionBar.remove(commentId)
                                         } else {

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -77,6 +77,7 @@ import com.jerboa.hostName
 import com.jerboa.isImage
 import com.jerboa.isSameInstance
 import com.jerboa.nsfwCheck
+import com.jerboa.openLink
 import com.jerboa.ui.components.common.ActionBarButton
 import com.jerboa.ui.components.common.CircularIcon
 import com.jerboa.ui.components.common.CommentOrPostNodeHeader
@@ -258,6 +259,8 @@ fun PostTitleBlock(
     postView: PostView,
     expandedImage: Boolean,
     account: Account?,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     val imagePost = postView.post.url?.let { isImage(it) } ?: run { false }
 
@@ -269,6 +272,9 @@ fun PostTitleBlock(
         PostTitleAndThumbnail(
             postView = postView,
             account = account,
+            useCustomTabs = useCustomTabs,
+            usePrivateTabs = usePrivateTabs,
+
         )
     }
 }
@@ -336,6 +342,8 @@ fun PostTitleAndImageLink(
 fun PostTitleAndThumbnail(
     postView: PostView,
     account: Account?,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     Column(
         modifier = Modifier.padding(horizontal = MEDIUM_PADDING),
@@ -362,7 +370,11 @@ fun PostTitleAndThumbnail(
                     }
                 }
             }
-            ThumbnailTile(postView = postView)
+            ThumbnailTile(
+                postView = postView,
+                useCustomTabs = useCustomTabs,
+                usePrivateTabs = usePrivateTabs,
+            )
         }
     }
 }
@@ -373,6 +385,8 @@ fun PostBody(
     fullBody: Boolean,
     expandedImage: Boolean,
     account: Account?,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     val post = postView.post
     Column(
@@ -382,6 +396,8 @@ fun PostBody(
             postView = postView,
             expandedImage = expandedImage,
             account = account,
+            useCustomTabs = useCustomTabs,
+            usePrivateTabs = usePrivateTabs,
         )
 
         // The metadata card
@@ -432,6 +448,8 @@ fun PreviewStoryTitleAndMetadata() {
         fullBody = false,
         expandedImage = false,
         account = null,
+        useCustomTabs = false,
+        usePrivateTabs = false,
     )
 }
 
@@ -654,6 +672,8 @@ fun PostFooterLinePreview() {
 fun PreviewPostListingCard() {
     PostListing(
         postView = samplePostView,
+        useCustomTabs = false,
+        usePrivateTabs = false,
         onUpvoteClick = {},
         onDownvoteClick = {},
         onReplyClick = {},
@@ -681,6 +701,8 @@ fun PreviewPostListingCard() {
 fun PreviewLinkPostListing() {
     PostListing(
         postView = sampleLinkPostView,
+        useCustomTabs = false,
+        usePrivateTabs = false,
         onUpvoteClick = {},
         onDownvoteClick = {},
         onReplyClick = {},
@@ -708,6 +730,8 @@ fun PreviewLinkPostListing() {
 fun PreviewImagePostListingCard() {
     PostListing(
         postView = sampleImagePostView,
+        useCustomTabs = false,
+        usePrivateTabs = false,
         onUpvoteClick = {},
         onDownvoteClick = {},
         onReplyClick = {},
@@ -735,6 +759,8 @@ fun PreviewImagePostListingCard() {
 fun PreviewImagePostListingSmallCard() {
     PostListing(
         postView = sampleImagePostView,
+        useCustomTabs = false,
+        usePrivateTabs = false,
         onUpvoteClick = {},
         onDownvoteClick = {},
         onReplyClick = {},
@@ -762,6 +788,8 @@ fun PreviewImagePostListingSmallCard() {
 fun PreviewLinkNoThumbnailPostListing() {
     PostListing(
         postView = sampleLinkNoThumbnailPostView,
+        useCustomTabs = false,
+        usePrivateTabs = false,
         onUpvoteClick = {},
         onDownvoteClick = {},
         onReplyClick = {},
@@ -787,6 +815,8 @@ fun PreviewLinkNoThumbnailPostListing() {
 @Composable
 fun PostListing(
     postView: PostView,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
     onUpvoteClick: (postView: PostView) -> Unit,
     onDownvoteClick: (postView: PostView) -> Unit,
     onReplyClick: (postView: PostView) -> Unit = {},
@@ -857,7 +887,10 @@ fun PostListing(
             expandedImage = true,
             enableDownVotes = enableDownVotes,
             showAvatar = showAvatar,
+            useCustomTabs = useCustomTabs,
+            usePrivateTabs = usePrivateTabs,
         )
+
         PostViewMode.SmallCard -> PostListingCard(
             postView = postView,
             instantScores = instantScores.value,
@@ -893,7 +926,10 @@ fun PostListing(
             expandedImage = false,
             enableDownVotes = enableDownVotes,
             showAvatar = showAvatar,
+            useCustomTabs = useCustomTabs,
+            usePrivateTabs = usePrivateTabs,
         )
+
         PostViewMode.List -> PostListingList(
             postView = postView,
             instantScores = instantScores.value,
@@ -919,6 +955,8 @@ fun PostListing(
             account = account,
             showVotingArrowsInListView = showVotingArrowsInListView,
             showAvatar = showAvatar,
+            useCustomTabs = useCustomTabs,
+            usePrivateTabs = usePrivateTabs,
         )
     }
 }
@@ -983,6 +1021,8 @@ fun PostListingList(
     account: Account?,
     showVotingArrowsInListView: Boolean,
     showAvatar: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     Column(
         modifier = Modifier
@@ -1079,7 +1119,11 @@ fun PostListingList(
                     NsfwBadge(nsfwCheck(postView))
                 }
             }
-            ThumbnailTile(postView)
+            ThumbnailTile(
+                postView = postView,
+                useCustomTabs = useCustomTabs,
+                usePrivateTabs = usePrivateTabs,
+            )
         }
     }
 }
@@ -1087,6 +1131,8 @@ fun PostListingList(
 @Composable
 private fun ThumbnailTile(
     postView: PostView,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     postView.post.url?.also { url ->
         var showImageDialog by remember { mutableStateOf(false) }
@@ -1095,9 +1141,23 @@ private fun ThumbnailTile(
             ImageViewerDialog(url, onBackRequest = { showImageDialog = false })
         }
 
+        // TODO weird performance issues with using a previously rendered navcontroller
+        val navController = rememberNavController()
+
         val postLinkPicMod = Modifier
             .size(POST_LINK_PIC_SIZE)
-            .clickable { showImageDialog = true }
+            .clickable {
+                if (isImage(url)) {
+                    showImageDialog = true
+                } else {
+                    openLink(
+                        url = url,
+                        navController = navController,
+                        useCustomTab = useCustomTabs,
+                        usePrivateTab = usePrivateTabs,
+                    )
+                }
+            }
 
         postView.post.thumbnail_url?.also { thumbnail ->
             PictrsThumbnailImage(
@@ -1149,6 +1209,8 @@ fun PostListingListPreview() {
         account = null,
         showVotingArrowsInListView = true,
         showAvatar = true,
+        useCustomTabs = false,
+        usePrivateTabs = false,
     )
 }
 
@@ -1175,6 +1237,8 @@ fun PostListingListWithThumbPreview() {
         account = null,
         showVotingArrowsInListView = true,
         showAvatar = true,
+        useCustomTabs = false,
+        usePrivateTabs = false,
     )
 }
 
@@ -1202,6 +1266,8 @@ fun PostListingCard(
     expandedImage: Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     Column(
         modifier = Modifier
@@ -1229,6 +1295,8 @@ fun PostListingCard(
             fullBody = fullBody,
             expandedImage = expandedImage,
             account = account,
+            useCustomTabs = useCustomTabs,
+            usePrivateTabs = usePrivateTabs,
         )
 
         // Footer bar

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -51,6 +51,8 @@ fun PostListings(
     showVotingArrowsInListView: Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
 ) {
     LazyColumn(
         state = listState,
@@ -91,6 +93,8 @@ fun PostListings(
                 showVotingArrowsInListView = showVotingArrowsInListView,
                 enableDownVotes = enableDownVotes,
                 showAvatar = showAvatar,
+                useCustomTabs = useCustomTabs,
+                usePrivateTabs = usePrivateTabs,
             )
             Divider(modifier = Modifier.padding(bottom = SMALL_PADDING))
         }
@@ -134,5 +138,7 @@ fun PreviewPostListings() {
         showVotingArrowsInListView = true,
         enableDownVotes = true,
         showAvatar = true,
+        useCustomTabs = false,
+        usePrivateTabs = false,
     )
 }


### PR DESCRIPTION
Somewhere along the line, clicking on thumbnail links got removed, and every thumbnail was treated as an image, even if it was a link post.

This fixes that by altering the thumbnail tile to check to see if the url is an image.