### PR TITLE
Fix rare edgecase crash when deleting app DB

### DIFF
--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.jerboa
 
 import android.app.Application
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -88,6 +89,7 @@ import com.jerboa.util.BackConfirmation.disposeConfirmation
 import com.jerboa.util.BackConfirmationMode
 import com.jerboa.util.ShowConfirmationDialog
 
+
 class JerboaApplication : Application() {
     lateinit var container: AppDBContainer
 
@@ -133,6 +135,12 @@ class MainActivity : AppCompatActivity() {
             }
 
             val appSettings by appSettingsViewModel.appSettings.observeAsState(APP_SETTINGS_DEFAULT)
+
+            @Suppress("SENSELESS_COMPARISON")
+            if(appSettings == null ) {
+                triggerRebirth(ctx)
+            }
+
 
             JerboaTheme(
                 appSettings = appSettings,

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.jerboa
 
 import android.app.Application
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -89,7 +88,6 @@ import com.jerboa.util.BackConfirmation.disposeConfirmation
 import com.jerboa.util.BackConfirmationMode
 import com.jerboa.util.ShowConfirmationDialog
 
-
 class JerboaApplication : Application() {
     lateinit var container: AppDBContainer
 
@@ -137,10 +135,9 @@ class MainActivity : AppCompatActivity() {
             val appSettings by appSettingsViewModel.appSettings.observeAsState(APP_SETTINGS_DEFAULT)
 
             @Suppress("SENSELESS_COMPARISON")
-            if(appSettings == null ) {
+            if (appSettings == null) {
                 triggerRebirth(ctx)
             }
-
 
             JerboaTheme(
                 appSettings = appSettings,

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1427,3 +1427,12 @@ inline fun <reified E : Enum<E>> getEnumFromIntSetting(
         enums[index]
     }
 }
+
+fun triggerRebirth(context: Context) {
+    val packageManager = context.packageManager
+    val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+    val componentName = intent!!.component
+    val mainIntent = Intent.makeRestartActivityTask(componentName)
+    context.startActivity(mainIntent)
+    Runtime.getRuntime().exit(0)
+}


### PR DESCRIPTION
Fix a rare crash when deleting the app DB while the app is still open. On relaunch it will return a null even though it should not.


Crash log
![studio64_9bvFUNO0Me](https://github.com/dessalines/jerboa/assets/67873169/5c648f30-c65f-4335-8804-1c82e417b8c9)

Before

https://github.com/dessalines/jerboa/assets/67873169/e7325f58-6ba1-4317-8aba-1bc5c4f3cc70




After: You can barely see it but it relaunches on startup

https://github.com/dessalines/jerboa/assets/67873169/e3dccba6-2219-424c-8d71-59ecc82096aa



