### PR TITLE
Fix crach on double clicking back button - fixes #1087

### DIFF
--- a/app/src/main/java/com/jerboa/JerboaAppState.kt
+++ b/app/src/main/java/com/jerboa/JerboaAppState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -21,6 +22,7 @@ import com.jerboa.model.ReplyItem
 import com.jerboa.ui.components.common.Route
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -46,6 +48,8 @@ class JerboaAppState(
     val navController: NavHostController,
     val coroutineScope: CoroutineScope,
 ) {
+
+    private val popBackStackBusy = mutableStateOf(false)
 
     fun toPrivateMessageReply(
         channel: RouteChannel<PrivateMessageDeps>,
@@ -141,7 +145,17 @@ class JerboaAppState(
         navController.navigate(Route.CommunityListArgs.makeRoute(select = "$select"))
     }
 
-    fun popBackStack(): Boolean = navController.popBackStack()
+    fun popBackStack(): Boolean = if (!popBackStackBusy.value) {
+        popBackStackBusy.value = true
+        navController.popBackStack().also {
+            coroutineScope.launch {
+                delay(300)
+                popBackStackBusy.value = false
+            }
+        }
+    } else {
+        false
+    }
 
     fun navigateUp(): Boolean = navController.navigateUp()
 


### PR DESCRIPTION
Issue link - [#1087](https://github.com/dessalines/jerboa/issues/1087) 

Added debounce to `JerboaAppState.popBackStack()`
The crash happens on all screens using a back button
All of the back buttons use `JerboaAppState.popBackStack() ` and only they use it
This is a known issue with the navigator, it most likely will not be fixed

Alternative fix - use `navigateUp()`?

Also, using the if as the function body doesn't look very pretty to me, but using other kotlin blocks or monads added complications