### PR TITLE
Save comment/saved/profile/inbox sort options

### DIFF
--- a/app/schemas/com.jerboa.db.AppDB/20.json
+++ b/app/schemas/com.jerboa.db.AppDB/20.json
@@ -1,0 +1,239 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 20,
+    "identityHash": "6e483d81bd4cc77bdad3f96c980022f8",
+    "entities": [
+      {
+        "tableName": "Account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current` INTEGER NOT NULL, `instance` TEXT NOT NULL, `name` TEXT NOT NULL, `jwt` TEXT NOT NULL, `default_listing_type` INTEGER NOT NULL DEFAULT 0, `default_sort_type` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "current",
+            "columnName": "current",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instance",
+            "columnName": "instance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jwt",
+            "columnName": "jwt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultListingType",
+            "columnName": "default_listing_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultSortType",
+            "columnName": "default_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "AppSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `font_size` INTEGER NOT NULL DEFAULT 16, `theme` INTEGER NOT NULL DEFAULT 0, `theme_color` INTEGER NOT NULL DEFAULT 0, `viewed_changelog` INTEGER NOT NULL DEFAULT 0, `post_view_mode` INTEGER NOT NULL DEFAULT 0, `show_bottom_nav` INTEGER NOT NULL DEFAULT 1, `show_collapsed_comment_content` INTEGER NOT NULL DEFAULT 0, `show_comment_action_bar_by_default` INTEGER NOT NULL DEFAULT 1, `show_voting_arrows_in_list_view` INTEGER NOT NULL DEFAULT 1, `show_parent_comment_navigation_buttons` INTEGER NOT NULL DEFAULT 1, `navigate_parent_comments_with_volume_buttons` INTEGER NOT NULL DEFAULT 0, `use_custom_tabs` INTEGER NOT NULL DEFAULT 1, `use_private_tabs` INTEGER NOT NULL DEFAULT 0, `secure_window` INTEGER NOT NULL DEFAULT 0, `blur_nsfw` INTEGER NOT NULL DEFAULT 1, `show_text_descriptions_in_navbar` INTEGER NOT NULL DEFAULT 1, `backConfirmationMode` INTEGER NOT NULL DEFAULT 1, `comment_sorting_mode` INTEGER NOT NULL DEFAULT 0, `profile_sorting_mode` INTEGER NOT NULL DEFAULT 2, `saved_sorting_mode` INTEGER NOT NULL DEFAULT 2, `inbox_unread` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "16"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "theme_color",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "viewedChangelog",
+            "columnName": "viewed_changelog",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "postViewMode",
+            "columnName": "post_view_mode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "showBottomNav",
+            "columnName": "show_bottom_nav",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showCollapsedCommentContent",
+            "columnName": "show_collapsed_comment_content",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "showCommentActionBarByDefault",
+            "columnName": "show_comment_action_bar_by_default",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showVotingArrowsInListView",
+            "columnName": "show_voting_arrows_in_list_view",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showParentCommentNavigationButtons",
+            "columnName": "show_parent_comment_navigation_buttons",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "navigateParentCommentsWithVolumeButtons",
+            "columnName": "navigate_parent_comments_with_volume_buttons",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "useCustomTabs",
+            "columnName": "use_custom_tabs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "usePrivateTabs",
+            "columnName": "use_private_tabs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "secureWindow",
+            "columnName": "secure_window",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNSFW",
+            "columnName": "blur_nsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showTextDescriptionsInNavbar",
+            "columnName": "show_text_descriptions_in_navbar",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "backConfirmationMode",
+            "columnName": "backConfirmationMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "commentSortingMode",
+            "columnName": "comment_sorting_mode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "savedSortingMode",
+            "columnName": "profile_sorting_mode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "2"
+          },
+          {
+            "fieldPath": "profileSortingMode",
+            "columnName": "saved_sorting_mode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "2"
+          },
+          {
+            "fieldPath": "inboxMode",
+            "columnName": "inbox_unread",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6e483d81bd4cc77bdad3f96c980022f8')"
+    ]
+  }
+}

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -470,6 +470,7 @@ class MainActivity : AppCompatActivity() {
                             siteViewModel = siteViewModel,
                             blurNSFW = appSettings.blurNSFW,
                             drawerState = drawerState,
+                            appSettingsViewModel = appSettingsViewModel,
                         )
                     }
 
@@ -499,6 +500,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
+                                appSettingsViewModel = appSettingsViewModel,
                             )
                         }
                     }
@@ -528,6 +530,7 @@ class MainActivity : AppCompatActivity() {
                             navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons,
                             siteViewModel = siteViewModel,
                             blurNSFW = appSettings.blurNSFW,
+                            appSettingsViewModel = appSettingsViewModel,
                         )
                     }
 

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -471,7 +471,6 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
-                                openImageViewer = { url -> navController.toView(url) },
                             )
                         }
                     }
@@ -501,7 +500,6 @@ class MainActivity : AppCompatActivity() {
                             navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons,
                             siteViewModel = siteViewModel,
                             blurNSFW = appSettings.blurNSFW,
-                            openImageViewer = navController::toView,
                         )
                     }
 

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -59,7 +59,6 @@ import com.jerboa.datatypes.types.*
 import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.Account
 import com.jerboa.db.AppSettings
-import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.model.HomeViewModel
 import com.jerboa.model.SiteViewModel
 import com.jerboa.ui.components.common.Route
@@ -1394,9 +1393,9 @@ fun <T> ApiState<T>.isRefreshing(): Boolean {
     return this == ApiState.Refreshing
 }
 
-inline fun <reified E : Enum<E>> convertIntSettingToEnum(
+inline fun <reified E : Enum<E>> getEnumFromIntSetting(
     appSettings: LiveData<AppSettings>,
-    getter: (AppSettings) -> Int
+    getter: (AppSettings) -> Int,
 ): E {
     val enums = enumValues<E>()
     val setting = appSettings.value ?: APP_SETTINGS_DEFAULT

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
 import androidx.core.os.LocaleListCompat
 import androidx.core.util.PatternsCompat
+import androidx.lifecycle.LiveData
 import androidx.navigation.NavController
 import arrow.core.compareTo
 import com.google.gson.Gson
@@ -55,7 +56,10 @@ import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.DEFAULT_INSTANCE
 import com.jerboa.datatypes.types.*
+import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.Account
+import com.jerboa.db.AppSettings
+import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.model.HomeViewModel
 import com.jerboa.model.SiteViewModel
 import com.jerboa.ui.components.common.Route
@@ -1388,4 +1392,19 @@ fun <T> ApiState<T>.isLoading(): Boolean {
 
 fun <T> ApiState<T>.isRefreshing(): Boolean {
     return this == ApiState.Refreshing
+}
+
+inline fun <reified E : Enum<E>> convertIntSettingToEnum(
+    appSettings: LiveData<AppSettings>,
+    getter: (AppSettings) -> Int
+): E {
+    val enums = enumValues<E>()
+    val setting = appSettings.value ?: APP_SETTINGS_DEFAULT
+    val index = getter(setting)
+
+    return if (index >= enums.size) { // Fallback to default
+        enums[getter(APP_SETTINGS_DEFAULT)]
+    } else {
+        enums[index]
+    }
 }

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -131,8 +131,6 @@ data class AppSettings(
         defaultValue = "1",
     )
     val backConfirmationMode: Int,
-
-    // TODO migrations
     @ColumnInfo(
         name = "comment_sorting_mode",
         defaultValue = "0",
@@ -140,17 +138,17 @@ data class AppSettings(
     val commentSortingMode: Int,
     @ColumnInfo(
         name = "profile_sorting_mode",
-        defaultValue = "0",
+        defaultValue = "2",
     )
     val savedSortingMode: Int,
     @ColumnInfo(
         name = "saved_sorting_mode",
-        defaultValue = "0",
+        defaultValue = "2",
     )
     val profileSortingMode: Int,
     @ColumnInfo(
         name = "inbox_unread",
-        defaultValue = "0",
+        defaultValue = "1",
     )
     val inboxMode: Int,
 )
@@ -175,9 +173,9 @@ val APP_SETTINGS_DEFAULT = AppSettings(
     showTextDescriptionsInNavbar = true,
     backConfirmationMode = 1,
     commentSortingMode = 0,
-    savedSortingMode = 0,
-    profileSortingMode = 0,
-    inboxMode = 0,
+    savedSortingMode = 2,
+    profileSortingMode = 2,
+    inboxMode = 1,
 )
 
 @Dao
@@ -341,7 +339,7 @@ class AppSettingsRepository(
 }
 
 @Database(
-    version = 19,
+    version = 20,
     entities = [Account::class, AppSettings::class],
     exportSchema = true,
 )
@@ -446,7 +444,6 @@ class AppSettingsViewModel(private val repository: AppSettingsRepository) : View
         repository.updateChangelog()
     }
 
-    // Todo use these when DB refactor happens
     fun updateCommentSortingMode(commentSortingMode: Int) = viewModelScope.launch {
         repository.updateCommentSortingMode(commentSortingMode)
     }

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -126,6 +126,28 @@ data class AppSettings(
         defaultValue = "1",
     )
     val showTextDescriptionsInNavbar: Boolean,
+
+    // TODO migrations
+    @ColumnInfo(
+        name = "comment_sorting_mode",
+        defaultValue = "0",
+    )
+    val commentSortingMode: Int,
+    @ColumnInfo(
+        name = "profile_sorting_mode",
+        defaultValue = "0",
+    )
+    val savedSortingMode: Int,
+    @ColumnInfo(
+        name = "saved_sorting_mode",
+        defaultValue = "0",
+    )
+    val profileSortingMode: Int,
+    @ColumnInfo(
+        name = "inbox_unread",
+        defaultValue = "0",
+    )
+    val inboxMode: Int,
 )
 
 val APP_SETTINGS_DEFAULT = AppSettings(
@@ -146,6 +168,10 @@ val APP_SETTINGS_DEFAULT = AppSettings(
     secureWindow = false,
     blurNSFW = true,
     showTextDescriptionsInNavbar = true,
+    commentSortingMode = 0,
+    savedSortingMode = 0,
+    profileSortingMode = 0,
+    inboxMode = 0,
 )
 
 @Dao
@@ -185,6 +211,18 @@ interface AppSettingsDao {
 
     @Query("UPDATE AppSettings set post_view_mode = :postViewMode")
     suspend fun updatePostViewMode(postViewMode: Int)
+
+    @Query("UPDATE AppSettings set comment_sorting_mode = :commentSortingMode")
+    suspend fun updateCommentSortingMode(commentSortingMode: Int)
+
+    @Query("UPDATE AppSettings set saved_sorting_mode = :savedSortingMode")
+    suspend fun updateSavedSortingMode(savedSortingMode: Int)
+
+    @Query("UPDATE AppSettings set profile_sorting_mode = :profileSortingMode")
+    suspend fun updateProfileSortingMode(profileSortingMode: Int)
+
+    @Query("UPDATE AppSettings set inbox_unread = :inboxMode")
+    suspend fun updateInboxMode(inboxMode: Int)
 }
 
 // Declares the DAO as a private property in the constructor. Pass in the DAO
@@ -273,6 +311,26 @@ class AppSettingsRepository(
                 Log.e("jerboa", "Failed to load changelog: $e")
             }
         }
+    }
+
+    @WorkerThread
+    suspend fun updateProfileSortingMode(profileSortingMode: Int) {
+        appSettingsDao.updateProfileSortingMode(profileSortingMode)
+    }
+
+    @WorkerThread
+    suspend fun updateSavedSortingMode(savedSortingMode: Int) {
+        appSettingsDao.updateSavedSortingMode(savedSortingMode)
+    }
+
+    @WorkerThread
+    suspend fun updateCommentSortingMode(commentSortingMode: Int) {
+        appSettingsDao.updateCommentSortingMode(commentSortingMode)
+    }
+
+    @WorkerThread
+    suspend fun updateInboxMode(inboxSortingMode: Int) {
+        appSettingsDao.updateInboxMode(inboxSortingMode)
     }
 }
 
@@ -374,12 +432,29 @@ class AppSettingsViewModel(private val repository: AppSettingsRepository) : View
         repository.markChangelogViewed()
     }
 
-    fun updatedPostViewMode(postViewMode: Int) = viewModelScope.launch {
+    fun updatePostViewMode(postViewMode: Int) = viewModelScope.launch {
         repository.updatePostViewMode(postViewMode)
     }
 
     fun updateChangelog() = viewModelScope.launch {
         repository.updateChangelog()
+    }
+
+    // Todo use these when DB refactor happens
+    fun updateCommentSortingMode(commentSortingMode: Int) = viewModelScope.launch {
+        repository.updateCommentSortingMode(commentSortingMode)
+    }
+
+    fun updateSavedSortingMode(savedSortingMode: Int) = viewModelScope.launch {
+        repository.updateSavedSortingMode(savedSortingMode)
+    }
+
+    fun updateProfileSortingMode(profileSortingMode: Int) = viewModelScope.launch {
+        repository.updateProfileSortingMode(profileSortingMode)
+    }
+
+    fun updateInboxMode(inboxMode: Int) = viewModelScope.launch {
+        repository.updateInboxMode(inboxMode)
     }
 }
 

--- a/app/src/main/java/com/jerboa/db/Migrations.kt
+++ b/app/src/main/java/com/jerboa/db/Migrations.kt
@@ -220,6 +220,24 @@ val MIGRATION_18_19 = object : Migration(18, 19) {
     }
 }
 
+val MIGRATION_19_20 = object : Migration(19, 20) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
+        database.execSQL(
+            "ALTER TABLE AppSettings ADD COLUMN comment_sorting_mode INTEGER NOT NULL DEFAULT 0",
+        )
+        database.execSQL(
+            "ALTER TABLE AppSettings ADD COLUMN profile_sorting_mode INTEGER NOT NULL DEFAULT 2",
+        )
+        database.execSQL(
+            "ALTER TABLE AppSettings ADD COLUMN saved_sorting_mode INTEGER NOT NULL DEFAULT 2",
+        )
+        database.execSQL(
+            "ALTER TABLE AppSettings ADD COLUMN inbox_unread INTEGER NOT NULL DEFAULT 1",
+        )
+    }
+}
+
 // Don't forget to test your migration with `./gradlew app:connectAndroidTest`
 val MIGRATIONS_LIST = arrayOf(
     MIGRATION_1_2,
@@ -240,4 +258,5 @@ val MIGRATIONS_LIST = arrayOf(
     MIGRATION_16_17,
     MIGRATION_17_18,
     MIGRATION_18_19,
+    MIGRATION_19_20,
 )

--- a/app/src/main/java/com/jerboa/model/PersonProfileViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/PersonProfileViewModel.kt
@@ -55,7 +55,7 @@ class PersonProfileViewModel : ViewModel(), Initializable {
     private var saveCommentRes: ApiState<CommentResponse> by mutableStateOf(ApiState.Empty)
     private var deleteCommentRes: ApiState<CommentResponse> by mutableStateOf(ApiState.Empty)
 
-    var sortType by mutableStateOf(SortType.Hot)
+    var sortType by mutableStateOf(SortType.New)
         private set
 
     var page by mutableIntStateOf(1)

--- a/app/src/main/java/com/jerboa/model/PersonProfileViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/PersonProfileViewModel.kt
@@ -6,17 +6,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.CreationExtras
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
-import com.jerboa.JerboaApplication
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
-import com.jerboa.convertIntSettingToEnum
 import com.jerboa.datatypes.types.BlockCommunity
 import com.jerboa.datatypes.types.BlockCommunityResponse
 import com.jerboa.datatypes.types.BlockPerson
@@ -35,8 +28,6 @@ import com.jerboa.datatypes.types.PostView
 import com.jerboa.datatypes.types.SaveComment
 import com.jerboa.datatypes.types.SavePost
 import com.jerboa.datatypes.types.SortType
-import com.jerboa.db.AppSettingsRepository
-import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.findAndUpdateComment
 import com.jerboa.findAndUpdatePost
 import com.jerboa.serializeToMap
@@ -45,7 +36,7 @@ import com.jerboa.showBlockPersonToast
 import com.jerboa.ui.components.common.Initializable
 import kotlinx.coroutines.launch
 
-class PersonProfileViewModel(private val appSettingsRepository: AppSettingsRepository) : ViewModel(), Initializable {
+class PersonProfileViewModel : ViewModel(), Initializable {
     override var initialized by mutableStateOf(false)
 
     var personDetailsRes: ApiState<GetPersonDetailsResponse> by mutableStateOf(
@@ -64,8 +55,7 @@ class PersonProfileViewModel(private val appSettingsRepository: AppSettingsRepos
     private var saveCommentRes: ApiState<CommentResponse> by mutableStateOf(ApiState.Empty)
     private var deleteCommentRes: ApiState<CommentResponse> by mutableStateOf(ApiState.Empty)
 
-
-    var sortType by mutableStateOf(convertIntSettingToEnum<SortType>(appSettingsRepository.appSettings) {it.profileSortingMode})
+    var sortType by mutableStateOf(SortType.Hot)
         private set
 
     var page by mutableIntStateOf(1)
@@ -75,9 +65,6 @@ class PersonProfileViewModel(private val appSettingsRepository: AppSettingsRepos
 
     fun updateSortType(sortType: SortType) {
         this.sortType = sortType
-        viewModelScope.launch {
-            appSettingsRepository.updateCommentSortingMode(sortType.ordinal)
-        }
     }
 
     fun resetPage() {
@@ -301,22 +288,4 @@ class PersonProfileViewModel(private val appSettingsRepository: AppSettingsRepos
             else -> {}
         }
     }
-
-    companion object {
-        val Factory: ViewModelProvider.Factory = object : ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(
-                modelClass: Class<T>,
-                extras: CreationExtras
-            ): T {
-                // Get the Application object from extras
-                val application = checkNotNull(extras[APPLICATION_KEY])
-
-                return PersonProfileViewModel(
-                    (application as JerboaApplication).appSettingsRepository,
-                ) as T
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/AccountHelpers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AccountHelpers.kt
@@ -4,12 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import com.jerboa.PostViewMode
-import com.jerboa.convertIntSettingToEnum
-import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
-import com.jerboa.db.AppSettings
 import com.jerboa.db.AppSettingsViewModel
+import com.jerboa.getEnumFromIntSetting
 
 @Composable
 fun getCurrentAccount(accountViewModel: AccountViewModel): Account? {
@@ -27,6 +25,5 @@ private fun getCurrentAccount(accounts: List<Account>?): Account? {
 }
 
 fun getPostViewMode(appSettingsViewModel: AppSettingsViewModel): PostViewMode {
-    return convertIntSettingToEnum<PostViewMode>(appSettingsViewModel.appSettings) { it.postViewMode }
+    return getEnumFromIntSetting<PostViewMode>(appSettingsViewModel.appSettings) { it.postViewMode }
 }
-

--- a/app/src/main/java/com/jerboa/ui/components/common/AccountHelpers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AccountHelpers.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import com.jerboa.PostViewMode
+import com.jerboa.convertIntSettingToEnum
 import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
+import com.jerboa.db.AppSettings
 import com.jerboa.db.AppSettingsViewModel
 
 @Composable
@@ -25,5 +27,6 @@ private fun getCurrentAccount(accounts: List<Account>?): Account? {
 }
 
 fun getPostViewMode(appSettingsViewModel: AppSettingsViewModel): PostViewMode {
-    return PostViewMode.values()[(appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT).postViewMode]
+    return convertIntSettingToEnum<PostViewMode>(appSettingsViewModel.appSettings) { it.postViewMode }
 }
+

--- a/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BarChart
 import androidx.compose.material.icons.outlined.Bookmarks
+import androidx.compose.material.icons.outlined.BrightnessHigh
 import androidx.compose.material.icons.outlined.BrightnessLow
 import androidx.compose.material.icons.outlined.FormatListNumbered
 import androidx.compose.material.icons.outlined.History
@@ -159,6 +160,12 @@ fun SortOptionsDialog(
                     icon = Icons.Outlined.BrightnessLow,
                     onClick = { onClickSortType(SortType.New) },
                     highlight = (selectedSortType == SortType.New),
+                )
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_old),
+                    icon = Icons.Outlined.BrightnessHigh,
+                    onClick = { onClickSortType(SortType.Old) },
+                    highlight = (selectedSortType == SortType.Old),
                 )
                 IconAndTextDrawerItem(
                     text = stringResource(R.string.dialogs_most_comments),

--- a/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
@@ -191,6 +191,7 @@ fun BottomNavActivity(
                             siteViewModel = siteViewModel,
                             blurNSFW = appSettings.blurNSFW,
                             drawerState = drawerState,
+                            appSettingsViewModel = appSettingsViewModel,
                         )
                     }
 

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -381,7 +381,7 @@ fun MainTopBar(
                 homeViewModel.resetPosts(account)
             },
             onClickPostViewMode = {
-                appSettingsViewModel.updatedPostViewMode(it.ordinal)
+                appSettingsViewModel.updatePostViewMode(it.ordinal)
             },
             onClickRefresh = {
                 scrollToTop()

--- a/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
@@ -35,6 +35,7 @@ import com.jerboa.datatypes.types.MarkPrivateMessageAsRead
 import com.jerboa.datatypes.types.SaveComment
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
+import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.model.InboxViewModel
 import com.jerboa.model.ReplyItem
 import com.jerboa.model.SiteViewModel
@@ -67,6 +68,7 @@ fun InboxActivity(
     drawerState: DrawerState,
     siteViewModel: SiteViewModel,
     accountViewModel: AccountViewModel,
+    appSettingsViewModel: AppSettingsViewModel,
     blurNSFW: Boolean,
 ) {
     Log.d("jerboa", "got to inbox activity")
@@ -82,6 +84,11 @@ fun InboxActivity(
     InitializeRoute(inboxViewModel) {
         if (account != null) {
             inboxViewModel.resetPages()
+
+            inboxViewModel.updateUnreadOnly(
+                getEnumFromIntSetting<UnreadOrAll>(appSettingsViewModel.appSettings) { it.inboxMode } == UnreadOrAll.Unread,
+            )
+
             inboxViewModel.getReplies(
                 inboxViewModel.getFormReplies(account.jwt),
             )
@@ -111,6 +118,7 @@ fun InboxActivity(
                     account?.also { acct ->
                         inboxViewModel.resetPages()
                         inboxViewModel.updateUnreadOnly(unreadOrAll == UnreadOrAll.Unread)
+                        appSettingsViewModel.updateInboxMode(unreadOrAll.ordinal)
                         inboxViewModel.getReplies(
                             inboxViewModel.getFormReplies(acct.jwt),
                         )

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -45,6 +45,7 @@ import com.jerboa.datatypes.types.SortType
 import com.jerboa.db.Account
 import com.jerboa.db.AccountViewModel
 import com.jerboa.db.AppSettingsViewModel
+import com.jerboa.getEnumFromIntSetting
 import com.jerboa.getLocalizedStringForUserTab
 import com.jerboa.isLoading
 import com.jerboa.isRefreshing
@@ -113,7 +114,7 @@ fun PersonProfileActivity(
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
-    val personProfileViewModel: PersonProfileViewModel = viewModel(factory = PersonProfileViewModel.Factory)
+    val personProfileViewModel: PersonProfileViewModel = viewModel()
 
     navController.ConsumeReturn<PostView>(PostEditReturn.POST_VIEW) { pv ->
         if (personProfileViewModel.initialized) personProfileViewModel.updatePost(pv)
@@ -148,6 +149,14 @@ fun PersonProfileActivity(
 
         personProfileViewModel.resetPage()
         personProfileViewModel.updateSavedOnly(savedMode)
+
+        personProfileViewModel.updateSortType(
+            getEnumFromIntSetting<SortType>(
+                appSettingsViewModel.appSettings,
+                if (savedMode) { it -> it.savedSortingMode } else { it -> it.profileSortingMode },
+            ),
+        )
+
         personProfileViewModel.getPersonDetails(
             GetPersonDetails(
                 person_id = personId,
@@ -193,6 +202,13 @@ fun PersonProfileActivity(
                             scrollToTop(scope, postListState)
                             personProfileViewModel.resetPage()
                             personProfileViewModel.updateSortType(sortType)
+
+                            if (savedMode) {
+                                appSettingsViewModel.updateSavedSortingMode(sortType.ordinal)
+                            } else {
+                                appSettingsViewModel.updateProfileSortingMode(sortType.ordinal)
+                            }
+
                             personProfileViewModel.getPersonDetails(
                                 GetPersonDetails(
                                     person_id = person.id,

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -113,7 +113,7 @@ fun PersonProfileActivity(
     val snackbarHostState = remember { SnackbarHostState() }
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
 
-    val personProfileViewModel: PersonProfileViewModel = viewModel()
+    val personProfileViewModel: PersonProfileViewModel = viewModel(factory = PersonProfileViewModel.Factory)
 
     navController.ConsumeReturn<PostView>(PostEditReturn.POST_VIEW) { pv ->
         if (personProfileViewModel.initialized) personProfileViewModel.updatePost(pv)

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -109,6 +109,7 @@ import com.jerboa.ui.components.common.toPost
 import com.jerboa.ui.components.common.toPostEdit
 import com.jerboa.ui.components.common.toPostReport
 import com.jerboa.ui.components.common.toProfile
+import com.jerboa.ui.components.common.toView
 import com.jerboa.ui.components.post.edit.PostEditReturn
 
 @Composable
@@ -148,7 +149,6 @@ fun PostActivity(
     showParentCommentNavigationButtons: Boolean,
     navigateParentCommentsWithVolumeButtons: Boolean,
     blurNSFW: Boolean,
-    openImageViewer: (url: String) -> Unit,
 ) {
     Log.d("jerboa", "got to post activity")
     val transferCommentEditDepsViaRoot = navController.rootChannel<CommentEditDeps>()
@@ -438,7 +438,7 @@ fun PostActivity(
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
                                     blurNSFW = blurNSFW,
-                                    openImageViewer = openImageViewer,
+                                    openImageViewer = navController::toView,
                                 )
                             }
 

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -71,8 +71,10 @@ import com.jerboa.datatypes.types.PostView
 import com.jerboa.datatypes.types.SaveComment
 import com.jerboa.datatypes.types.SavePost
 import com.jerboa.db.AccountViewModel
+import com.jerboa.db.AppSettingsViewModel
 import com.jerboa.getCommentParentId
 import com.jerboa.getDepthFromComment
+import com.jerboa.getEnumFromIntSetting
 import com.jerboa.getLocalizedCommentSortTypeName
 import com.jerboa.isLoading
 import com.jerboa.isModerator
@@ -140,6 +142,7 @@ fun PostActivity(
     id: Either<PostId, CommentId>,
     siteViewModel: SiteViewModel,
     accountViewModel: AccountViewModel,
+    appSettingsViewModel: AppSettingsViewModel,
     navController: NavController,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
@@ -175,11 +178,7 @@ fun PostActivity(
 
     InitializeRoute(postViewModel) {
         postViewModel.initialize(id = id)
-        postViewModel.getData(account)
-    }
-
-    val onClickSortType = { commentSortType: CommentSortType ->
-        postViewModel.updateSortType(commentSortType)
+        postViewModel.updateSortType(getEnumFromIntSetting<CommentSortType>(appSettingsViewModel.appSettings) { it.commentSortingMode })
         postViewModel.getData(account)
     }
 
@@ -212,7 +211,9 @@ fun PostActivity(
             onDismissRequest = { showSortOptions = false },
             onClickSortType = {
                 showSortOptions = false
-                onClickSortType(it)
+                appSettingsViewModel.updateCommentSortingMode(it.ordinal)
+                postViewModel.updateSortType(it)
+                postViewModel.getData(account)
             },
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -114,6 +114,10 @@ fun LookAndFeelActivity(
                 secureWindow = secureWindowState.value,
                 showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
                 blurNSFW = blurNSFW.value,
+                inboxMode = settings.inboxMode,
+                commentSortingMode = settings.commentSortingMode,
+                savedSortingMode = settings.savedSortingMode,
+                profileSortingMode = settings.profileSortingMode,
             ),
         )
     }

--- a/app/src/main/java/com/jerboa/util/BackConfirmation.kt
+++ b/app/src/main/java/com/jerboa/util/BackConfirmation.kt
@@ -27,7 +27,7 @@ object BackConfirmation {
     private var isBackPressedOnce = false
     private var ref: OnBackPressedCallback? = null
     fun ComponentActivity.addConfirmationToast(navController: NavController, ctx: Context) {
-        if (ref != null) throw IllegalStateException("Previous callback not cleaned up")
+        if (ref != null) disposeConfirmation()
 
         ref = this.onBackPressedDispatcher.addCallback(this) {
             val isRoot = navController.previousBackStackEntry == null
@@ -46,7 +46,7 @@ object BackConfirmation {
     }
 
     fun ComponentActivity.addConfirmationDialog(navController: NavController, showDialog: () -> Unit) {
-        if (ref != null) throw IllegalStateException("Previous callback not cleaned up")
+        if (ref != null) disposeConfirmation()
 
         ref = this.onBackPressedDispatcher.addCallback(this) {
             val isRoot = navController.previousBackStackEntry == null

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -39,7 +39,7 @@ android {
         maybeCreate<ManagedVirtualDevice>("pixel6Api31").apply {
             device = "Pixel 6"
             apiLevel = 30
-            systemImageSource = "aosp-atd"
+            systemImageSource = "aosp"
         }
     }
 

--- a/benchmarks/src/main/java/com/jerboa/actions/JerboaActions.kt
+++ b/benchmarks/src/main/java/com/jerboa/actions/JerboaActions.kt
@@ -84,15 +84,17 @@ fun MacrobenchmarkScope.waitUntilLoadingDone(timeout: Long = 10_000) {
     device.wait(Until.gone(By.res("jerboa:loading")), timeout)
 }
 
-fun MacrobenchmarkScope.waitUntilPostsActuallyVisible(retry: Boolean = true, timeout: Long = 10_000) {
+fun MacrobenchmarkScope.waitUntilPostsActuallyVisible(retry: Boolean = true, timeout: Long = 10_000, depth: Int = 0) {
     device.wait(
         Until.hasObject(By.res("jerboa:posts").hasDescendant(By.res("jerboa:post"))),
         timeout,
     )
+    if (depth > 10) throw IllegalStateException("Exceed retrial")
+
     if (retry && !device.hasObject(By.res("jerboa:posts").hasDescendant(By.res("jerboa:post")))) {
         openOptions()
         clickRefresh()
-        waitUntilPostsActuallyVisible(timeout = timeout)
+        waitUntilPostsActuallyVisible(timeout = timeout, depth = depth + 1)
     }
 }
 


### PR DESCRIPTION
Save comment/saved/profile/inbox sort options. These should be the remaining options that were not retained.

Also added missing sort type `old`

Fixes #976
Fixes #921