### PR TITLE
Make Search Page have consistent back button

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityList.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityList.kt
@@ -62,7 +62,7 @@ fun CommunityListHeader(
                 },
             ) {
                 Icon(
-                    Icons.Outlined.Close,
+                    Icons.Outlined.ArrowBack,
                     contentDescription = stringResource(R.string.community_list_back),
                 )
             }


### PR DESCRIPTION
All other tabs use the back arrow while the search page (`CommunityListActivity`) uses the 'X'.

This PR fixes that so the back buttons are consistent.
