### PR TITLE
Fix .zoomable functionality in ImageViewerDialog and add "swipe up to close"

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/ImageViewerDialog.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/ImageViewerDialog.kt
@@ -11,6 +11,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -113,7 +116,17 @@ fun ImageViewerDialog(url: String, onBackRequest: () -> Unit) {
         ),
     ) {
         Box(
-            Modifier.background(backgroundColor.value),
+            Modifier
+                .background(backgroundColor.value)
+                .scrollable(
+                    orientation = Orientation.Vertical,
+                    state = rememberScrollableState(
+                        consumeScrollDelta = {
+                            if (it < -70) onBackRequest()
+                            it
+                        },
+                    ),
+                ),
         ) {
             Image(
                 painter = rememberAsyncImagePainter(url, imageLoader = imageLoader),
@@ -123,10 +136,7 @@ fun ImageViewerDialog(url: String, onBackRequest: () -> Unit) {
                     .zoomable(
                         zoomState = rememberZoomState(),
                         onTap = { showTopBar = !showTopBar },
-                    )
-                    .clickable {
-                        onBackRequest()
-                    },
+                    ),
             )
 
             Row(


### PR DESCRIPTION
This closes #892 

With my PR #738 I broke the intended functionality of `com.jerboa.ui.components.common.ImageViewerDialog.kt`.

**The originally intended functionality was:**
* tap dialog to hide / show top icon bar
* double tap to zoom in 
* double tap + drag to zoom in and out

**My mistake:**

I added a `.clickable` modifier to the image. This overwrote the indended functionality (...and added a white overlay according to @pipe01 which I honestly could not reproduce)

**My solution in this PR:**

I removed the `.clickable` modifier to restore the original functionality and also added the `.scrollable` modifier to the surrounding box. The box now listens to a scroll gesture and dismisses the dialog if it detects a scroll with a delta < -70. This translates to a "quickly swipe up" gesture.