### PR TITLE
Add blur option, fix non blurred community icons/banners

### DIFF
--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -118,7 +118,7 @@ class MainActivity : AppCompatActivity() {
                 fetchInitialData(accountSync, siteViewModel)
             }
 
-            val appSettings by appSettingsViewModel.appSettings.observeAsState()
+            val appSettings by appSettingsViewModel.appSettings.observeAsState() // TODO set default
 
             JerboaTheme(
                 appSettings = appSettings,
@@ -206,6 +206,7 @@ class MainActivity : AppCompatActivity() {
                                 siteViewModel = siteViewModel,
                                 useCustomTabs = appSettings?.useCustomTabs ?: true,
                                 usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                                blurNSFW =  appSettings?.blurNSFW ?: true,
                             )
                         }
 
@@ -237,6 +238,7 @@ class MainActivity : AppCompatActivity() {
                                 siteViewModel = siteViewModel,
                                 useCustomTabs = appSettings?.useCustomTabs ?: true,
                                 usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                                blurNSFW =  appSettings?.blurNSFW ?: true,
                             )
                         }
 
@@ -302,6 +304,7 @@ class MainActivity : AppCompatActivity() {
                             siteViewModel = siteViewModel,
                             useCustomTabs = appSettings?.useCustomTabs ?: true,
                             usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -332,6 +335,7 @@ class MainActivity : AppCompatActivity() {
                             siteViewModel = siteViewModel,
                             useCustomTabs = appSettings?.useCustomTabs ?: true,
                             usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -350,6 +354,7 @@ class MainActivity : AppCompatActivity() {
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
                             selectMode = args.select,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -401,6 +406,7 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -429,6 +435,7 @@ class MainActivity : AppCompatActivity() {
                                 siteViewModel = siteViewModel,
                                 useCustomTabs = appSettings?.useCustomTabs ?: true,
                                 usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                                blurNSFW =  appSettings?.blurNSFW ?: true,
                             )
                         }
                     }
@@ -457,6 +464,7 @@ class MainActivity : AppCompatActivity() {
                             showParentCommentNavigationButtons = appSettings?.showParentCommentNavigationButtons ?: true,
                             navigateParentCommentsWithVolumeButtons = appSettings?.navigateParentCommentsWithVolumeButtons ?: false,
                             siteViewModel = siteViewModel,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -31,6 +31,7 @@ import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.MINIMUM_API_VERSION
+import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.AccountRepository
 import com.jerboa.db.AccountViewModel
 import com.jerboa.db.AccountViewModelFactory
@@ -118,7 +119,7 @@ class MainActivity : AppCompatActivity() {
                 fetchInitialData(accountSync, siteViewModel)
             }
 
-            val appSettings by appSettingsViewModel.appSettings.observeAsState() // TODO set default
+            val appSettings by appSettingsViewModel.appSettings.observeAsState(APP_SETTINGS_DEFAULT)
 
             JerboaTheme(
                 appSettings = appSettings,
@@ -128,8 +129,8 @@ class MainActivity : AppCompatActivity() {
 
                 MarkdownHelper.init(
                     navController,
-                    appSettingsViewModel.appSettings.value?.useCustomTabs ?: true,
-                    appSettingsViewModel.appSettings.value?.usePrivateTabs ?: false,
+                    appSettings.useCustomTabs,
+                    appSettings.usePrivateTabs,
                 )
 
                 ShowChangelog(appSettingsViewModel = appSettingsViewModel)
@@ -202,11 +203,11 @@ class MainActivity : AppCompatActivity() {
                                 communityViewModel = communityViewModel,
                                 accountViewModel = accountViewModel,
                                 appSettingsViewModel = appSettingsViewModel,
-                                showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
+                                showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                                 siteViewModel = siteViewModel,
-                                useCustomTabs = appSettings?.useCustomTabs ?: true,
-                                usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                                blurNSFW =  appSettings?.blurNSFW ?: true,
+                                useCustomTabs = appSettings.useCustomTabs,
+                                usePrivateTabs = appSettings.usePrivateTabs,
+                                blurNSFW =  appSettings.blurNSFW,
                             )
                         }
 
@@ -234,11 +235,11 @@ class MainActivity : AppCompatActivity() {
                                 communityViewModel = communityViewModel,
                                 accountViewModel = accountViewModel,
                                 appSettingsViewModel = appSettingsViewModel,
-                                showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
+                                showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                                 siteViewModel = siteViewModel,
-                                useCustomTabs = appSettings?.useCustomTabs ?: true,
-                                usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                                blurNSFW =  appSettings?.blurNSFW ?: true,
+                                useCustomTabs = appSettings.useCustomTabs ,
+                                usePrivateTabs = appSettings.usePrivateTabs ,
+                                blurNSFW =  appSettings.blurNSFW ,
                             )
                         }
 
@@ -300,11 +301,11 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
                             siteViewModel = siteViewModel,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            useCustomTabs = appSettings.useCustomTabs ,
+                            usePrivateTabs = appSettings.usePrivateTabs ,
+                            blurNSFW = appSettings.blurNSFW ,
                         )
                     }
 
@@ -331,11 +332,11 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
                             siteViewModel = siteViewModel,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            useCustomTabs = appSettings.useCustomTabs ,
+                            usePrivateTabs = appSettings.usePrivateTabs ,
+                            blurNSFW = appSettings.blurNSFW ,
                         )
                     }
 
@@ -354,7 +355,7 @@ class MainActivity : AppCompatActivity() {
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
                             selectMode = args.select,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            blurNSFW = appSettings.blurNSFW ,
                         )
                     }
 
@@ -406,7 +407,7 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            blurNSFW = appSettings.blurNSFW ,
                         )
                     }
 
@@ -427,15 +428,15 @@ class MainActivity : AppCompatActivity() {
                                 id = Either.Left(args.id),
                                 accountViewModel = accountViewModel,
                                 navController = navController,
-                                showCollapsedCommentContent = appSettings?.showCollapsedCommentContent ?: false,
-                                showActionBarByDefault = appSettings?.showCommentActionBarByDefault ?: true,
-                                showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
-                                showParentCommentNavigationButtons = appSettings?.showParentCommentNavigationButtons ?: true,
-                                navigateParentCommentsWithVolumeButtons = appSettings?.navigateParentCommentsWithVolumeButtons ?: false,
+                                showCollapsedCommentContent = appSettings.showCollapsedCommentContent ,
+                                showActionBarByDefault = appSettings.showCommentActionBarByDefault ,
+                                showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
+                                showParentCommentNavigationButtons = appSettings.showParentCommentNavigationButtons ,
+                                navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons ,
                                 siteViewModel = siteViewModel,
-                                useCustomTabs = appSettings?.useCustomTabs ?: true,
-                                usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                                blurNSFW =  appSettings?.blurNSFW ?: true,
+                                useCustomTabs = appSettings.useCustomTabs ,
+                                usePrivateTabs = appSettings.usePrivateTabs ,
+                                blurNSFW =  appSettings.blurNSFW ,
                             )
                         }
                     }
@@ -456,15 +457,15 @@ class MainActivity : AppCompatActivity() {
                             id = Either.Right(args.id),
                             accountViewModel = accountViewModel,
                             navController = navController,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                            showCollapsedCommentContent = appSettings?.showCollapsedCommentContent ?: false,
-                            showActionBarByDefault = appSettings?.showCommentActionBarByDefault ?: true,
-                            showVotingArrowsInListView = appSettings?.showVotingArrowsInListView ?: true,
-                            showParentCommentNavigationButtons = appSettings?.showParentCommentNavigationButtons ?: true,
-                            navigateParentCommentsWithVolumeButtons = appSettings?.navigateParentCommentsWithVolumeButtons ?: false,
+                            useCustomTabs = appSettings.useCustomTabs ,
+                            usePrivateTabs = appSettings.usePrivateTabs ,
+                            showCollapsedCommentContent = appSettings.showCollapsedCommentContent ,
+                            showActionBarByDefault = appSettings.showCommentActionBarByDefault ,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
+                            showParentCommentNavigationButtons = appSettings.showParentCommentNavigationButtons ,
+                            navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons ,
                             siteViewModel = siteViewModel,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            blurNSFW = appSettings.blurNSFW ,
                         )
                     }
 
@@ -586,8 +587,8 @@ class MainActivity : AppCompatActivity() {
                     composable(route = Route.ABOUT) {
                         AboutActivity(
                             navController = navController,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                            useCustomTabs = appSettings.useCustomTabs ,
+                            usePrivateTabs = appSettings.usePrivateTabs ,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -207,7 +207,7 @@ class MainActivity : AppCompatActivity() {
                                 siteViewModel = siteViewModel,
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
-                                blurNSFW =  appSettings.blurNSFW,
+                                blurNSFW = appSettings.blurNSFW,
                             )
                         }
 
@@ -237,9 +237,9 @@ class MainActivity : AppCompatActivity() {
                                 appSettingsViewModel = appSettingsViewModel,
                                 showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                                 siteViewModel = siteViewModel,
-                                useCustomTabs = appSettings.useCustomTabs ,
-                                usePrivateTabs = appSettings.usePrivateTabs ,
-                                blurNSFW =  appSettings.blurNSFW ,
+                                useCustomTabs = appSettings.useCustomTabs,
+                                usePrivateTabs = appSettings.usePrivateTabs,
+                                blurNSFW = appSettings.blurNSFW,
                             )
                         }
 
@@ -301,11 +301,11 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                             siteViewModel = siteViewModel,
-                            useCustomTabs = appSettings.useCustomTabs ,
-                            usePrivateTabs = appSettings.usePrivateTabs ,
-                            blurNSFW = appSettings.blurNSFW ,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -332,11 +332,11 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                             siteViewModel = siteViewModel,
-                            useCustomTabs = appSettings.useCustomTabs ,
-                            usePrivateTabs = appSettings.usePrivateTabs ,
-                            blurNSFW = appSettings.blurNSFW ,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -355,7 +355,7 @@ class MainActivity : AppCompatActivity() {
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
                             selectMode = args.select,
-                            blurNSFW = appSettings.blurNSFW ,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -407,7 +407,7 @@ class MainActivity : AppCompatActivity() {
                             navController = navController,
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
-                            blurNSFW = appSettings.blurNSFW ,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -428,15 +428,15 @@ class MainActivity : AppCompatActivity() {
                                 id = Either.Left(args.id),
                                 accountViewModel = accountViewModel,
                                 navController = navController,
-                                showCollapsedCommentContent = appSettings.showCollapsedCommentContent ,
-                                showActionBarByDefault = appSettings.showCommentActionBarByDefault ,
-                                showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
-                                showParentCommentNavigationButtons = appSettings.showParentCommentNavigationButtons ,
-                                navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons ,
+                                showCollapsedCommentContent = appSettings.showCollapsedCommentContent,
+                                showActionBarByDefault = appSettings.showCommentActionBarByDefault,
+                                showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
+                                showParentCommentNavigationButtons = appSettings.showParentCommentNavigationButtons,
+                                navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons,
                                 siteViewModel = siteViewModel,
-                                useCustomTabs = appSettings.useCustomTabs ,
-                                usePrivateTabs = appSettings.usePrivateTabs ,
-                                blurNSFW =  appSettings.blurNSFW ,
+                                useCustomTabs = appSettings.useCustomTabs,
+                                usePrivateTabs = appSettings.usePrivateTabs,
+                                blurNSFW = appSettings.blurNSFW,
                             )
                         }
                     }
@@ -457,15 +457,15 @@ class MainActivity : AppCompatActivity() {
                             id = Either.Right(args.id),
                             accountViewModel = accountViewModel,
                             navController = navController,
-                            useCustomTabs = appSettings.useCustomTabs ,
-                            usePrivateTabs = appSettings.usePrivateTabs ,
-                            showCollapsedCommentContent = appSettings.showCollapsedCommentContent ,
-                            showActionBarByDefault = appSettings.showCommentActionBarByDefault ,
-                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView ,
-                            showParentCommentNavigationButtons = appSettings.showParentCommentNavigationButtons ,
-                            navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons ,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
+                            showCollapsedCommentContent = appSettings.showCollapsedCommentContent,
+                            showActionBarByDefault = appSettings.showCommentActionBarByDefault,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
+                            showParentCommentNavigationButtons = appSettings.showParentCommentNavigationButtons,
+                            navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons,
                             siteViewModel = siteViewModel,
-                            blurNSFW = appSettings.blurNSFW ,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -587,8 +587,8 @@ class MainActivity : AppCompatActivity() {
                     composable(route = Route.ABOUT) {
                         AboutActivity(
                             navController = navController,
-                            useCustomTabs = appSettings.useCustomTabs ,
-                            usePrivateTabs = appSettings.usePrivateTabs ,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -58,6 +58,8 @@ import com.jerboa.api.ApiState
 import com.jerboa.api.DEFAULT_INSTANCE
 import com.jerboa.datatypes.types.*
 import com.jerboa.db.Account
+import com.jerboa.db.AppSettings
+import com.jerboa.db.DEFAULT_FONT_SIZE
 import com.jerboa.ui.components.common.Route
 import com.jerboa.ui.components.home.HomeViewModel
 import com.jerboa.ui.components.home.SiteViewModel

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -58,8 +58,6 @@ import com.jerboa.api.ApiState
 import com.jerboa.api.DEFAULT_INSTANCE
 import com.jerboa.datatypes.types.*
 import com.jerboa.db.Account
-import com.jerboa.db.AppSettings
-import com.jerboa.db.DEFAULT_FONT_SIZE
 import com.jerboa.ui.components.common.Route
 import com.jerboa.ui.components.home.HomeViewModel
 import com.jerboa.ui.components.home.SiteViewModel

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -144,7 +144,6 @@ val APP_SETTINGS_DEFAULT = AppSettings(
     blurNSFW = true,
 )
 
-
 @Dao
 interface AccountDao {
     @Query("SELECT * FROM account")

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -125,6 +125,26 @@ data class AppSettings(
     val blurNSFW: Boolean,
 )
 
+val APP_SETTINGS_DEFAULT = AppSettings(
+    id = 1,
+    fontSize = DEFAULT_FONT_SIZE,
+    theme = 0,
+    themeColor = 0,
+    viewedChangelog = 0,
+    postViewMode = 0,
+    showBottomNav = true,
+    showCollapsedCommentContent = false,
+    showCommentActionBarByDefault = true,
+    showVotingArrowsInListView = true,
+    showParentCommentNavigationButtons = false,
+    navigateParentCommentsWithVolumeButtons = false,
+    useCustomTabs = true,
+    usePrivateTabs = false,
+    secureWindow = false,
+    blurNSFW = true,
+)
+
+
 @Dao
 interface AccountDao {
     @Query("SELECT * FROM account")

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -118,6 +118,11 @@ data class AppSettings(
         defaultValue = "0",
     )
     val secureWindow: Boolean,
+    @ColumnInfo(
+        name = "blur_nsfw",
+        defaultValue = "1",
+    )
+    val blurNSFW: Boolean,
 )
 
 @Dao
@@ -436,8 +441,17 @@ val MIGRATION_15_16 = object : Migration(15, 16) {
     }
 }
 
+val MIGRATION_16_17 = object : Migration(16, 17) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
+        database.execSQL(
+            "ALTER TABLE AppSettings add column blur_nsfw INTEGER NOT NULL default 1",
+        )
+    }
+}
+
 @Database(
-    version = 16,
+    version = 17,
     entities = [Account::class, AppSettings::class],
     exportSchema = true,
 )
@@ -477,6 +491,7 @@ abstract class AppDB : RoomDatabase() {
                         MIGRATION_13_14,
                         MIGRATION_14_15,
                         MIGRATION_15_16,
+                        MIGRATION_16_17,
                     )
                     // Necessary because it can't insert data on creation
                     .addCallback(object : Callback() {

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -213,6 +213,7 @@ fun LazyListScope.commentNodeItem(
     showActionBar: (commentId: Int) -> Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     val commentView = node.commentView
     val commentId = commentView.comment.id
@@ -277,6 +278,7 @@ fun LazyListScope.commentNodeItem(
                                 community = commentView.community,
                                 onCommunityClick = onCommunityClick,
                                 onPostClick = onPostClick,
+                                blurNSFW = blurNSFW,
                             )
                         }
                         CommentNodeHeader(
@@ -406,6 +408,7 @@ fun LazyListScope.commentNodeItem(
             showActionBar = showActionBar,
             enableDownVotes = enableDownVotes,
             showAvatar = showAvatar,
+            blurNSFW = blurNSFW,
         )
     }
 }
@@ -464,6 +467,7 @@ fun PostAndCommunityContextHeader(
     community: Community,
     onCommunityClick: (community: Community) -> Unit,
     onPostClick: (postId: Int) -> Unit,
+    blurNSFW: Boolean,
 ) {
     Column(
         modifier = Modifier.padding(top = LARGE_PADDING),
@@ -481,6 +485,7 @@ fun PostAndCommunityContextHeader(
                 community = community,
                 onClick = onCommunityClick,
                 showDefaultIcon = false,
+                blurNSFW = blurNSFW,
             )
         }
     }
@@ -494,6 +499,7 @@ fun PostAndCommunityContextHeaderPreview() {
         community = sampleCommunity,
         onCommunityClick = {},
         onPostClick = {},
+        blurNSFW = true,
     )
 }
 
@@ -666,6 +672,7 @@ fun CommentNodesPreview() {
         showActionBar = { _ -> true },
         enableDownVotes = true,
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
@@ -46,6 +46,7 @@ fun CommentNodes(
     showActionBar: (commentId: Int) -> Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     LazyColumn(state = listState) {
         commentNodeItems(
@@ -81,6 +82,7 @@ fun CommentNodes(
             showActionBar = showActionBar,
             enableDownVotes = enableDownVotes,
             showAvatar = showAvatar,
+            blurNSFW = blurNSFW,
         )
     }
 }
@@ -118,6 +120,7 @@ fun LazyListScope.commentNodeItems(
     showActionBar: (commentId: Int) -> Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     nodes.forEach { node ->
         commentNodeItem(
@@ -153,6 +156,7 @@ fun LazyListScope.commentNodeItems(
             showActionBar = showActionBar,
             enableDownVotes = enableDownVotes,
             showAvatar = showAvatar,
+            blurNSFW = blurNSFW,
         )
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -323,6 +323,7 @@ fun CommentMentionNode(
     onBlockCreatorClick: (creator: Person) -> Unit,
     account: Account?,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     // These are necessary for instant comment voting
     val score = personMentionView.counts.score
@@ -343,6 +344,7 @@ fun CommentMentionNode(
             community = personMentionView.community,
             onCommunityClick = onCommunityClick,
             onPostClick = onPostClick,
+            blurNSFW = blurNSFW,
         )
         CommentMentionNodeHeader(
             personMentionView = personMentionView,

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
@@ -308,6 +308,7 @@ fun CommentReplyNode(
     onBlockCreatorClick: (creator: Person) -> Unit,
     account: Account?,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     // These are necessary for instant comment voting
     val score = commentReplyView.counts.score
@@ -328,6 +329,7 @@ fun CommentReplyNode(
             community = commentReplyView.community,
             onCommunityClick = onCommunityClick,
             onPostClick = onPostClick,
+            blurNSFW = blurNSFW,
         )
         CommentReplyNodeHeader(
             commentReplyView = commentReplyView,

--- a/app/src/main/java/com/jerboa/ui/components/common/AccountHelpers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AccountHelpers.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import com.jerboa.PostViewMode
+import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
 import com.jerboa.db.AppSettingsViewModel
@@ -24,5 +25,5 @@ private fun getCurrentAccount(accounts: List<Account>?): Account? {
 }
 
 fun getPostViewMode(appSettingsViewModel: AppSettingsViewModel): PostViewMode {
-    return PostViewMode.values()[appSettingsViewModel.appSettings.value?.postViewMode ?: 0]
+    return PostViewMode.values()[(appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT).postViewMode]
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
@@ -49,33 +49,41 @@ fun CircularIcon(
     contentDescription: String?,
     size: Dp = ICON_SIZE,
     thumbnailSize: Int = ICON_THUMBNAIL_SIZE,
+    blur: Boolean = false
 ) {
     AsyncImage(
         model = getImageRequest(
             context = LocalContext.current,
             path = icon,
             size = thumbnailSize,
-            nsfw = false,
+            blur = blur,
         ),
         placeholder = painterResource(R.drawable.ic_launcher_foreground),
         contentDescription = contentDescription,
         contentScale = ContentScale.Crop,
-        modifier = getBlurredRoundedModifier(
-            modifier = modifier,
-            rounded = true,
-            nsfw = false,
-        ).size(size),
+        modifier = modifier
+            .getBlurredOrRounded(
+                rounded = true,
+                blur = blur,
+            )
+            .size(size),
     )
 }
 
 @Composable
-fun LargerCircularIcon(modifier: Modifier = Modifier, icon: String, contentDescription: String? = null) {
+fun LargerCircularIcon(
+    modifier: Modifier = Modifier,
+    icon: String,
+    contentDescription: String? = null,
+    blur: Boolean = false
+) {
     CircularIcon(
         modifier = modifier,
         icon = icon,
         contentDescription = contentDescription,
         size = LARGER_ICON_SIZE,
         thumbnailSize = LARGER_ICON_THUMBNAIL_SIZE,
+        blur = blur
     )
 }
 
@@ -88,17 +96,16 @@ fun CircularIconPreview() {
     )
 }
 
-fun getBlurredRoundedModifier(
-    modifier: Modifier = Modifier,
-    rounded: Boolean,
-    nsfw: Boolean,
+fun Modifier.getBlurredOrRounded(
+    blur: Boolean,
+    rounded: Boolean = false,
 ): Modifier {
-    var lModifier = modifier
+    var lModifier = this
 
     if (rounded) {
         lModifier = lModifier.clip(RoundedCornerShape(12f))
     }
-    if (nsfw && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    if (blur && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
         lModifier = lModifier.blur(radius = 100.dp)
     }
     return lModifier
@@ -108,13 +115,13 @@ fun getImageRequest(
     context: Context,
     path: String,
     size: Int,
-    nsfw: Boolean,
+    blur: Boolean,
 ): ImageRequest {
     val builder = ImageRequest.Builder(context)
         .data(pictrsImageThumbnail(path, size))
         .crossfade(true)
 
-    if (nsfw && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+    if (blur && Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
         builder.transformations(
             listOf(
                 BlurTransformation(
@@ -131,7 +138,7 @@ fun getImageRequest(
 @Composable
 fun PictrsThumbnailImage(
     thumbnail: String,
-    nsfw: Boolean,
+    blur: Boolean,
     modifier: Modifier = Modifier,
 ) {
     AsyncImage(
@@ -139,15 +146,14 @@ fun PictrsThumbnailImage(
             context = LocalContext.current,
             path = thumbnail,
             size = THUMBNAIL_SIZE,
-            nsfw = nsfw,
+            blur = blur,
         ),
         placeholder = painterResource(R.drawable.ic_launcher_foreground),
         contentDescription = null,
         contentScale = ContentScale.Crop,
-        modifier = getBlurredRoundedModifier(
-            modifier = modifier,
+        modifier = modifier.getBlurredOrRounded(
             rounded = true,
-            nsfw = nsfw,
+            blur = blur,
         ),
     )
 }
@@ -155,7 +161,7 @@ fun PictrsThumbnailImage(
 @Composable
 fun PictrsUrlImage(
     url: String,
-    nsfw: Boolean,
+    blur: Boolean,
     modifier: Modifier = Modifier,
 ) {
     AsyncImage(
@@ -163,16 +169,17 @@ fun PictrsUrlImage(
             context = LocalContext.current,
             path = url,
             size = MAX_IMAGE_SIZE,
-            nsfw = nsfw,
+            blur = blur,
         ),
         placeholder = painterResource(R.drawable.ic_launcher_foreground),
         contentDescription = null,
         contentScale = ContentScale.FillWidth,
-        modifier = getBlurredRoundedModifier(
-            modifier = modifier,
-            rounded = false,
-            nsfw = nsfw,
-        ).fillMaxWidth(),
+        modifier = modifier
+            .getBlurredOrRounded(
+                rounded = false,
+                blur = blur,
+            )
+            .fillMaxWidth(),
     )
 }
 
@@ -181,18 +188,23 @@ fun PictrsBannerImage(
     url: String,
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
+    blur: Boolean = false
 ) {
     AsyncImage(
         model = getImageRequest(
             context = LocalContext.current,
             path = url,
             size = MAX_IMAGE_SIZE,
-            nsfw = false,
+            blur = blur,
         ),
         placeholder = painterResource(R.drawable.ic_launcher_foreground),
         contentDescription = contentDescription,
         contentScale = ContentScale.FillWidth,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .getBlurredOrRounded(
+                blur = blur,
+            )
+            .fillMaxWidth(),
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/PictrsImage.kt
@@ -49,7 +49,7 @@ fun CircularIcon(
     contentDescription: String?,
     size: Dp = ICON_SIZE,
     thumbnailSize: Int = ICON_THUMBNAIL_SIZE,
-    blur: Boolean = false
+    blur: Boolean = false,
 ) {
     AsyncImage(
         model = getImageRequest(
@@ -75,7 +75,7 @@ fun LargerCircularIcon(
     modifier: Modifier = Modifier,
     icon: String,
     contentDescription: String? = null,
-    blur: Boolean = false
+    blur: Boolean = false,
 ) {
     CircularIcon(
         modifier = modifier,
@@ -83,7 +83,7 @@ fun LargerCircularIcon(
         contentDescription = contentDescription,
         size = LARGER_ICON_SIZE,
         thumbnailSize = LARGER_ICON_THUMBNAIL_SIZE,
-        blur = blur
+        blur = blur,
     )
 }
 
@@ -188,7 +188,7 @@ fun PictrsBannerImage(
     url: String,
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
-    blur: Boolean = false
+    blur: Boolean = false,
 ) {
     AsyncImage(
         model = getImageRequest(

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -32,7 +32,7 @@ fun CommunityTopSection(
     communityView: CommunityView,
     modifier: Modifier = Modifier,
     onClickFollowCommunity: (communityView: CommunityView) -> Unit,
-    blurNSFW: Boolean
+    blurNSFW: Boolean,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -46,7 +46,7 @@ fun CommunityTopSection(
                 PictrsBannerImage(
                     url = it,
                     modifier = Modifier.height(DRAWER_BANNER_SIZE),
-                    blur = blurNSFW && communityView.community.nsfw
+                    blur = blurNSFW && communityView.community.nsfw,
                 )
             }
             communityView.community.icon?.also {
@@ -120,7 +120,7 @@ fun CommunityTopSectionPreview() {
     CommunityTopSection(
         communityView = sampleCommunityView,
         onClickFollowCommunity = {},
-        blurNSFW = true
+        blurNSFW = true,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -32,6 +32,7 @@ fun CommunityTopSection(
     communityView: CommunityView,
     modifier: Modifier = Modifier,
     onClickFollowCommunity: (communityView: CommunityView) -> Unit,
+    blurNSFW: Boolean
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -45,10 +46,11 @@ fun CommunityTopSection(
                 PictrsBannerImage(
                     url = it,
                     modifier = Modifier.height(DRAWER_BANNER_SIZE),
+                    blur = blurNSFW && communityView.community.nsfw
                 )
             }
             communityView.community.icon?.also {
-                LargerCircularIcon(icon = it)
+                LargerCircularIcon(icon = it, blur = blurNSFW && communityView.community.nsfw)
             }
         }
         Column(
@@ -118,6 +120,7 @@ fun CommunityTopSectionPreview() {
     CommunityTopSection(
         communityView = sampleCommunityView,
         onClickFollowCommunity = {},
+        blurNSFW = true
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -80,6 +80,7 @@ fun CommunityActivity(
     showVotingArrowsInListView: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to community activity")
     val transferCreatePostDepsViaRoot = navController.rootChannel<CreatePostDeps>()
@@ -236,6 +237,7 @@ fun CommunityActivity(
                                                     )
                                                 }
                                             },
+                                            blurNSFW = blurNSFW,
                                         )
                                     }
 
@@ -368,6 +370,7 @@ fun CommunityActivity(
                             showVotingArrowsInListView = showVotingArrowsInListView,
                             useCustomTabs = useCustomTabs,
                             usePrivateTabs = usePrivateTabs,
+                            blurNSFW = blurNSFW,
                         )
                     }
                     else -> {}

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityLink.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityLink.kt
@@ -72,6 +72,7 @@ fun CommunityLink(
     onClick: (community: Community) -> Unit,
     clickable: Boolean = true,
     showDefaultIcon: Boolean,
+    blurNSFW: Boolean,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -88,6 +89,7 @@ fun CommunityLink(
                 contentDescription = null,
                 size = size,
                 thumbnailSize = thumbnailSize,
+                blur = blurNSFW && community.nsfw,
             )
         } ?: run {
             if (showDefaultIcon) {
@@ -115,6 +117,7 @@ fun CommunityLinkLarger(
     community: Community,
     onClick: (community: Community) -> Unit,
     showDefaultIcon: Boolean,
+    blurNSFW: Boolean,
 ) {
     CommunityLink(
         community = community,
@@ -128,6 +131,7 @@ fun CommunityLinkLarger(
             .fillMaxWidth(),
         onClick = onClick,
         showDefaultIcon = showDefaultIcon,
+        blurNSFW = blurNSFW,
     )
 }
 
@@ -136,6 +140,7 @@ fun CommunityLinkLargerWithUserCount(
     communityView: CommunityView,
     onClick: (community: Community) -> Unit,
     showDefaultIcon: Boolean,
+    blurNSFW: Boolean,
 ) {
     CommunityLink(
         community = communityView.community,
@@ -150,6 +155,7 @@ fun CommunityLinkLargerWithUserCount(
         style = MaterialTheme.typography.titleLarge,
         onClick = onClick,
         showDefaultIcon = showDefaultIcon,
+        blurNSFW = blurNSFW,
     )
 }
 
@@ -160,6 +166,7 @@ fun CommunityLinkPreview() {
         community = sampleCommunity,
         onClick = {},
         showDefaultIcon = true,
+        blurNSFW = true,
     )
 }
 
@@ -170,5 +177,6 @@ fun CommunityLinkWithUsersPreview() {
         communityView = sampleCommunityView,
         onClick = {},
         showDefaultIcon = true,
+        blurNSFW = true,
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityList.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityList.kt
@@ -65,6 +65,7 @@ fun CommunityListings(
     communities: List<CommunityView>,
     onClickCommunity: (community: Community) -> Unit,
     modifier: Modifier = Modifier,
+    blurNSFW: Boolean,
 ) {
     val listState = rememberLazyListState()
 
@@ -82,12 +83,14 @@ fun CommunityListings(
                     community = item.community,
                     onClick = onClickCommunity,
                     showDefaultIcon = true,
+                    blurNSFW = blurNSFW,
                 )
             } else {
                 CommunityLinkLargerWithUserCount(
                     communityView = item,
                     onClick = onClickCommunity,
                     showDefaultIcon = true,
+                    blurNSFW = blurNSFW,
                 )
             }
         }
@@ -101,6 +104,7 @@ fun CommunityListingsPreview() {
     CommunityListings(
         communities = communities,
         onClickCommunity = {},
+        blurNSFW = true,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListActivity.kt
@@ -45,6 +45,7 @@ fun CommunityListActivity(
     accountViewModel: AccountViewModel,
     selectMode: Boolean = false,
     siteViewModel: SiteViewModel,
+    blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to community list activity")
 
@@ -107,6 +108,7 @@ fun CommunityListActivity(
                             modifier = Modifier
                                 .padding(padding)
                                 .imePadding(),
+                            blurNSFW = blurNSFW,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
@@ -58,7 +58,7 @@ fun BottomNavActivity(
     accountViewModel: AccountViewModel,
     siteViewModel: SiteViewModel,
     appSettingsViewModel: AppSettingsViewModel,
-    appSettings: AppSettings?,
+    appSettings: AppSettings,
 ) {
     val account = getCurrentAccount(accountViewModel)
     val ctx = LocalContext.current
@@ -102,8 +102,8 @@ fun BottomNavActivity(
                         homeViewModel = homeViewModel,
                         scope = scope,
                         drawerState = drawerState,
-                        onSelectTab = if (appSettings?.showBottomNav == true) onSelectTab else null,
-                        blurNSFW = appSettingsViewModel.appSettings.value?.blurNSFW ?: true,
+                        onSelectTab = if (appSettings.showBottomNav) onSelectTab else null,
+                        blurNSFW = appSettings.blurNSFW,
                     )
                 },
             )
@@ -113,7 +113,7 @@ fun BottomNavActivity(
             Scaffold(
                 bottomBar = {
                     BottomAppBarAll(
-                        showBottomNav = appSettingsViewModel.appSettings.value?.showBottomNav,
+                        showBottomNav = appSettings.showBottomNav,
                         selectedTab = selectedTab,
                         unreadCounts = siteViewModel.getUnreadCountTotal(),
                         onSelect = onSelectTab,
@@ -139,12 +139,11 @@ fun BottomNavActivity(
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings?.showVotingArrowsInListView
-                                ?: true,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
                             drawerState = drawerState,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -154,7 +153,7 @@ fun BottomNavActivity(
                             accountViewModel = accountViewModel,
                             selectMode = false,
                             siteViewModel = siteViewModel,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -163,7 +162,7 @@ fun BottomNavActivity(
                             navController = navController,
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -174,12 +173,11 @@ fun BottomNavActivity(
                             navController = navController,
                             accountViewModel = accountViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings?.showVotingArrowsInListView
-                                ?: true,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                             siteViewModel = siteViewModel,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
 
@@ -190,12 +188,11 @@ fun BottomNavActivity(
                             navController = navController,
                             accountViewModel = accountViewModel,
                             appSettingsViewModel = appSettingsViewModel,
-                            showVotingArrowsInListView = appSettings?.showVotingArrowsInListView
-                                ?: true,
+                            showVotingArrowsInListView = appSettings.showVotingArrowsInListView,
                             siteViewModel = siteViewModel,
-                            useCustomTabs = appSettings?.useCustomTabs ?: true,
-                            usePrivateTabs = appSettings?.usePrivateTabs ?: false,
-                            blurNSFW = appSettings?.blurNSFW ?: true,
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
+                            blurNSFW = appSettings.blurNSFW,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
@@ -103,6 +103,7 @@ fun BottomNavActivity(
                         scope = scope,
                         drawerState = drawerState,
                         onSelectTab = if (appSettings?.showBottomNav == true) onSelectTab else null,
+                        blurNSFW = appSettingsViewModel.appSettings.value?.blurNSFW ?: true,
                     )
                 },
             )
@@ -143,6 +144,7 @@ fun BottomNavActivity(
                             useCustomTabs = appSettings?.useCustomTabs ?: true,
                             usePrivateTabs = appSettings?.usePrivateTabs ?: false,
                             drawerState = drawerState,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -152,6 +154,7 @@ fun BottomNavActivity(
                             accountViewModel = accountViewModel,
                             selectMode = false,
                             siteViewModel = siteViewModel,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -160,6 +163,7 @@ fun BottomNavActivity(
                             navController = navController,
                             accountViewModel = accountViewModel,
                             siteViewModel = siteViewModel,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -175,6 +179,7 @@ fun BottomNavActivity(
                             siteViewModel = siteViewModel,
                             useCustomTabs = appSettings?.useCustomTabs ?: true,
                             usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
 
@@ -190,6 +195,7 @@ fun BottomNavActivity(
                             siteViewModel = siteViewModel,
                             useCustomTabs = appSettings?.useCustomTabs ?: true,
                             usePrivateTabs = appSettings?.usePrivateTabs ?: false,
+                            blurNSFW = appSettings?.blurNSFW ?: true,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -117,6 +117,7 @@ fun Drawer(
     onClickSettings: () -> Unit,
     onClickCommunities: () -> Unit,
     isOpen: Boolean,
+    blurNSFW: Boolean,
 ) {
     var showAccountAddMode by rememberSaveable { mutableStateOf(false) }
 
@@ -150,6 +151,7 @@ fun Drawer(
         onClickSaved = onClickSaved,
         onClickSettings = onClickSettings,
         onClickCommunities = onClickCommunities,
+        blurNSFW = blurNSFW,
     )
 }
 
@@ -169,6 +171,7 @@ fun DrawerContent(
     onClickCommunities: () -> Unit,
     myUserInfo: MyUserInfo?,
     unreadCount: Int,
+    blurNSFW: Boolean,
 ) {
     AnimatedVisibility(
         visible = showAccountAddMode,
@@ -194,6 +197,7 @@ fun DrawerContent(
             unreadCount = unreadCount,
             onClickSettings = onClickSettings,
             onClickCommunities = onClickCommunities,
+            blurNSFW = blurNSFW,
         )
     }
 }
@@ -209,6 +213,7 @@ fun DrawerItemsMain(
     onClickListingType: (ListingType) -> Unit,
     onCommunityClick: (community: Community) -> Unit,
     unreadCount: Int,
+    blurNSFW: Boolean,
 ) {
     val listState = rememberLazyListState()
 
@@ -308,6 +313,7 @@ fun DrawerItemsMain(
                     community = follow.community,
                     onClick = onCommunityClick,
                     showDefaultIcon = true,
+                    blurNSFW = blurNSFW,
                 )
             }
         }
@@ -327,6 +333,7 @@ fun DrawerItemsMainPreview() {
         onClickSettings = {},
         onClickCommunities = {},
         unreadCount = 2,
+        blurNSFW = true,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -91,6 +91,7 @@ fun HomeActivity(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     drawerState: DrawerState,
+    blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to home activity")
     val transferCreatePostDepsViaRoot = navController.rootChannel<CreatePostDeps>()
@@ -136,6 +137,7 @@ fun HomeActivity(
                 showVotingArrowsInListView = showVotingArrowsInListView,
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
+                blurNSFW = blurNSFW,
             )
         },
         floatingActionButtonPosition = FabPosition.End,
@@ -175,6 +177,7 @@ fun MainPostListingsContent(
     showVotingArrowsInListView: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     val transferPostEditDepsViaRoot = navController.rootChannel<PostEditDeps>()
 
@@ -337,6 +340,7 @@ fun MainPostListingsContent(
                     showVotingArrowsInListView = showVotingArrowsInListView,
                     useCustomTabs = useCustomTabs,
                     usePrivateTabs = usePrivateTabs,
+                    blurNSFW = blurNSFW,
                 )
             }
 
@@ -354,6 +358,7 @@ fun MainDrawer(
     scope: CoroutineScope,
     drawerState: DrawerState,
     onSelectTab: ((BottomNavTab) -> Unit)?,
+    blurNSFW: Boolean,
 ) {
     val ctx = LocalContext.current
 
@@ -461,6 +466,7 @@ fun MainDrawer(
             }
             closeDrawer(scope, drawerState)
         },
+        blurNSFW = blurNSFW,
     )
 }
 

--- a/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
@@ -68,6 +68,7 @@ fun InboxActivity(
     navController: NavController,
     siteViewModel: SiteViewModel,
     accountViewModel: AccountViewModel,
+    blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to inbox activity")
 
@@ -165,6 +166,7 @@ fun InboxActivity(
                 ctx = ctx,
                 account = account,
                 scope = scope,
+                blurNSFW = blurNSFW,
             )
         },
     )
@@ -186,6 +188,7 @@ fun InboxTabs(
     account: Account?,
     scope: CoroutineScope,
     padding: PaddingValues,
+    blurNSFW: Boolean,
 ) {
     val transferPrivateMessageDepsViaRoot = navController.rootChannel<PrivateMessageDeps>()
     val transferCommentReplyDepsViaRoot = navController.rootChannel<CommentReplyDeps>()
@@ -395,6 +398,7 @@ fun InboxTabs(
                                             },
                                             account = account,
                                             showAvatar = siteViewModel.showAvatar(),
+                                            blurNSFW = blurNSFW,
                                         )
                                     }
                                 }
@@ -562,6 +566,7 @@ fun InboxTabs(
                                             },
                                             account = account,
                                             showAvatar = siteViewModel.showAvatar(),
+                                            blurNSFW = blurNSFW,
                                         )
                                     }
                                 }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -94,6 +94,7 @@ fun PersonProfileActivity(
     showVotingArrowsInListView: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to person activity")
 
@@ -219,6 +220,7 @@ fun PersonProfileActivity(
                 showAvatar = siteViewModel.showAvatar(),
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
+                blurNSFW = blurNSFW,
             )
         },
     )
@@ -247,6 +249,7 @@ fun UserTabs(
     showAvatar: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     val transferCommentEditDepsViaRoot = navController.rootChannel<CommentEditDeps>()
     val transferCommentReplyDepsViaRoot = navController.rootChannel<CommentReplyDeps>()
@@ -365,6 +368,7 @@ fun UserTabs(
                                             navController.toCommunity(id = community.id)
                                         },
                                         showDefaultIcon = true,
+                                        blurNSFW = blurNSFW,
                                     )
                                 }
                             }
@@ -498,6 +502,7 @@ fun UserTabs(
                                     showVotingArrowsInListView = showVotingArrowsInListView,
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
+                                    blurNSFW = blurNSFW,
                                 )
                             }
                         }
@@ -671,6 +676,7 @@ fun UserTabs(
                                     moderators = listOf(),
                                     enableDownVotes = enableDownVotes,
                                     showAvatar = showAvatar,
+                                    blurNSFW = blurNSFW,
                                 )
                             }
                         }

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -141,6 +141,7 @@ fun PostActivity(
     showVotingArrowsInListView: Boolean,
     showParentCommentNavigationButtons: Boolean,
     navigateParentCommentsWithVolumeButtons: Boolean,
+    blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to post activity")
     val transferCommentEditDepsViaRoot = navController.rootChannel<CommentEditDeps>()
@@ -423,6 +424,7 @@ fun PostActivity(
                                     showVotingArrowsInListView = showVotingArrowsInListView,
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
+                                    blurNSFW = blurNSFW,
                                 )
                             }
 
@@ -609,6 +611,7 @@ fun PostActivity(
                                                 commentId,
                                             )
                                         },
+                                        blurNSFW = blurNSFW,
                                     )
                                 }
 

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -122,6 +122,7 @@ fun PostHeaderLine(
     modifier: Modifier = Modifier,
     showCommunityName: Boolean = true,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     val community = postView.community
     Column(modifier = modifier) {
@@ -141,6 +142,7 @@ fun PostHeaderLine(
                             size = MEDIUM_ICON_SIZE,
                             modifier = Modifier.clickable { onCommunityClick(community) },
                             thumbnailSize = LARGER_ICON_THUMBNAIL_SIZE,
+                            blur = blurNSFW && community.nsfw
                         )
                     }
                 }
@@ -228,6 +230,7 @@ fun PostHeaderLinePreview() {
         onCommunityClick = {},
         onPersonClick = {},
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 
@@ -263,12 +266,14 @@ fun PostTitleBlock(
     account: Account?,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     val imagePost = postView.post.url?.let { isImage(it) } ?: run { false }
 
     if (imagePost && expandedImage) {
         PostTitleAndImageLink(
             postView = postView,
+            blurNSFW = blurNSFW,
         )
     } else {
         PostTitleAndThumbnail(
@@ -276,7 +281,7 @@ fun PostTitleBlock(
             account = account,
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
-
+            blurNSFW = blurNSFW,
         )
     }
 }
@@ -308,6 +313,7 @@ fun PostName(
 @Composable
 fun PostTitleAndImageLink(
     postView: PostView,
+    blurNSFW: Boolean,
 ) {
     // This was tested, we know it exists
     val url = postView.post.url!!
@@ -335,7 +341,7 @@ fun PostTitleAndImageLink(
         .clickable { showImageDialog = true }
     PictrsUrlImage(
         url = url,
-        nsfw = nsfwCheck(postView),
+        blur = blurNSFW && nsfwCheck(postView),
         modifier = postLinkPicMod,
     )
 }
@@ -346,6 +352,7 @@ fun PostTitleAndThumbnail(
     account: Account?,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     Column(
         modifier = Modifier.padding(horizontal = MEDIUM_PADDING),
@@ -376,6 +383,7 @@ fun PostTitleAndThumbnail(
                 postView = postView,
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
+                blurNSFW = blurNSFW,
             )
         }
     }
@@ -389,6 +397,7 @@ fun PostBody(
     account: Account?,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     val post = postView.post
     Column(
@@ -400,6 +409,7 @@ fun PostBody(
             account = account,
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
+            blurNSFW = blurNSFW,
         )
 
         // The metadata card
@@ -452,6 +462,7 @@ fun PreviewStoryTitleAndMetadata() {
         account = null,
         useCustomTabs = false,
         usePrivateTabs = false,
+        blurNSFW = true,
     )
 }
 
@@ -695,6 +706,7 @@ fun PreviewPostListingCard() {
         showVotingArrowsInListView = true,
         enableDownVotes = true,
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 
@@ -724,6 +736,7 @@ fun PreviewLinkPostListing() {
         showVotingArrowsInListView = true,
         enableDownVotes = true,
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 
@@ -753,6 +766,7 @@ fun PreviewImagePostListingCard() {
         showVotingArrowsInListView = true,
         enableDownVotes = true,
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 
@@ -782,6 +796,7 @@ fun PreviewImagePostListingSmallCard() {
         showVotingArrowsInListView = true,
         enableDownVotes = true,
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 
@@ -811,6 +826,7 @@ fun PreviewLinkNoThumbnailPostListing() {
         showVotingArrowsInListView = true,
         enableDownVotes = true,
         showAvatar = true,
+        blurNSFW = true,
     )
 }
 
@@ -840,6 +856,7 @@ fun PostListing(
     showVotingArrowsInListView: Boolean,
     enableDownVotes: Boolean,
     showAvatar: Boolean,
+    blurNSFW: Boolean,
 ) {
     // This stores vote data
     val instantScores = remember {
@@ -891,6 +908,7 @@ fun PostListing(
             showAvatar = showAvatar,
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
+            blurNSFW = blurNSFW,
         )
 
         PostViewMode.SmallCard -> PostListingCard(
@@ -930,6 +948,7 @@ fun PostListing(
             showAvatar = showAvatar,
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
+            blurNSFW = blurNSFW,
         )
 
         PostViewMode.List -> PostListingList(
@@ -957,6 +976,7 @@ fun PostListing(
             showAvatar = showAvatar,
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
+            blurNSFW = blurNSFW,
         )
     }
 }
@@ -1021,6 +1041,7 @@ fun PostListingList(
     showAvatar: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     Column(
         modifier = Modifier
@@ -1064,6 +1085,7 @@ fun PostListingList(
                             onClick = {},
                             clickable = false,
                             showDefaultIcon = false,
+                            blurNSFW = blurNSFW,
                         )
                         DotSpacer(0.dp)
                     }
@@ -1123,6 +1145,7 @@ fun PostListingList(
                 postView = postView,
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
+                blurNSFW = blurNSFW,
             )
         }
     }
@@ -1133,6 +1156,7 @@ private fun ThumbnailTile(
     postView: PostView,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     postView.post.url?.also { url ->
         var showImageDialog by remember { mutableStateOf(false) }
@@ -1162,7 +1186,7 @@ private fun ThumbnailTile(
         postView.post.thumbnail_url?.also { thumbnail ->
             PictrsThumbnailImage(
                 thumbnail = thumbnail,
-                nsfw = nsfwCheck(postView),
+                blur = blurNSFW && nsfwCheck(postView),
                 modifier = postLinkPicMod,
             )
         } ?: run {
@@ -1209,6 +1233,7 @@ fun PostListingListPreview() {
         showAvatar = true,
         useCustomTabs = false,
         usePrivateTabs = false,
+        blurNSFW = true,
     )
 }
 
@@ -1235,6 +1260,7 @@ fun PostListingListWithThumbPreview() {
         showAvatar = true,
         useCustomTabs = false,
         usePrivateTabs = false,
+        blurNSFW = true,
     )
 }
 
@@ -1264,6 +1290,7 @@ fun PostListingCard(
     showAvatar: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     Column(
         modifier = Modifier
@@ -1283,6 +1310,8 @@ fun PostListingCard(
             showCommunityName = showCommunityName,
             modifier = Modifier.padding(horizontal = MEDIUM_PADDING),
             showAvatar = showAvatar,
+            blurNSFW = blurNSFW,
+
         )
 
         //  Title + metadata
@@ -1293,6 +1322,7 @@ fun PostListingCard(
             account = account,
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
+            blurNSFW = blurNSFW,
         )
 
         // Footer bar

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -142,7 +142,7 @@ fun PostHeaderLine(
                             size = MEDIUM_ICON_SIZE,
                             modifier = Modifier.clickable { onCommunityClick(community) },
                             thumbnailSize = LARGER_ICON_THUMBNAIL_SIZE,
-                            blur = blurNSFW && community.nsfw
+                            blur = blurNSFW && community.nsfw,
                         )
                     }
                 }

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -53,6 +53,7 @@ fun PostListings(
     showAvatar: Boolean,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
+    blurNSFW: Boolean,
 ) {
     LazyColumn(
         state = listState,
@@ -95,6 +96,7 @@ fun PostListings(
                 showAvatar = showAvatar,
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
+                blurNSFW = blurNSFW,
             )
             Divider(modifier = Modifier.padding(bottom = SMALL_PADDING))
         }
@@ -140,5 +142,6 @@ fun PreviewPostListings() {
         showAvatar = true,
         useCustomTabs = false,
         usePrivateTabs = false,
+        blurNSFW = true,
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/post/composables/PostComposables.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/composables/PostComposables.kt
@@ -191,7 +191,7 @@ fun CreateEditPostBody(
         if (isImage(url)) {
             PictrsUrlImage(
                 url = url,
-                nsfw = false,
+                blur = false,
             )
         }
 

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -88,6 +88,7 @@ fun LookAndFeelActivity(
     val usePrivateTabsState = rememberBooleanSettingState(settings?.usePrivateTabs ?: false)
 
     val secureWindowState = rememberBooleanSettingState(settings?.secureWindow ?: false)
+    val blurNSFW = rememberBooleanSettingState(settings?.blurNSFW ?: true)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -111,6 +112,7 @@ fun LookAndFeelActivity(
                 useCustomTabs = useCustomTabsState.value,
                 usePrivateTabs = usePrivateTabsState.value,
                 secureWindow = secureWindowState.value,
+                blurNSFW = blurNSFW.value,
             ),
         )
     }
@@ -276,6 +278,13 @@ fun LookAndFeelActivity(
                     state = secureWindowState,
                     title = {
                         Text(text = stringResource(R.string.look_and_feel_secure_window))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = blurNSFW,
+                    title = {
+                        Text(stringResource(id = R.string.blur_nsfw))
                     },
                     onCheckedChange = { updateAppSettings() },
                 )

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -37,9 +37,9 @@ import com.jerboa.PostViewMode
 import com.jerboa.R
 import com.jerboa.ThemeColor
 import com.jerboa.ThemeMode
+import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.AppSettings
 import com.jerboa.db.AppSettingsViewModel
-import com.jerboa.db.DEFAULT_FONT_SIZE
 import com.jerboa.getLangPreferenceDropdownEntries
 import com.jerboa.matchLocale
 import com.jerboa.ui.components.common.SimpleTopAppBar
@@ -53,9 +53,9 @@ fun LookAndFeelActivity(
     Log.d("jerboa", "Got to lookAndFeel activity")
     val ctx = LocalContext.current
 
-    val settings = appSettingsViewModel.appSettings.value
-    val themeState = rememberIntSettingState(settings?.theme ?: 0)
-    val themeColorState = rememberIntSettingState(settings?.themeColor ?: 0)
+    val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
+    val themeState = rememberIntSettingState(settings.theme)
+    val themeColorState = rememberIntSettingState(settings.themeColor)
 
     val localeMap = remember {
         getLangPreferenceDropdownEntries(ctx)
@@ -65,30 +65,29 @@ fun LookAndFeelActivity(
     val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
 
     val fontSizeState = rememberFloatSettingState(
-        settings?.fontSize?.toFloat()
-            ?: DEFAULT_FONT_SIZE.toFloat(),
+        settings.fontSize.toFloat(),
     )
-    val postViewModeState = rememberIntSettingState(settings?.postViewMode ?: 0)
-    val showBottomNavState = rememberBooleanSettingState(settings?.showBottomNav ?: true)
+    val postViewModeState = rememberIntSettingState(settings.postViewMode)
+    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav )
     val showCollapsedCommentContentState =
-        rememberBooleanSettingState(settings?.showCollapsedCommentContent ?: false)
+        rememberBooleanSettingState(settings.showCollapsedCommentContent )
     val showCommentActionBarByDefaultState = rememberBooleanSettingState(
-        settings?.showCommentActionBarByDefault ?: true,
+        settings.showCommentActionBarByDefault ,
     )
     val showVotingArrowsInListViewState = rememberBooleanSettingState(
-        settings?.showVotingArrowsInListView ?: true,
+        settings.showVotingArrowsInListView ,
     )
     val showParentCommentNavigationButtonsState = rememberBooleanSettingState(
-        settings?.showParentCommentNavigationButtons ?: true,
+        settings.showParentCommentNavigationButtons ,
     )
     val navigateParentCommentsWithVolumeButtonsState = rememberBooleanSettingState(
-        settings?.navigateParentCommentsWithVolumeButtons ?: false,
+        settings.navigateParentCommentsWithVolumeButtons ,
     )
-    val useCustomTabsState = rememberBooleanSettingState(settings?.useCustomTabs ?: true)
-    val usePrivateTabsState = rememberBooleanSettingState(settings?.usePrivateTabs ?: false)
+    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs )
+    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs )
 
-    val secureWindowState = rememberBooleanSettingState(settings?.secureWindow ?: false)
-    val blurNSFW = rememberBooleanSettingState(settings?.blurNSFW ?: true)
+    val secureWindowState = rememberBooleanSettingState(settings.secureWindow )
+    val blurNSFW = rememberBooleanSettingState(settings.blurNSFW )
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -98,7 +97,7 @@ fun LookAndFeelActivity(
         appSettingsViewModel.update(
             AppSettings(
                 id = 1,
-                viewedChangelog = appSettingsViewModel.appSettings.value?.viewedChangelog ?: 0,
+                viewedChangelog = settings.viewedChangelog,
                 theme = themeState.value,
                 themeColor = themeColorState.value,
                 fontSize = fontSizeState.value.toInt(),

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -68,26 +68,26 @@ fun LookAndFeelActivity(
         settings.fontSize.toFloat(),
     )
     val postViewModeState = rememberIntSettingState(settings.postViewMode)
-    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav )
+    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
     val showCollapsedCommentContentState =
-        rememberBooleanSettingState(settings.showCollapsedCommentContent )
+        rememberBooleanSettingState(settings.showCollapsedCommentContent)
     val showCommentActionBarByDefaultState = rememberBooleanSettingState(
-        settings.showCommentActionBarByDefault ,
+        settings.showCommentActionBarByDefault,
     )
     val showVotingArrowsInListViewState = rememberBooleanSettingState(
-        settings.showVotingArrowsInListView ,
+        settings.showVotingArrowsInListView,
     )
     val showParentCommentNavigationButtonsState = rememberBooleanSettingState(
-        settings.showParentCommentNavigationButtons ,
+        settings.showParentCommentNavigationButtons,
     )
     val navigateParentCommentsWithVolumeButtonsState = rememberBooleanSettingState(
-        settings.navigateParentCommentsWithVolumeButtons ,
+        settings.navigateParentCommentsWithVolumeButtons,
     )
-    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs )
-    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs )
+    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
+    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
 
-    val secureWindowState = rememberBooleanSettingState(settings.secureWindow )
-    val blurNSFW = rememberBooleanSettingState(settings.blurNSFW )
+    val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
+    val blurNSFW = rememberBooleanSettingState(settings.blurNSFW)
 
     val snackbarHostState = remember { SnackbarHostState() }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,4 +334,5 @@
     <string name="generic_error">An error has occurred</string>
     <string name="create_edit_post_close">Close</string>
     <string name="lang_language">Language</string>
+    <string name="blur_nsfw">Blur NSFW Content</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,5 +334,5 @@
     <string name="generic_error">An error has occurred</string>
     <string name="create_edit_post_close">Close</string>
     <string name="lang_language">Language</string>
-    <string name="blur_nsfw">Blur NSFW Content</string>
+    <string name="blur_nsfw">Blur NSFW images</string>
 </resources>


### PR DESCRIPTION
Add a blur option in settings, that controls if NSFW images should be blurred.
Fix community icons and banners not being blurred for NSFW communities

Refactor app setting defaults, previously app settings default where littered all over the place. If we wanted to change a default we would have to track down a dozen places. Now it is all stored in a central location.

Fixes #529
Makes #514 obsolete and can be closed

Tested on android 13 & 11