### PR TITLE
Add "..." for too long community names

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityLink.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityLink.kt
@@ -42,13 +42,14 @@ fun CommunityName(
     community: Community,
     color: Color = MaterialTheme.colorScheme.primary,
     style: TextStyle = MaterialTheme.typography.bodyMedium,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
     Text(
         text = communityNameShown(community),
         style = style,
         color = color,
         modifier = modifier,
-        overflow = TextOverflow.Clip,
+        overflow = overflow,
         maxLines = 1,
     )
 }


### PR DESCRIPTION
Adds ellipsis textoverflow to community names.

Names are now shorted using ...
![studio64_QoMpUBnSCP](https://github.com/dessalines/jerboa/assets/67873169/d35a165c-3faa-4ed0-922c-24a7a7e1c4b4)
![3k5gbaoi3X](https://github.com/dessalines/jerboa/assets/67873169/882840fe-5ad1-4bd1-a1b8-89854c474dee)

Does not affect community names on their page
![Fgo1lyLCSC](https://github.com/dessalines/jerboa/assets/67873169/6774dfd9-4452-4a1f-a3a9-a3d7f8d7b456)

Fixes #983 
Fixes #775 