### PR TITLE
Fetch unreadCount on refresh, make unreadCount use less API calls, fix mark unread reply bug

### DIFF
--- a/app/src/main/java/com/jerboa/api/Http.kt
+++ b/app/src/main/java/com/jerboa/api/Http.kt
@@ -29,7 +29,7 @@ const val VERSION = "v3"
 const val DEFAULT_INSTANCE = "lemmy.ml"
 const val MINIMUM_API_VERSION: String = "0.18"
 val REDACTED_QUERY_PARAMS = setOf("auth")
-val REDACTED_BODY_FIELDS = setOf("jwt", "password")
+val REDACTED_BODY_FIELDS = setOf("jwt", "password", "auth")
 
 interface API {
     @GET("site")

--- a/app/src/main/java/com/jerboa/model/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/SiteViewModel.kt
@@ -86,6 +86,22 @@ class SiteViewModel : ViewModel() {
         }
     }
 
+    fun updateUnreadCounts(dReplies: Int = 0, dMentions: Int = 0, dMessages: Int = 0) {
+        when (val res = unreadCountRes) {
+            is ApiState.Success -> {
+                unreadCountRes = ApiState.Success(
+                    GetUnreadCountResponse(
+                        private_messages = res.data.private_messages + dMessages,
+                        mentions = res.data.mentions + dMentions,
+                        replies = res.data.replies + dReplies,
+                    ),
+                )
+            }
+
+            else -> {}
+        }
+    }
+
     fun showAvatar(): Boolean {
         return when (val res = siteRes) {
             is ApiState.Success -> res.data.my_user?.local_user_view?.local_user?.show_avatars ?: true

--- a/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/InboxActivity.kt
@@ -276,6 +276,7 @@ fun InboxTabs(
                                     inboxViewModel.getFormReplies(acct.jwt),
                                     ApiState.Refreshing,
                                 )
+                                siteViewModel.fetchUnreadCounts(GetUnreadCount(acct.jwt))
                             }
                         },
                     )
@@ -290,7 +291,7 @@ fun InboxTabs(
                         }
                     }
 
-                    val markAsRead = { crv: CommentReplyView ->
+                    val markAsRead: (CommentReplyView) -> Unit = { crv: CommentReplyView ->
                         account?.also { acct ->
                             inboxViewModel.markReplyAsRead(
                                 MarkCommentReplyAsRead(
@@ -299,11 +300,7 @@ fun InboxTabs(
                                     auth = acct.jwt,
                                 ),
                                 onSuccess = {
-                                    siteViewModel.fetchUnreadCounts(
-                                        GetUnreadCount(
-                                            auth = acct.jwt,
-                                        ),
-                                    )
+                                    siteViewModel.updateUnreadCounts(dReplies = if (crv.comment_reply.read) 1 else -1)
                                 },
                             )
                         }
@@ -379,7 +376,7 @@ fun InboxTabs(
                                                     )
                                                 }
                                             },
-                                            onMarkAsReadClick = { crv -> markAsRead(crv) },
+                                            onMarkAsReadClick = markAsRead,
                                             onReportClick = { cv ->
                                                 appState.toComment(id = cv.comment.id)
                                             },
@@ -389,7 +386,10 @@ fun InboxTabs(
                                             },
                                             onCommentClick = { crv ->
                                                 goToComment(crv)
-                                                markAsRead(crv)
+                                                // Do not mark already read reply as read
+                                                if (!crv.comment_reply.read) {
+                                                    markAsRead(crv)
+                                                }
                                             },
                                             onCommunityClick = { community ->
                                                 appState.toCommunity(id = community.id)
@@ -455,6 +455,7 @@ fun InboxTabs(
                                     inboxViewModel.getFormMentions(acct.jwt),
                                     ApiState.Refreshing,
                                 )
+                                siteViewModel.fetchUnreadCounts(GetUnreadCount(acct.jwt))
                             }
                         },
                     )
@@ -541,11 +542,7 @@ fun InboxTabs(
                                                             auth = acct.jwt,
                                                         ),
                                                         onSuccess = {
-                                                            siteViewModel.fetchUnreadCounts(
-                                                                GetUnreadCount(
-                                                                    auth = acct.jwt,
-                                                                ),
-                                                            )
+                                                            siteViewModel.updateUnreadCounts(dMentions = if (pm.person_mention.read) 1 else -1)
                                                         },
                                                     )
                                                 }
@@ -624,6 +621,7 @@ fun InboxTabs(
                                     inboxViewModel.getFormMessages(acct.jwt),
                                     ApiState.Refreshing,
                                 )
+                                siteViewModel.fetchUnreadCounts(GetUnreadCount(acct.jwt))
                             }
                         },
                     )
@@ -677,11 +675,7 @@ fun InboxTabs(
                                                             auth = acct.jwt,
                                                         ),
                                                         onSuccess = {
-                                                            siteViewModel.fetchUnreadCounts(
-                                                                GetUnreadCount(
-                                                                    auth = acct.jwt,
-                                                                ),
-                                                            )
+                                                            siteViewModel.updateUnreadCounts(dMessages = if (pm.private_message.read) 1 else -1)
                                                         },
                                                     )
                                                 },

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -1067,6 +1067,7 @@ fun PostListing(
             openLink = openLink,
             showPostLinkPreview = showPostLinkPreview,
             openImageViewer = openImageViewer,
+            showIfRead = showIfRead,
         )
 
         PostViewMode.List -> PostListingList(
@@ -1097,6 +1098,7 @@ fun PostListing(
             blurNSFW = blurNSFW,
             openImageViewer = openImageViewer,
             openLink = openLink,
+            // TODO showIfRead?
         )
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -1067,7 +1067,6 @@ fun PostListing(
             openLink = openLink,
             showPostLinkPreview = showPostLinkPreview,
             openImageViewer = openImageViewer,
-            showIfRead = showIfRead,
         )
 
         PostViewMode.List -> PostListingList(
@@ -1098,7 +1097,6 @@ fun PostListing(
             blurNSFW = blurNSFW,
             openImageViewer = openImageViewer,
             openLink = openLink,
-            // TODO showIfRead?
         )
     }
 }


### PR DESCRIPTION
- Fixes missing redaction of AUTH in body
- Fixes refresh not getting unreadCount
- Removes the API calls for unreadCount on markRead by applying smart logic
- Fixes clicking on a read reply marking it as unread

https://github.com/dessalines/jerboa/assets/67873169/526cc611-4efc-4289-b28a-02afeec6e3e6

