### PR TITLE
Change app display name

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa for Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Gå til kommentar</string>
     <string name="comment_node_go_to">Gå til %1$s</string>
     <string name="comment_node_view_source">Vis kilde</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Gå til kommentar</string>
     <string name="comment_node_go_to">Gå til %1$s</string>
     <string name="comment_node_view_source">Vis kilde</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa für Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Zum Kommentar</string>
     <string name="comment_node_go_to">Gehe zu %1$s</string>
     <string name="comment_node_view_source">Quelle anzeigen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Zum Kommentar</string>
     <string name="comment_node_go_to">Gehe zu %1$s</string>
     <string name="comment_node_view_source">Quelle anzeigen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Ir a comentario</string>
     <string name="comment_node_go_to">Ir a %1$s</string>
     <string name="comment_node_view_source">Ver Fuente</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa para Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Ir a comentario</string>
     <string name="comment_node_go_to">Ir a %1$s</string>
     <string name="comment_node_view_source">Ver Fuente</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Aller au commentaire</string>
     <string name="comment_node_view_source">Afficher la source</string>
     <string name="comment_node_copy_permalink">Copier le lien permanent</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa pour Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Aller au commentaire</string>
     <string name="comment_node_view_source">Afficher la source</string>
     <string name="comment_node_copy_permalink">Copier le lien permanent</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -42,7 +42,7 @@
     <string name="account_settings_topyear">Top dell\'anno</string>
     <string name="addBookmark">Aggiungi ai segnalibri</string>
     <string name="app_bars_dot_spacer">·</string>
-    <string name="app_name">Jerboa per Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="bottomBar_bookmarks">Vai ai miei segnalibri</string>
     <string name="bottomBar_home">Vai alla home</string>
     <string name="bottomBar_inbox">Vai alla posta in arrivo</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -42,7 +42,6 @@
     <string name="account_settings_topyear">Top dell\'anno</string>
     <string name="addBookmark">Aggiungi ai segnalibri</string>
     <string name="app_bars_dot_spacer">·</string>
-    <string name="app_name">Jerboa</string>
     <string name="bottomBar_bookmarks">Vai ai miei segnalibri</string>
     <string name="bottomBar_home">Vai alla home</string>
     <string name="bottomBar_inbox">Vai alla posta in arrivo</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">ジェルボア</string>
     <string name="comment_node_goto_comment">コメントへ行く</string>
     <string name="comment_node_go_to">%1$sへ行く</string>
     <string name="comment_node_view_source">原文を見る</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">댓글로 가기</string>
     <string name="comment_node_go_to">%1$s로 가기</string>
     <string name="comment_node_view_source">원본 보기</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa for Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">댓글로 가기</string>
     <string name="comment_node_go_to">%1$s로 가기</string>
     <string name="comment_node_view_source">원본 보기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Ga naar reactie</string>
     <string name="comment_node_go_to">Ga naar %1$s</string>
     <string name="comment_node_view_source">Bekijk bron</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa voor Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Ga naar reactie</string>
     <string name="comment_node_go_to">Ga naar %1$s</string>
     <string name="comment_node_view_source">Bekijk bron</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa dla Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Idź do Komentarza</string>
     <string name="comment_node_go_to">Idź do %1$s</string>
     <string name="comment_node_view_source">Wyświetl Źródło</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Idź do Komentarza</string>
     <string name="comment_node_go_to">Idź do %1$s</string>
     <string name="comment_node_view_source">Wyświetl Źródło</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa para Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Ir ao Comentário</string>
     <string name="comment_node_view_source">Ver Fonte</string>
     <string name="comment_node_copy_permalink">Copiar Link do Comentário</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Ir ao Comentário</string>
     <string name="comment_node_view_source">Ver Fonte</string>
     <string name="comment_node_copy_permalink">Copiar Link do Comentário</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -274,7 +274,6 @@
     <string name="account_settings_topyear">Лучшее за  год</string>
     <string name="addBookmark">Добавить в закладки</string>
     <string name="app_bars_dot_spacer">.</string>
-    <string name="app_name">Jerboa</string>
     <string name="bottomBar_bookmarks">Перейти в закладки</string>
     <string name="bottomBar_home">Перейти на главный экран</string>
     <string name="bottomBar_inbox">Перейти во входящее</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -274,7 +274,7 @@
     <string name="account_settings_topyear">Лучшее за  год</string>
     <string name="addBookmark">Добавить в закладки</string>
     <string name="app_bars_dot_spacer">.</string>
-    <string name="app_name">Jerboa для Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="bottomBar_bookmarks">Перейти в закладки</string>
     <string name="bottomBar_home">Перейти на главный экран</string>
     <string name="bottomBar_inbox">Перейти во входящее</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Jerboa för Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Gåtill Kommentar</string>
     <string name="comment_node_go_to">Gå till %1$s</string>
     <string name="comment_node_view_source">Visa Källa</string>

--- a/app/src/main/res/values-se/strings.xml
+++ b/app/src/main/res/values-se/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Jerboa</string>
     <string name="comment_node_goto_comment">Gåtill Kommentar</string>
     <string name="comment_node_go_to">Gå till %1$s</string>
     <string name="comment_node_view_source">Visa Källa</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="account_settings_topyear">TopYear</string>
     <string name="addBookmark">Add to bookmarks</string>
     <string name="app_bars_dot_spacer">·</string>
-    <string name="app_name">Jerboa for Lemmy</string>
+    <string name="app_name">Jerboa</string>
     <string name="bottomBar_bookmarks">Go to my bookmarks</string>
     <string name="bottomBar_home">Go home</string>
     <string name="bottomBar_inbox">Go to my inbox</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="account_settings_topyear">TopYear</string>
     <string name="addBookmark">Add to bookmarks</string>
     <string name="app_bars_dot_spacer">·</string>
-    <string name="app_name">Jerboa</string>
+    <string name="app_name" translatable="false">Jerboa</string>
     <string name="bottomBar_bookmarks">Go to my bookmarks</string>
     <string name="bottomBar_home">Go home</string>
     <string name="bottomBar_inbox">Go to my inbox</string>

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Jerboa for Lemmy


### PR DESCRIPTION
This will change the name shown on the android home screen and settings to `Jerboa` while leaving the name on the Play Store as `Jerboa for Lemmy`

This gives a bit of a cleaner look as long app names will either overflow to a new line or will be truncated with an ellipse (eg. `Jerboa for Le...`) but will retain the searchability for users searching "Lemmy" on the Play Store and it's still clear from the title what the app is for.

This does remove the localization but I believe it should be possible to restore this by creating a title.txt file in the respective locale folder under `fastlane/metadata/android/`, although I don't know Fastlane well enough to confirm this.