### PR TITLE
Fix regression due to deprecations change

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -227,8 +227,8 @@ fun CommentOrPostNodeHeader(
     showAvatar: Boolean,
 ) {
     FlowRow(
-        verticalArrangement = Arrangement.SpaceBetween,
-        horizontalArrangement = Arrangement.Center,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalArrangement = Arrangement.Center,
         modifier = Modifier
             .fillMaxWidth()
             .padding(


### PR DESCRIPTION
Fixes a visual regression due to a change in made in which I fixed some deprecations #962 

Old:
![L0zE7VL9W7](https://github.com/dessalines/jerboa/assets/67873169/4e686031-1033-4078-9a97-108d9e8fe0eb)

Now and what it was before:
![CXZPhu7mGp](https://github.com/dessalines/jerboa/assets/67873169/603e1bfe-9287-4de1-afc7-4ebe91ccff73)
