### PR TITLE
Prevent duplicate accounts from logging in

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -235,7 +235,7 @@ fun LoginForm(
         )
         Button(
             enabled = isValid && !loading,
-            onClick = { onClickLogin(form, instance) },
+            onClick = { onClickLogin(form, instance.lowercase()) },
             modifier = Modifier.padding(top = 10.dp),
         ) {
             if (loading) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,4 +344,5 @@
     <string name="exit">Exit</string>
     <string name="back_dialog_title">Are you sure you want to exit?</string>
     <string name="failed_saving_image">Failed to save image!</string>
+    <string name="login_already_logged_in">You are already logged in with this account</string>
 </resources>


### PR DESCRIPTION
Fixes #987 

https://github.com/dessalines/jerboa/assets/67873169/8fbaf24c-07cb-4616-a721-10d9bfa8e4ed

I used name + instance to define duplicate because person.Id could be duplicate for two separate accounts on different instances.

I do feel like this whole login function with its numerous changeLemmyInstances should be refactored to use createTempInstance and only be swapped on login.