### PR TITLE
Added ability to switch languages

### DIFF
--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.jerboa
 
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -82,6 +83,7 @@ import com.jerboa.ui.components.settings.account.AccountSettingsViewModel
 import com.jerboa.ui.components.settings.account.AccountSettingsViewModelFactory
 import com.jerboa.ui.components.settings.lookandfeel.LookAndFeelActivity
 import com.jerboa.ui.theme.JerboaTheme
+import com.jerboa.util.JerboaPreferences
 
 class JerboaApplication : Application() {
     private val database by lazy { AppDB.getDatabase(this) }
@@ -114,6 +116,8 @@ class MainActivity : ComponentActivity() {
     private val appSettingsViewModel: AppSettingsViewModel by viewModels {
         AppSettingsViewModelFactory((application as JerboaApplication).appSettingsRepository)
     }
+
+    lateinit var jerboaPreferences: JerboaPreferences
 
     @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -660,6 +664,7 @@ class MainActivity : ComponentActivity() {
                         LookAndFeelActivity(
                             navController = navController,
                             appSettingsViewModel = appSettingsViewModel,
+                            context = baseContext,
                         )
                     }
                     composable(
@@ -688,5 +693,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+    override fun attachBaseContext(newBase: Context) {
+        jerboaPreferences = JerboaPreferences(newBase)
+        val lang = jerboaPreferences.getLanguageLocal()
+        super.attachBaseContext(createContextWithLanguage(newBase, lang))
     }
 }

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -7,6 +7,7 @@ import android.content.ContentValues
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.media.MediaScannerConnection
@@ -71,6 +72,7 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.text.DecimalFormat
 import java.util.*
+import kotlin.collections.HashMap
 import kotlin.math.abs
 import kotlin.math.pow
 
@@ -78,6 +80,24 @@ val gson = Gson()
 
 const val DEBOUNCE_DELAY = 1000L
 const val MAX_POST_TITLE_LENGTH = 200
+
+fun getAvailableLanguages(context: Context): HashMap<String, String> {
+    return hashMapOf(
+        context.getString(R.string.english_language) to "en",
+        context.getString(R.string.danish_language) to "da",
+        context.getString(R.string.german_language) to "de",
+        context.getString(R.string.spanish_language) to "es",
+        context.getString(R.string.french_language) to "fr",
+        context.getString(R.string.italian_language) to "it",
+        context.getString(R.string.japanese_language) to "ja",
+        context.getString(R.string.korean_language) to "ko",
+        context.getString(R.string.dutch_language) to "nl",
+        context.getString(R.string.polish_language) to "pl",
+        context.getString(R.string.portuguese_language) to "pt",
+        context.getString(R.string.russian_language) to "ru",
+        context.getString(R.string.northern_sami_language) to "se",
+    )
+}
 
 val DEFAULT_LEMMY_INSTANCES = listOf(
     "beehaw.org",
@@ -1288,4 +1308,32 @@ fun copyToClipboard(context: Context, textToCopy: CharSequence, clipLabel: CharS
         return true
     }
     return false
+}
+
+/**
+ * Creates a configuration context with the language passed as parameter
+ * @param context The application context
+ * @param language The language code (Ex: "en" for English)
+ *
+ * @return A new ConfigurationContext with the given language
+ */
+fun createContextWithLanguage(context: Context, language: String): Context {
+    fun getSystemLocale(config: Configuration): Locale {
+        return config.locales.get(0)
+    }
+
+    fun setSystemLocale(config: Configuration, locale: Locale) {
+        config.setLocale(locale)
+    }
+
+    val config = context.resources.configuration
+    val sysLocale: Locale = getSystemLocale(config)
+
+    if (language.isNotBlank() && sysLocale.language != language) {
+        val locale = Locale(language)
+        Locale.setDefault(locale)
+        setSystemLocale(config, locale)
+    }
+
+    return context.createConfigurationContext(config)
 }

--- a/app/src/main/java/com/jerboa/util/JerboaPreferences.kt
+++ b/app/src/main/java/com/jerboa/util/JerboaPreferences.kt
@@ -1,0 +1,30 @@
+package com.jerboa.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.jerboa.getAvailableLanguages
+
+class JerboaPreferences(context: Context) {
+    private val PREFERENCE_NAME = "JerboaPreferences"
+
+    // If the device's language is available, use it
+    // use english otherwise
+    val DEFAULT_LANGUAGE =
+        if (getAvailableLanguages(context).contains(androidx.compose.ui.text.intl.Locale.current.language)) {
+            androidx.compose.ui.text.intl.Locale.current.language
+        } else {
+            "en"
+        }
+
+    private val preference: SharedPreferences = context.getSharedPreferences(PREFERENCE_NAME, Context.MODE_PRIVATE)
+
+    fun getLanguageLocal(): String {
+        return preference.getString("Language", DEFAULT_LANGUAGE) ?: DEFAULT_LANGUAGE
+    }
+
+    fun setLanguageLocal(local: String) {
+        val editor = preference.edit()
+        editor.putString("Language", local)
+        editor.apply()
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -317,4 +317,18 @@
     <string name="inbox_activity_messages">Mensajes</string>
     <string name="bookmarks_activity_saved">Guardado</string>
     <string name="generic_error">Ha ocurrido un error</string>
+    <string name="app_language">Idioma</string>
+    <string name="english_language">Inglés</string>
+    <string name="danish_language">Danés</string>
+    <string name="german_language">Alemán</string>
+    <string name="spanish_language">Español</string>
+    <string name="french_language">Francés</string>
+    <string name="italian_language">Italiano</string>
+    <string name="japanese_language">Japonés</string>
+    <string name="korean_language">Coreano</string>
+    <string name="dutch_language">Holandés</string>
+    <string name="polish_language">Polaco</string>
+    <string name="portuguese_language">Portugués</string>
+    <string name="russian_language">Ruso</string>
+    <string name="northern_sami_language">Sami del norte</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,4 +330,18 @@
     <string name="inbox_activity_messages">Messages</string>
     <string name="bookmarks_activity_saved">Saved</string>
     <string name="generic_error">An error has occurred</string>
+    <string name="app_language">Language</string>
+    <string name="english_language">English</string>
+    <string name="danish_language">Danish</string>
+    <string name="german_language">German</string>
+    <string name="spanish_language">Spanish</string>
+    <string name="french_language">French</string>
+    <string name="italian_language">Italian</string>
+    <string name="japanese_language">Japanese</string>
+    <string name="korean_language">Korean</string>
+    <string name="dutch_language">Dutch</string>
+    <string name="polish_language">Polish</string>
+    <string name="portuguese_language">Portuguese</string>
+    <string name="russian_language">Russian</string>
+    <string name="northern_sami_language">Northern Sami</string>
 </resources>


### PR DESCRIPTION
Now we can change languages inside of the app. 
I didn't add the selected language to the local database and instead used SharedPreferences because the language change occurs before the database is even ready (when you first open the app). If there's a workaround or a better way to do it let me know.