### PR TITLE
Add option to show/hide post previews

### DIFF
--- a/app/schemas/com.jerboa.db.AppDB/21.json
+++ b/app/schemas/com.jerboa.db.AppDB/21.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 21,
-    "identityHash": "70391a79e30a53a6573461d57c3be6bb",
+    "identityHash": "57b5a9e25468cc9029f803df34415820",
     "entities": [
       {
         "tableName": "Account",
@@ -64,7 +64,7 @@
       },
       {
         "tableName": "AppSettings",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `font_size` INTEGER NOT NULL DEFAULT 16, `theme` INTEGER NOT NULL DEFAULT 0, `theme_color` INTEGER NOT NULL DEFAULT 0, `viewed_changelog` INTEGER NOT NULL DEFAULT 0, `post_view_mode` INTEGER NOT NULL DEFAULT 0, `show_bottom_nav` INTEGER NOT NULL DEFAULT 1, `show_collapsed_comment_content` INTEGER NOT NULL DEFAULT 0, `show_comment_action_bar_by_default` INTEGER NOT NULL DEFAULT 1, `show_voting_arrows_in_list_view` INTEGER NOT NULL DEFAULT 1, `show_parent_comment_navigation_buttons` INTEGER NOT NULL DEFAULT 0, `navigate_parent_comments_with_volume_buttons` INTEGER NOT NULL DEFAULT 0, `use_custom_tabs` INTEGER NOT NULL DEFAULT 1, `use_private_tabs` INTEGER NOT NULL DEFAULT 0, `secure_window` INTEGER NOT NULL DEFAULT 0, `blur_nsfw` INTEGER NOT NULL DEFAULT 1, `show_text_descriptions_in_navbar` INTEGER NOT NULL DEFAULT 1, `backConfirmationMode` INTEGER NOT NULL DEFAULT 1, `show_post_previews` INTEGER NOT NULL DEFAULT 1)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `font_size` INTEGER NOT NULL DEFAULT 16, `theme` INTEGER NOT NULL DEFAULT 0, `theme_color` INTEGER NOT NULL DEFAULT 0, `viewed_changelog` INTEGER NOT NULL DEFAULT 0, `post_view_mode` INTEGER NOT NULL DEFAULT 0, `show_bottom_nav` INTEGER NOT NULL DEFAULT 1, `show_collapsed_comment_content` INTEGER NOT NULL DEFAULT 0, `show_comment_action_bar_by_default` INTEGER NOT NULL DEFAULT 1, `show_voting_arrows_in_list_view` INTEGER NOT NULL DEFAULT 1, `show_parent_comment_navigation_buttons` INTEGER NOT NULL DEFAULT 0, `navigate_parent_comments_with_volume_buttons` INTEGER NOT NULL DEFAULT 0, `use_custom_tabs` INTEGER NOT NULL DEFAULT 1, `use_private_tabs` INTEGER NOT NULL DEFAULT 0, `secure_window` INTEGER NOT NULL DEFAULT 0, `blur_nsfw` INTEGER NOT NULL DEFAULT 1, `show_text_descriptions_in_navbar` INTEGER NOT NULL DEFAULT 1, `backConfirmationMode` INTEGER NOT NULL DEFAULT 1, `show_post_link_previews` INTEGER NOT NULL DEFAULT 1)",
         "fields": [
           {
             "fieldPath": "id",
@@ -192,8 +192,8 @@
             "defaultValue": "1"
           },
           {
-            "fieldPath": "showPostPreviews",
-            "columnName": "show_post_previews",
+            "fieldPath": "showPostLinkPreviews",
+            "columnName": "show_post_link_previews",
             "affinity": "INTEGER",
             "notNull": true,
             "defaultValue": "1"
@@ -212,7 +212,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '70391a79e30a53a6573461d57c3be6bb')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '57b5a9e25468cc9029f803df34415820')"
     ]
   }
 }

--- a/app/schemas/com.jerboa.db.AppDB/21.json
+++ b/app/schemas/com.jerboa.db.AppDB/21.json
@@ -1,0 +1,218 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "70391a79e30a53a6573461d57c3be6bb",
+    "entities": [
+      {
+        "tableName": "Account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `current` INTEGER NOT NULL, `instance` TEXT NOT NULL, `name` TEXT NOT NULL, `jwt` TEXT NOT NULL, `default_listing_type` INTEGER NOT NULL DEFAULT 0, `default_sort_type` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "current",
+            "columnName": "current",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instance",
+            "columnName": "instance",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "jwt",
+            "columnName": "jwt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "defaultListingType",
+            "columnName": "default_listing_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "defaultSortType",
+            "columnName": "default_sort_type",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "AppSettings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `font_size` INTEGER NOT NULL DEFAULT 16, `theme` INTEGER NOT NULL DEFAULT 0, `theme_color` INTEGER NOT NULL DEFAULT 0, `viewed_changelog` INTEGER NOT NULL DEFAULT 0, `post_view_mode` INTEGER NOT NULL DEFAULT 0, `show_bottom_nav` INTEGER NOT NULL DEFAULT 1, `show_collapsed_comment_content` INTEGER NOT NULL DEFAULT 0, `show_comment_action_bar_by_default` INTEGER NOT NULL DEFAULT 1, `show_voting_arrows_in_list_view` INTEGER NOT NULL DEFAULT 1, `show_parent_comment_navigation_buttons` INTEGER NOT NULL DEFAULT 0, `navigate_parent_comments_with_volume_buttons` INTEGER NOT NULL DEFAULT 0, `use_custom_tabs` INTEGER NOT NULL DEFAULT 1, `use_private_tabs` INTEGER NOT NULL DEFAULT 0, `secure_window` INTEGER NOT NULL DEFAULT 0, `blur_nsfw` INTEGER NOT NULL DEFAULT 1, `show_text_descriptions_in_navbar` INTEGER NOT NULL DEFAULT 1, `backConfirmationMode` INTEGER NOT NULL DEFAULT 1, `show_post_previews` INTEGER NOT NULL DEFAULT 1)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "font_size",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "16"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "theme_color",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "viewedChangelog",
+            "columnName": "viewed_changelog",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "postViewMode",
+            "columnName": "post_view_mode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "showBottomNav",
+            "columnName": "show_bottom_nav",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showCollapsedCommentContent",
+            "columnName": "show_collapsed_comment_content",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "showCommentActionBarByDefault",
+            "columnName": "show_comment_action_bar_by_default",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showVotingArrowsInListView",
+            "columnName": "show_voting_arrows_in_list_view",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showParentCommentNavigationButtons",
+            "columnName": "show_parent_comment_navigation_buttons",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "navigateParentCommentsWithVolumeButtons",
+            "columnName": "navigate_parent_comments_with_volume_buttons",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "useCustomTabs",
+            "columnName": "use_custom_tabs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "usePrivateTabs",
+            "columnName": "use_private_tabs",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "secureWindow",
+            "columnName": "secure_window",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "blurNSFW",
+            "columnName": "blur_nsfw",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showTextDescriptionsInNavbar",
+            "columnName": "show_text_descriptions_in_navbar",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "backConfirmationMode",
+            "columnName": "backConfirmationMode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showPostPreviews",
+            "columnName": "show_post_previews",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '70391a79e30a53a6573461d57c3be6bb')"
+    ]
+  }
+}

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -272,6 +272,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
+                                showPostPreviews = appSettings.showPostPreviews,
                             )
                         }
 
@@ -304,6 +305,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
+                                showPostPreviews = appSettings.showPostPreviews,
                             )
                         }
 
@@ -370,6 +372,7 @@ class MainActivity : AppCompatActivity() {
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
+                            showPostPreviews = appSettings.showPostPreviews,
                             drawerState = drawerState,
                             openImageViewer = navController::toView,
                         )
@@ -403,6 +406,7 @@ class MainActivity : AppCompatActivity() {
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
+                            showPostPreviews = appSettings.showPostPreviews,
                             drawerState = drawerState,
                             openImageViewer = navController::toView,
                         )
@@ -507,6 +511,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
+                                showPostPreview = appSettings.showPostPreviews,
                                 openImageViewer = { url -> navController.toView(url) },
                             )
                         }
@@ -537,6 +542,7 @@ class MainActivity : AppCompatActivity() {
                             navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons,
                             siteViewModel = siteViewModel,
                             blurNSFW = appSettings.blurNSFW,
+                            showPostPreview = appSettings.showPostPreviews,
                             openImageViewer = navController::toView,
                         )
                     }

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -272,7 +272,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
-                                showPostPreviews = appSettings.showPostPreviews,
+                                showPostLinkPreviews = appSettings.showPostLinkPreviews,
                             )
                         }
 
@@ -305,7 +305,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
-                                showPostPreviews = appSettings.showPostPreviews,
+                                showPostLinkPreviews = appSettings.showPostLinkPreviews,
                             )
                         }
 
@@ -372,7 +372,7 @@ class MainActivity : AppCompatActivity() {
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
-                            showPostPreviews = appSettings.showPostPreviews,
+                            showPostLinkPreviews = appSettings.showPostLinkPreviews,
                             drawerState = drawerState,
                             openImageViewer = navController::toView,
                         )
@@ -406,7 +406,7 @@ class MainActivity : AppCompatActivity() {
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
-                            showPostPreviews = appSettings.showPostPreviews,
+                            showPostLinkPreviews = appSettings.showPostLinkPreviews,
                             drawerState = drawerState,
                             openImageViewer = navController::toView,
                         )
@@ -511,7 +511,7 @@ class MainActivity : AppCompatActivity() {
                                 useCustomTabs = appSettings.useCustomTabs,
                                 usePrivateTabs = appSettings.usePrivateTabs,
                                 blurNSFW = appSettings.blurNSFW,
-                                showPostPreview = appSettings.showPostPreviews,
+                                showPostLinkPreview = appSettings.showPostLinkPreviews,
                                 openImageViewer = { url -> navController.toView(url) },
                             )
                         }
@@ -542,7 +542,7 @@ class MainActivity : AppCompatActivity() {
                             navigateParentCommentsWithVolumeButtons = appSettings.navigateParentCommentsWithVolumeButtons,
                             siteViewModel = siteViewModel,
                             blurNSFW = appSettings.blurNSFW,
-                            showPostPreview = appSettings.showPostPreviews,
+                            showPostLinkPreview = appSettings.showPostLinkPreviews,
                             openImageViewer = navController::toView,
                         )
                     }

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -34,7 +34,7 @@ val APP_SETTINGS_DEFAULT = AppSettings(
     blurNSFW = true,
     showTextDescriptionsInNavbar = true,
     backConfirmationMode = 1,
-    showPostPreviews = true,
+    showPostLinkPreviews = true,
 )
 
 @Database(

--- a/app/src/main/java/com/jerboa/db/AppDB.kt
+++ b/app/src/main/java/com/jerboa/db/AppDB.kt
@@ -34,10 +34,11 @@ val APP_SETTINGS_DEFAULT = AppSettings(
     blurNSFW = true,
     showTextDescriptionsInNavbar = true,
     backConfirmationMode = 1,
+    showPostPreviews = true,
 )
 
 @Database(
-    version = 20,
+    version = 21,
     entities = [Account::class, AppSettings::class],
     exportSchema = true,
 )

--- a/app/src/main/java/com/jerboa/db/AppDBMigrations.kt
+++ b/app/src/main/java/com/jerboa/db/AppDBMigrations.kt
@@ -265,7 +265,7 @@ val MIGRATION_20_21 = object : Migration(20, 21) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
         database.execSQL(
-            "ALTER TABLE AppSettings ADD COLUMN show_post_previews INTEGER NOT NULL DEFAULT 1",
+            "ALTER TABLE AppSettings ADD COLUMN show_post_link_previews INTEGER NOT NULL DEFAULT 1",
         )
     }
 }

--- a/app/src/main/java/com/jerboa/db/AppDBMigrations.kt
+++ b/app/src/main/java/com/jerboa/db/AppDBMigrations.kt
@@ -261,6 +261,15 @@ val MIGRATION_19_20 = object : Migration(19, 20) {
     }
 }
 
+val MIGRATION_20_21 = object : Migration(20, 21) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(UPDATE_APP_CHANGELOG_UNVIEWED)
+        database.execSQL(
+            "ALTER TABLE AppSettings ADD COLUMN show_post_previews INTEGER NOT NULL DEFAULT 1",
+        )
+    }
+}
+
 // Don't forget to test your migration with `./gradlew app:connectAndroidTest`
 val MIGRATIONS_LIST = arrayOf(
     MIGRATION_1_2,
@@ -282,4 +291,5 @@ val MIGRATIONS_LIST = arrayOf(
     MIGRATION_17_18,
     MIGRATION_18_19,
     MIGRATION_19_20,
+    MIGRATION_20_21,
 )

--- a/app/src/main/java/com/jerboa/db/entity/AppSettings.kt
+++ b/app/src/main/java/com/jerboa/db/entity/AppSettings.kt
@@ -94,8 +94,8 @@ data class AppSettings(
     )
     val backConfirmationMode: Int,
     @ColumnInfo(
-        name = "show_post_previews",
+        name = "show_post_link_previews",
         defaultValue = "1",
     )
-    val showPostPreviews: Boolean,
+    val showPostLinkPreviews: Boolean,
 )

--- a/app/src/main/java/com/jerboa/db/entity/AppSettings.kt
+++ b/app/src/main/java/com/jerboa/db/entity/AppSettings.kt
@@ -93,4 +93,9 @@ data class AppSettings(
         defaultValue = "1",
     )
     val backConfirmationMode: Int,
+    @ColumnInfo(
+        name = "show_post_previews",
+        defaultValue = "1",
+    )
+    val showPostPreviews: Boolean,
 )

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -90,6 +90,7 @@ fun CommunityActivity(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreviews: Boolean,
 ) {
     Log.d("jerboa", "got to community activity")
     val transferCreatePostDepsViaRoot = navController.rootChannel<CreatePostDeps>()
@@ -388,6 +389,7 @@ fun CommunityActivity(
                             useCustomTabs = useCustomTabs,
                             usePrivateTabs = usePrivateTabs,
                             blurNSFW = blurNSFW,
+                            showPostPreviews = showPostPreviews,
                             openImageViewer = navController::toView,
                             navController = navController,
                         )

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -90,7 +90,7 @@ fun CommunityActivity(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreviews: Boolean,
+    showPostLinkPreviews: Boolean,
 ) {
     Log.d("jerboa", "got to community activity")
     val transferCreatePostDepsViaRoot = navController.rootChannel<CreatePostDeps>()
@@ -389,7 +389,7 @@ fun CommunityActivity(
                             useCustomTabs = useCustomTabs,
                             usePrivateTabs = usePrivateTabs,
                             blurNSFW = blurNSFW,
-                            showPostPreviews = showPostPreviews,
+                            showPostLinkPreviews = showPostLinkPreviews,
                             openImageViewer = navController::toView,
                             navController = navController,
                         )

--- a/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
@@ -170,6 +170,7 @@ fun BottomNavActivity(
                             usePrivateTabs = appSettings.usePrivateTabs,
                             drawerState = drawerState,
                             blurNSFW = appSettings.blurNSFW,
+                            showPostPreviews = appSettings.showPostPreviews,
                         )
                     }
 
@@ -206,6 +207,7 @@ fun BottomNavActivity(
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
+                            showPostPreviews = appSettings.showPostPreviews,
                             drawerState = drawerState,
                             openImageViewer = navController::toView,
                         )
@@ -223,6 +225,7 @@ fun BottomNavActivity(
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
+                            showPostPreviews = appSettings.showPostPreviews,
                             openImageViewer = navController::toView,
                             drawerState = drawerState,
                         )

--- a/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/BottomNavActivity.kt
@@ -170,7 +170,7 @@ fun BottomNavActivity(
                             usePrivateTabs = appSettings.usePrivateTabs,
                             drawerState = drawerState,
                             blurNSFW = appSettings.blurNSFW,
-                            showPostPreviews = appSettings.showPostPreviews,
+                            showPostLinkPreviews = appSettings.showPostLinkPreviews,
                         )
                     }
 
@@ -207,7 +207,7 @@ fun BottomNavActivity(
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
-                            showPostPreviews = appSettings.showPostPreviews,
+                            showPostLinkPreviews = appSettings.showPostLinkPreviews,
                             drawerState = drawerState,
                             openImageViewer = navController::toView,
                         )
@@ -225,7 +225,7 @@ fun BottomNavActivity(
                             useCustomTabs = appSettings.useCustomTabs,
                             usePrivateTabs = appSettings.usePrivateTabs,
                             blurNSFW = appSettings.blurNSFW,
-                            showPostPreviews = appSettings.showPostPreviews,
+                            showPostLinkPreviews = appSettings.showPostLinkPreviews,
                             openImageViewer = navController::toView,
                             drawerState = drawerState,
                         )

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -96,7 +96,7 @@ fun HomeActivity(
     usePrivateTabs: Boolean,
     drawerState: DrawerState,
     blurNSFW: Boolean,
-    showPostPreviews: Boolean,
+    showPostLinkPreviews: Boolean,
 ) {
     Log.d("jerboa", "got to home activity")
     val transferCreatePostDepsViaRoot = navController.rootChannel<CreatePostDeps>()
@@ -148,7 +148,7 @@ fun HomeActivity(
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
                 blurNSFW = blurNSFW,
-                showPostPreviews = showPostPreviews,
+                showPostLinkPreviews = showPostLinkPreviews,
             )
         },
         floatingActionButtonPosition = FabPosition.End,
@@ -189,7 +189,7 @@ fun MainPostListingsContent(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreviews: Boolean,
+    showPostLinkPreviews: Boolean,
 ) {
     val transferPostEditDepsViaRoot = navController.rootChannel<PostEditDeps>()
 
@@ -349,7 +349,7 @@ fun MainPostListingsContent(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
-            showPostPreviews = showPostPreviews,
+            showPostLinkPreviews = showPostLinkPreviews,
             navController = navController,
             openImageViewer = navController::toView,
         )

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -96,6 +96,7 @@ fun HomeActivity(
     usePrivateTabs: Boolean,
     drawerState: DrawerState,
     blurNSFW: Boolean,
+    showPostPreviews: Boolean,
 ) {
     Log.d("jerboa", "got to home activity")
     val transferCreatePostDepsViaRoot = navController.rootChannel<CreatePostDeps>()
@@ -147,6 +148,7 @@ fun HomeActivity(
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
                 blurNSFW = blurNSFW,
+                showPostPreviews = showPostPreviews,
             )
         },
         floatingActionButtonPosition = FabPosition.End,
@@ -187,6 +189,7 @@ fun MainPostListingsContent(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreviews: Boolean,
 ) {
     val transferPostEditDepsViaRoot = navController.rootChannel<PostEditDeps>()
 
@@ -346,6 +349,7 @@ fun MainPostListingsContent(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
+            showPostPreviews = showPostPreviews,
             navController = navController,
             openImageViewer = navController::toView,
         )

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -122,7 +122,7 @@ fun PersonProfileActivity(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreviews: Boolean,
+    showPostLinkPreviews: Boolean,
     openImageViewer: (url: String) -> Unit,
     drawerState: DrawerState,
 ) {
@@ -269,7 +269,7 @@ fun PersonProfileActivity(
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
                 blurNSFW = blurNSFW,
-                showPostPreviews = showPostPreviews,
+                showPostLinkPreviews = showPostLinkPreviews,
                 openImageViewer = openImageViewer,
             )
         },
@@ -300,7 +300,7 @@ fun UserTabs(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreviews: Boolean,
+    showPostLinkPreviews: Boolean,
     openImageViewer: (url: String) -> Unit,
 ) {
     val transferCommentEditDepsViaRoot = navController.rootChannel<CommentEditDeps>()
@@ -564,7 +564,7 @@ fun UserTabs(
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
                                     blurNSFW = blurNSFW,
-                                    showPostPreviews = showPostPreviews,
+                                    showPostLinkPreviews = showPostLinkPreviews,
                                     navController = navController,
                                     openImageViewer = openImageViewer,
                                 )

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -122,6 +122,7 @@ fun PersonProfileActivity(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreviews: Boolean,
     openImageViewer: (url: String) -> Unit,
     drawerState: DrawerState,
 ) {
@@ -268,6 +269,7 @@ fun PersonProfileActivity(
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
                 blurNSFW = blurNSFW,
+                showPostPreviews = showPostPreviews,
                 openImageViewer = openImageViewer,
             )
         },
@@ -298,6 +300,7 @@ fun UserTabs(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreviews: Boolean,
     openImageViewer: (url: String) -> Unit,
 ) {
     val transferCommentEditDepsViaRoot = navController.rootChannel<CommentEditDeps>()
@@ -561,6 +564,7 @@ fun UserTabs(
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
                                     blurNSFW = blurNSFW,
+                                    showPostPreviews = showPostPreviews,
                                     navController = navController,
                                     openImageViewer = openImageViewer,
                                 )

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -148,6 +148,7 @@ fun PostActivity(
     showParentCommentNavigationButtons: Boolean,
     navigateParentCommentsWithVolumeButtons: Boolean,
     blurNSFW: Boolean,
+    showPostPreview: Boolean,
     openImageViewer: (url: String) -> Unit,
 ) {
     Log.d("jerboa", "got to post activity")
@@ -438,6 +439,7 @@ fun PostActivity(
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
                                     blurNSFW = blurNSFW,
+                                    showPostPreview = showPostPreview,
                                     openImageViewer = openImageViewer,
                                     navController = navController,
                                 )

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -148,7 +148,7 @@ fun PostActivity(
     showParentCommentNavigationButtons: Boolean,
     navigateParentCommentsWithVolumeButtons: Boolean,
     blurNSFW: Boolean,
-    showPostPreview: Boolean,
+    showPostLinkPreview: Boolean,
     openImageViewer: (url: String) -> Unit,
 ) {
     Log.d("jerboa", "got to post activity")
@@ -439,7 +439,7 @@ fun PostActivity(
                                     useCustomTabs = useCustomTabs,
                                     usePrivateTabs = usePrivateTabs,
                                     blurNSFW = blurNSFW,
-                                    showPostPreview = showPostPreview,
+                                    showPostLinkPreview = showPostLinkPreview,
                                     openImageViewer = openImageViewer,
                                     navController = navController,
                                 )

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -409,6 +409,7 @@ fun PostBody(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreview: Boolean,
     openImageViewer: (url: String) -> Unit,
     navController: NavController,
     clickBody: () -> Unit = {},
@@ -429,7 +430,7 @@ fun PostBody(
         )
 
         // The metadata card
-        if (fullBody && post.embed_title !== null) {
+        if (fullBody && showPostPreview && post.embed_title !== null) {
             MetadataCard(post = post)
         }
 
@@ -492,6 +493,7 @@ fun PreviewStoryTitleAndMetadata() {
         useCustomTabs = false,
         usePrivateTabs = false,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -509,6 +511,7 @@ fun PreviewSourcePost() {
         useCustomTabs = false,
         usePrivateTabs = false,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -771,6 +774,7 @@ fun PreviewPostListingCard() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -804,6 +808,7 @@ fun PreviewLinkPostListing() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -837,6 +842,7 @@ fun PreviewImagePostListingCard() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -870,6 +876,7 @@ fun PreviewImagePostListingSmallCard() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -903,6 +910,7 @@ fun PreviewLinkNoThumbnailPostListing() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
+        showPostPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -936,6 +944,7 @@ fun PostListing(
     enableDownVotes: Boolean,
     showAvatar: Boolean,
     blurNSFW: Boolean,
+    showPostPreview: Boolean,
     navController: NavController,
     openImageViewer: (url: String) -> Unit,
 ) {
@@ -997,6 +1006,7 @@ fun PostListing(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
+            showPostPreview = showPostPreview,
             navController = navController,
             openImageViewer = openImageViewer,
         )
@@ -1044,6 +1054,7 @@ fun PostListing(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
+            showPostPreview = showPostPreview,
             navController = navController,
             openImageViewer = openImageViewer,
         )
@@ -1396,6 +1407,7 @@ fun PostListingCard(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreview: Boolean,
     navController: NavController,
     openImageViewer: (url: String) -> Unit,
 ) {
@@ -1430,6 +1442,7 @@ fun PostListingCard(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
+            showPostPreview = showPostPreview,
             openImageViewer = openImageViewer,
             clickBody = { onPostClick(postView) },
             navController = navController,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -409,7 +409,7 @@ fun PostBody(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreview: Boolean,
+    showPostLinkPreview: Boolean,
     openImageViewer: (url: String) -> Unit,
     navController: NavController,
     clickBody: () -> Unit = {},
@@ -430,7 +430,7 @@ fun PostBody(
         )
 
         // The metadata card
-        if (fullBody && showPostPreview && post.embed_title !== null) {
+        if (fullBody && showPostLinkPreview && post.embed_title !== null) {
             MetadataCard(post = post)
         }
 
@@ -493,7 +493,7 @@ fun PreviewStoryTitleAndMetadata() {
         useCustomTabs = false,
         usePrivateTabs = false,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -511,7 +511,7 @@ fun PreviewSourcePost() {
         useCustomTabs = false,
         usePrivateTabs = false,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -774,7 +774,7 @@ fun PreviewPostListingCard() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -808,7 +808,7 @@ fun PreviewLinkPostListing() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -842,7 +842,7 @@ fun PreviewImagePostListingCard() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -876,7 +876,7 @@ fun PreviewImagePostListingSmallCard() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -910,7 +910,7 @@ fun PreviewLinkNoThumbnailPostListing() {
         enableDownVotes = true,
         showAvatar = true,
         blurNSFW = true,
-        showPostPreview = true,
+        showPostLinkPreview = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )
@@ -944,7 +944,7 @@ fun PostListing(
     enableDownVotes: Boolean,
     showAvatar: Boolean,
     blurNSFW: Boolean,
-    showPostPreview: Boolean,
+    showPostLinkPreview: Boolean,
     navController: NavController,
     openImageViewer: (url: String) -> Unit,
 ) {
@@ -1006,7 +1006,7 @@ fun PostListing(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
-            showPostPreview = showPostPreview,
+            showPostLinkPreview = showPostLinkPreview,
             navController = navController,
             openImageViewer = openImageViewer,
         )
@@ -1054,7 +1054,7 @@ fun PostListing(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
-            showPostPreview = showPostPreview,
+            showPostLinkPreview = showPostLinkPreview,
             navController = navController,
             openImageViewer = openImageViewer,
         )
@@ -1407,7 +1407,7 @@ fun PostListingCard(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreview: Boolean,
+    showPostLinkPreview: Boolean,
     navController: NavController,
     openImageViewer: (url: String) -> Unit,
 ) {
@@ -1442,7 +1442,7 @@ fun PostListingCard(
             useCustomTabs = useCustomTabs,
             usePrivateTabs = usePrivateTabs,
             blurNSFW = blurNSFW,
-            showPostPreview = showPostPreview,
+            showPostLinkPreview = showPostLinkPreview,
             openImageViewer = openImageViewer,
             clickBody = { onPostClick(postView) },
             navController = navController,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -60,6 +60,7 @@ fun PostListings(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
+    showPostPreviews: Boolean,
     openImageViewer: (url: String) -> Unit,
     navController: NavController,
 ) {
@@ -107,6 +108,7 @@ fun PostListings(
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
                 blurNSFW = blurNSFW,
+                showPostPreview = showPostPreviews,
                 openImageViewer = openImageViewer,
                 navController = navController,
             )
@@ -156,6 +158,7 @@ fun PreviewPostListings() {
         useCustomTabs = false,
         usePrivateTabs = false,
         blurNSFW = true,
+        showPostPreviews = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -60,7 +60,7 @@ fun PostListings(
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     blurNSFW: Boolean,
-    showPostPreviews: Boolean,
+    showPostLinkPreviews: Boolean,
     openImageViewer: (url: String) -> Unit,
     navController: NavController,
 ) {
@@ -108,7 +108,7 @@ fun PostListings(
                 useCustomTabs = useCustomTabs,
                 usePrivateTabs = usePrivateTabs,
                 blurNSFW = blurNSFW,
-                showPostPreview = showPostPreviews,
+                showPostLinkPreview = showPostLinkPreviews,
                 openImageViewer = openImageViewer,
                 navController = navController,
             )
@@ -158,7 +158,7 @@ fun PreviewPostListings() {
         useCustomTabs = false,
         usePrivateTabs = false,
         blurNSFW = true,
-        showPostPreviews = true,
+        showPostLinkPreviews = true,
         openImageViewer = {},
         navController = rememberNavController(),
     )

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -92,7 +92,7 @@ fun LookAndFeelActivity(
     val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
     val blurNSFW = rememberBooleanSettingState(settings.blurNSFW)
     val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
-    val showPostPreviewMode = rememberBooleanSettingState(settings.showPostPreviews)
+    val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -119,7 +119,7 @@ fun LookAndFeelActivity(
                 showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
                 blurNSFW = blurNSFW.value,
                 backConfirmationMode = backConfirmationMode.value,
-                showPostPreviews = showPostPreviewMode.value,
+                showPostLinkPreviews = showPostLinkPreviewMode.value,
             ),
         )
     }
@@ -303,9 +303,9 @@ fun LookAndFeelActivity(
                     onCheckedChange = { updateAppSettings() },
                 )
                 SettingsCheckbox(
-                    state = showPostPreviewMode,
+                    state = showPostLinkPreviewMode,
                     title = {
-                        Text(stringResource(id = R.string.show_post_previews))
+                        Text(stringResource(id = R.string.show_post_link_previews))
                     },
                     onCheckedChange = { updateAppSettings() },
                 )

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -92,6 +92,7 @@ fun LookAndFeelActivity(
     val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
     val blurNSFW = rememberBooleanSettingState(settings.blurNSFW)
     val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
+    val showPostPreviewMode = rememberBooleanSettingState(settings.showPostPreviews)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -118,6 +119,7 @@ fun LookAndFeelActivity(
                 showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
                 blurNSFW = blurNSFW.value,
                 backConfirmationMode = backConfirmationMode.value,
+                showPostPreviews = showPostPreviewMode.value,
             ),
         )
     }
@@ -297,6 +299,13 @@ fun LookAndFeelActivity(
                     state = blurNSFW,
                     title = {
                         Text(stringResource(id = R.string.blur_nsfw))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = showPostPreviewMode,
+                    title = {
+                        Text(stringResource(id = R.string.show_post_previews))
                     },
                     onCheckedChange = { updateAppSettings() },
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,6 +320,7 @@
     <string name="lang_language">Language</string>
     <string name="loading">Loading</string>
     <string name="blur_nsfw">Blur NSFW images</string>
+    <string name="show_post_previews">Show post previews</string>
     <string name="sorttype_tophour">TopHour</string>
     <string name="sorttype_topsixhour">TopSixHour</string>
     <string name="sorttype_toptwelvehour">TopTwelveHour</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -320,7 +320,7 @@
     <string name="lang_language">Language</string>
     <string name="loading">Loading</string>
     <string name="blur_nsfw">Blur NSFW images</string>
-    <string name="show_post_previews">Show post previews</string>
+    <string name="show_post_link_previews">Show post link previews</string>
     <string name="sorttype_tophour">TopHour</string>
     <string name="sorttype_topsixhour">TopSixHour</string>
     <string name="sorttype_toptwelvehour">TopTwelveHour</string>


### PR DESCRIPTION
In an issue somewhere someone suggested that titles and bodies were being duplicated when it was actually just that the user copied the title and article description into their post. I thought maybe adding an option to disable the preview would be a good idea.

When enabled/current behavior:
![image](https://github.com/dessalines/jerboa/assets/1341797/181a42d3-8958-45fb-9380-8ecaf2d52052)

After with disabled:
![image](https://github.com/dessalines/jerboa/assets/1341797/a68f4650-24d5-4c28-8c5b-138bf051508b)
