### PR TITLE
Fix edit comment view text is being empty

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditActivity.kt
@@ -36,8 +36,8 @@ fun CommentEditActivity(
         commentEditViewModel.initialize(commentView)
     }
 
-    var content by rememberSaveable(commentEditViewModel.commentView.value, stateSaver = TextFieldValue.Saver) {
-        mutableStateOf(TextFieldValue(commentEditViewModel.commentView.value?.comment?.content.orEmpty()))
+    var content by rememberSaveable(stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(commentView.comment.content))
     }
 
     val loading = when (commentEditViewModel.editCommentRes) {

--- a/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/edit/CommentEditActivity.kt
@@ -1,7 +1,6 @@
 package com.jerboa.ui.components.comment.edit
 
 import android.util.Log
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -22,7 +21,6 @@ object CommentEditReturn {
     const val COMMENT_VIEW = "comment-edit::return(comment-view)"
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CommentEditActivity(
     commentView: CommentView,
@@ -38,7 +36,9 @@ fun CommentEditActivity(
         commentEditViewModel.initialize(commentView)
     }
 
-    var content by rememberSaveable(stateSaver = TextFieldValue.Saver) { mutableStateOf(TextFieldValue(commentEditViewModel.commentView.value?.comment?.content.orEmpty())) }
+    var content by rememberSaveable(commentEditViewModel.commentView.value, stateSaver = TextFieldValue.Saver) {
+        mutableStateOf(TextFieldValue(commentEditViewModel.commentView.value?.comment?.content.orEmpty()))
+    }
 
     val loading = when (commentEditViewModel.editCommentRes) {
         ApiState.Loading -> true


### PR DESCRIPTION
Fixes the edit comment view being empty

It was composed first before the initialize was called which sets the commentView. Causing it to set the remember with empty text. I changed the remember to change when commentView changes. Not sure if it is normal that it compose before initialize fires. @nahwneeth ?

Fixes #895 

https://github.com/dessalines/jerboa/assets/67873169/12ccdcee-6aca-46a1-96c9-cca6d416809a

