### PR TITLE
Fix clear backstack not working properly

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/Navigation.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Navigation.kt
@@ -61,7 +61,7 @@ inline fun <reified D> NavController.takeDepsFromRoot(): State<D> {
 
 fun NavController.toLogin() = navigate(Route.LOGIN)
 
-fun NavController.toHome() = navigate(Route.HOME) { popUpTo(0) }
+fun NavController.toHome() = navigate(Route.HOME) { popUpTo(graph.id) }
 
 fun NavController.toInbox() = navigate(Route.INBOX)
 


### PR DESCRIPTION
The current approach had issue, and that was noticeable when u tried returning from after you logged in.

![studio64_1LFQhRULhQ](https://github.com/dessalines/jerboa/assets/67873169/355d3d40-8d93-4a22-83ee-2cdbff4f9a7a)

Here demo of it allowing you to go back on login.
https://github.com/dessalines/jerboa/assets/67873169/c9baa6bd-6916-446f-91bc-fbbbe827f5cd




How it is now fixed
https://github.com/dessalines/jerboa/assets/67873169/917ab0f4-bff0-43f2-95ee-88d8d5688063

see https://stackoverflow.com/a/74993733/16066673

