### PR TITLE
Update deps, gradle and target SDK 34

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,13 +12,13 @@ plugins {
 apply(from = "update_instances.gradle.kts")
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.jerboa"
         namespace = "com.jerboa"
         minSdk = 26
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 41
         versionName = "0.0.41"
 
@@ -99,8 +99,6 @@ android {
 }
 
 dependencies {
-    val composeVersion = "1.5.0-beta03"
-
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.github.alorma:compose-settings-ui-m3:0.27.0")
 
@@ -154,10 +152,11 @@ dependencies {
     // Unfortunately, ui tooling, and the markdown thing, still brings in the other material2 dependencies
     implementation("androidx.compose.material3:material3:1.1.1")
     implementation("androidx.compose.material3:material3-window-size-class:1.1.1")
+    val composeVersion = "1.5.0-rc01"
     implementation("androidx.compose.material:material-icons-extended:$composeVersion")
     implementation("org.ocpsoft.prettytime:prettytime:5.0.6.Final")
     implementation("io.coil-kt:coil-compose:2.4.0")
-    implementation("androidx.navigation:navigation-compose:2.7.0-beta01")
+    implementation("androidx.navigation:navigation-compose:2.7.0-rc01")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
@@ -179,4 +178,7 @@ dependencies {
     baselineProfile(project(":benchmarks"))
 
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5")
+    implementation("me.saket.swipe:swipe:1.2.0")
+
+
 }

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -21,12 +21,12 @@ android {
     }
 
     defaultConfig {
+        testInstrumentationRunnerArguments += mapOf("suppressErrors" to "EMULATOR")
         minSdk = 26
         targetSdk =  33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         // Only use the emulator to test benchmarks
-        testInstrumentationRunnerArguments += mapOf("androidx.benchmark.suppressErrors" to "EMULATOR")
     }
 
     targetProjectPath = ":app"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,13 +8,13 @@ buildscript {
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id("com.android.application") version "8.0.2" apply false
-    id("com.android.library") version "8.0.2" apply false
+    id("com.android.application") version "8.1.0" apply false
+    id("com.android.library") version "8.1.0" apply false
     id("org.jetbrains.kotlin.android") version "1.8.20" apply false
     id("com.github.ben-manes.versions") version "0.42.0"
     id("org.jmailen.kotlinter") version "3.15.0" apply false
     id("com.google.devtools.ksp") version "1.8.21-1.0.11" apply false
-    id( "com.android.test") version "8.0.2" apply false
+    id( "com.android.test") version "8.1.0" apply false
     id( "androidx.baselineprofile") version "1.2.0-alpha13" apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=a62c5f99585dd9e1f95dab7b9415a0e698fa9dd1e6c38537faa81ac078f4d23e
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Deps needed to be updated, compose 1.5 requires that we target SDk 34. So  I did that and test the app. It works fine.

The only issue is that the status bar seems to be wrong.

That's probably an issue with compose though cuz we don't manually set nowhere how high the status bar should be.
I'll make a separate issue to look into it later.

![image](https://github.com/dessalines/jerboa/assets/67873169/f165ba09-fc95-4c6e-a036-6770b807706e)
