### PR TITLE
Fix Inbox Spanish Translation, closes #1110

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -277,7 +277,7 @@
     <string name="sorttype_newcomments">Con Nuevos Comentarios</string>
     <string name="bottomBar_label_home">Inicio</string>
     <string name="bottomBar_label_search">Buscar</string>
-    <string name="bottomBar_label_inbox">Bandeja de Entrada</string>
+    <string name="bottomBar_label_inbox">Entrada</string>
     <string name="bottomBar_label_bookmarks">Guardados</string>
     <string name="bottomBar_label_profile">Perfil</string>
     <string name="look_and_feel_secure_window">Prevenir capturas de pantalla</string>


### PR DESCRIPTION
In this context "Inbox" can be translated as "Entrada" instead of "Bandeja de Entrada" and thus avoid breaking the bottom navbar.

![inbox_fixed](https://github.com/dessalines/jerboa/assets/572924/bf530f48-a876-4f16-85f6-ad18d55cd26e)
