### PR TITLE
Allow logging into unsupported older server versions

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
@@ -376,7 +376,7 @@ fun ShowOutdatedServerDialog(siteVersion: String, onConfirm: () -> Unit) {
         text = {
             Text(
                 stringResource(
-                    R.string.dialogs_server_version_outdated,
+                    R.string.dialogs_server_version_outdated_warning,
                     siteVersion,
                     MINIMUM_API_VERSION,
                 ),

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -39,8 +39,8 @@ class SiteViewModel : ViewModel() {
     }
 
     fun updateFromAccount(account: Account) {
-        updateSortType(SortType.values().getOrElse(account.defaultSortType) { sortType })
-        updateListingType(ListingType.values().getOrElse(account.defaultListingType) { listingType })
+        updateSortType(SortType.values().getOrElse(if(account.defaultSortType != null) account.defaultSortType else 0) { sortType })
+        updateListingType(ListingType.values().getOrElse(if(account.defaultListingType != null) account.defaultListingType else 0) { listingType })
     }
 
     fun getSite(
@@ -52,9 +52,9 @@ class SiteViewModel : ViewModel() {
 
             when (val res = siteRes) {
                 is ApiState.Success -> {
-                    res.data.my_user?.local_user_view?.local_user?.let {
-                        updateSortType(it.default_sort_type)
-                        updateListingType(it.default_listing_type)
+                    res.data.my_user?.local_user_view?.local_user!!.let {
+                        updateSortType(if(it.default_sort_type != null) it.default_sort_type else SortType.Active)
+                        updateListingType(if(it.default_listing_type != null) it.default_listing_type else ListingType.Local)
                     }
                 }
                 else -> {}

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -52,14 +52,12 @@ class SiteViewModel : ViewModel() {
 
             when (val res = siteRes) {
                 is ApiState.Success -> {
-                    try {
-                        res.data.my_user?.local_user_view?.local_user?.let {
+                    res.data.my_user?.local_user_view?.local_user?.let {
+                        try {
                             updateSortType(it.default_sort_type)
                             updateListingType(it.default_listing_type)
-                        }
-                        // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
-                    } catch (e: NullPointerException) {
-                        res.data.my_user?.local_user_view?.local_user?.let {
+                        // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, use fallback values instead
+                        } catch (e: NullPointerException) {
                             updateSortType(SortType.Active)
                             updateListingType(ListingType.Local)
                         }

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -39,8 +39,8 @@ class SiteViewModel : ViewModel() {
     }
 
     fun updateFromAccount(account: Account) {
-        updateSortType(SortType.values().getOrElse(if (account.defaultSortType != null) account.defaultSortType else 0) { sortType })
-        updateListingType(ListingType.values().getOrElse(if (account.defaultListingType != null) account.defaultListingType else 0) { listingType })
+        updateSortType(SortType.values().getOrElse(account.defaultSortType) { sortType })
+        updateListingType(ListingType.values().getOrElse(account.defaultListingType) { listingType })
     }
 
     fun getSite(
@@ -52,9 +52,18 @@ class SiteViewModel : ViewModel() {
 
             when (val res = siteRes) {
                 is ApiState.Success -> {
-                    res.data.my_user?.local_user_view?.local_user!!.let {
-                        updateSortType(if (it.default_sort_type != null) it.default_sort_type else SortType.Active)
-                        updateListingType(if (it.default_listing_type != null) it.default_listing_type else ListingType.Local)
+
+                    try {
+                        res.data.my_user?.local_user_view?.local_user?.let {
+                            updateSortType(it.default_sort_type)
+                            updateListingType(it.default_listing_type)
+                        }
+                        //Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
+                    } catch (e: NullPointerException) {
+                        res.data.my_user?.local_user_view?.local_user?.let {
+                            updateSortType(SortType.Active)
+                            updateListingType(ListingType.Local)
+                        }
                     }
                 }
                 else -> {}

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -52,7 +52,6 @@ class SiteViewModel : ViewModel() {
 
             when (val res = siteRes) {
                 is ApiState.Success -> {
-
                     try {
                         res.data.my_user?.local_user_view?.local_user?.let {
                             updateSortType(it.default_sort_type)

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -56,7 +56,7 @@ class SiteViewModel : ViewModel() {
                         try {
                             updateSortType(it.default_sort_type)
                             updateListingType(it.default_listing_type)
-                        // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, use fallback values instead
+                            // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, use fallback values instead
                         } catch (e: NullPointerException) {
                             updateSortType(SortType.Active)
                             updateListingType(ListingType.Local)

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -57,7 +57,7 @@ class SiteViewModel : ViewModel() {
                             updateSortType(it.default_sort_type)
                             updateListingType(it.default_listing_type)
                         }
-                        //Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
+                        // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
                     } catch (e: NullPointerException) {
                         res.data.my_user?.local_user_view?.local_user?.let {
                             updateSortType(SortType.Active)

--- a/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/SiteViewModel.kt
@@ -39,8 +39,8 @@ class SiteViewModel : ViewModel() {
     }
 
     fun updateFromAccount(account: Account) {
-        updateSortType(SortType.values().getOrElse(if(account.defaultSortType != null) account.defaultSortType else 0) { sortType })
-        updateListingType(ListingType.values().getOrElse(if(account.defaultListingType != null) account.defaultListingType else 0) { listingType })
+        updateSortType(SortType.values().getOrElse(if (account.defaultSortType != null) account.defaultSortType else 0) { sortType })
+        updateListingType(ListingType.values().getOrElse(if (account.defaultListingType != null) account.defaultListingType else 0) { listingType })
     }
 
     fun getSite(
@@ -53,8 +53,8 @@ class SiteViewModel : ViewModel() {
             when (val res = siteRes) {
                 is ApiState.Success -> {
                     res.data.my_user?.local_user_view?.local_user!!.let {
-                        updateSortType(if(it.default_sort_type != null) it.default_sort_type else SortType.Active)
-                        updateListingType(if(it.default_listing_type != null) it.default_listing_type else ListingType.Local)
+                        updateSortType(if (it.default_sort_type != null) it.default_sort_type else SortType.Active)
+                        updateListingType(if (it.default_listing_type != null) it.default_listing_type else ListingType.Local)
                     }
                 }
                 else -> {}

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -17,6 +17,7 @@ import com.jerboa.api.apiWrapper
 import com.jerboa.api.retrofitErrorHandler
 import com.jerboa.compareVersions
 import com.jerboa.datatypes.types.GetSite
+import com.jerboa.datatypes.types.ListingType
 import com.jerboa.datatypes.types.Login
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
@@ -97,7 +98,7 @@ class LoginViewModel : ViewModel() {
                     val siteVersion = siteRes.data.version
                     if (compareVersions(siteVersion, MINIMUM_API_VERSION) < 0) {
                         val message = ctx.resources.getString(
-                            R.string.dialogs_server_version_outdated_short,
+                            R.string.dialogs_server_version_outdated_warning_short,
                             siteVersion,
                         )
                         Toast.makeText(ctx, message, Toast.LENGTH_SHORT).show()
@@ -105,14 +106,15 @@ class LoginViewModel : ViewModel() {
 
                     try {
                         val luv = siteRes.data.my_user!!.local_user_view
+
                         val account = Account(
                             id = luv.person.id,
                             name = luv.person.name,
                             current = true,
                             instance = instance,
                             jwt = jwt,
-                            defaultListingType = luv.local_user.default_listing_type.ordinal,
-                            defaultSortType = luv.local_user.default_sort_type.ordinal,
+                            defaultListingType = if (luv.local_user.default_listing_type != null) luv.local_user.default_listing_type.ordinal else 0,
+                            defaultSortType = if (luv.local_user.default_listing_type != null) luv.local_user.default_sort_type.ordinal else 0,
                         )
 
                         // Remove the default account

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -105,42 +105,33 @@ class LoginViewModel : ViewModel() {
 
                     try {
                         val luv = siteRes.data.my_user!!.local_user_view
+                        var dlt : Int
+                        var dst : Int
 
                         try {
-                            val account = Account(
-                                id = luv.person.id,
-                                name = luv.person.name,
-                                current = true,
-                                instance = instance,
-                                jwt = jwt,
-                                defaultListingType = luv.local_user.default_listing_type.ordinal,
-                                defaultSortType = luv.local_user.default_sort_type.ordinal,
-                            )
-
-                            // Remove the default account
-                            accountViewModel.removeCurrent()
-
-                            // Save that info in the DB
-                            accountViewModel.insert(account)
-
+                            dlt = luv.local_user.default_listing_type.ordinal
+                            dst = luv.local_user.default_sort_type.ordinal
                             // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
                         } catch (e: NullPointerException) {
-                            val account = Account(
-                                id = luv.person.id,
-                                name = luv.person.name,
-                                current = true,
-                                instance = instance,
-                                jwt = jwt,
-                                defaultListingType = 0,
-                                defaultSortType = 0,
-                            )
-
-                            // Remove the default account
-                            accountViewModel.removeCurrent()
-
-                            // Save that info in the DB
-                            accountViewModel.insert(account)
+                            dlt = 0
+                            dst = 0
                         }
+
+                        val account = Account(
+                            id = luv.person.id,
+                            name = luv.person.name,
+                            current = true,
+                            instance = instance,
+                            jwt = jwt,
+                            defaultListingType = dlt,
+                            defaultSortType = dst,
+                        )
+
+                        // Remove the default account
+                        accountViewModel.removeCurrent()
+
+                        // Save that info in the DB
+                        accountViewModel.insert(account)
                     } catch (e: Exception) {
                         loading = false
                         Log.e("login", e.toString())

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -17,7 +17,6 @@ import com.jerboa.api.apiWrapper
 import com.jerboa.api.retrofitErrorHandler
 import com.jerboa.compareVersions
 import com.jerboa.datatypes.types.GetSite
-import com.jerboa.datatypes.types.ListingType
 import com.jerboa.datatypes.types.Login
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -106,7 +106,7 @@ class LoginViewModel : ViewModel() {
                     try {
                         val luv = siteRes.data.my_user!!.local_user_view
 
-                        try{
+                        try {
                             val account = Account(
                                 id = luv.person.id,
                                 name = luv.person.name,

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -105,8 +105,8 @@ class LoginViewModel : ViewModel() {
 
                     try {
                         val luv = siteRes.data.my_user!!.local_user_view
-                        var dlt : Int
-                        var dst : Int
+                        var dlt: Int
+                        var dst: Int
 
                         try {
                             dlt = luv.local_user.default_listing_type.ordinal

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginViewModel.kt
@@ -123,7 +123,7 @@ class LoginViewModel : ViewModel() {
                             // Save that info in the DB
                             accountViewModel.insert(account)
 
-                            //Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
+                            // Lemmy 0.17.x logins fail due to a defaultlisting being null for some reason, fallback to zero
                         } catch (e: NullPointerException) {
                             val account = Account(
                                 id = luv.person.id,
@@ -141,7 +141,6 @@ class LoginViewModel : ViewModel() {
                             // Save that info in the DB
                             accountViewModel.insert(account)
                         }
-
                     } catch (e: Exception) {
                         loading = false
                         Log.e("login", e.toString())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,7 +146,9 @@
     <string name="dialogs_old">Old</string>
     <string name="dialogs_unread">Unread</string>
     <string name="dialogs_server_version_outdated">Server version (%1$s) is under the minimum supported version (%2$s).\n\nPlease inform your administrator and login to another instance, or sign out and use the default instance.</string>
+    <string name="dialogs_server_version_outdated_warning">Server version (%1$s) is under the minimum supported version (%2$s).\n\nAll features may not work as expected, and you may experience issues with this app.\n\nTo suppress this message, contact the instance administrator to update, or log in to an updated instance.</string>
     <string name="dialogs_server_version_outdated_short">Server version (%1$s) too low.</string>
+    <string name="dialogs_server_version_outdated_warning_short">Server version (%1$s) is unsupported.</string>
     <string name="floating_createPost">Create post</string>
     <string name="form_submit">Submit</string>
     <string name="homeHeader_filter">Select feed</string>


### PR DESCRIPTION
Hello, I have made a version that patches the errors that come up when logging into pre-0.18 servers. This change will allow people to be logged in on 0.17.x and 0.18 on the same Jerboa app.

Full list:

    Changed the outdated messages to a warning
    added checks if default listing types and default sort types were null, defaulted to 0.

I think this change would be highly desirable for people, feel free to mention any issues that this could help solve: E.g. https://github.com/dessalines/jerboa/issues/832, https://github.com/dessalines/jerboa/issues/820, https://github.com/dessalines/jerboa/issues/851, and maybe more.