### PR TITLE
Remove account_approved and account_email_verified add account_banned checks

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
@@ -176,8 +176,8 @@ fun RepliedPost(
             score = postView.counts.score,
             onPersonClick = onPersonClick,
             isModerator = isModerator,
-            showAvatar = true,
-            showScores = true,
+            showAvatar = showAvatar,
+            showScores = showScores,
 
         )
         val text = postView.post.body ?: run { postView.post.name }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -353,7 +353,7 @@
     <string name="private_message_success">Message sent</string>
     <string name="retry">Retry</string>
     <string name="no_network">No network connection found</string>
-    <string name="verification_connection_failed_instance">Failed to connect to instance</string>
+    <string name="verification_connection_failed_instance">Failed to connect to instance (%s)</string>
     <string name="verification_account_deleted">Your account might have been deleted</string>
     <string name="verification_failed_retrieve_profile">Failed to retrieve your profile</string>
     <string name="verification_token_expired">Your JWT token has expired</string>
@@ -371,6 +371,6 @@
     <string name="login_view_model_registration_pending">Registration approval is still pending</string>
     <string name="login_view_model_missing_totp">TOTP token is missing</string>
     <string name="login_view_model_incorrect_totp">Incorrect TOTP token given</string>
-    <string name="verification_failed_instance">This instance is experiencing internal server errors</string>
+    <string name="verification_failed_instance">This instance (%s) is experiencing internal server errors</string>
     <string name="verification_failed_user_banned">Your account is banned until %s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -360,8 +360,6 @@
     <string name="verification_login_again">Login again</string>
     <string name="verification_failed_verify_token">Failed to verify JWT token</string>
     <string name="verification_failed_retrieve_site">Failed to retrieve site info</string>
-    <string name="verification_email_failed">Email needs to be verified</string>
-    <string name="verification_application_approval_failed">Your application has not been approved yet</string>
     <string name="verification_no_account">This action requires an account</string>
     <string name="verification_delete_account">Remove your account</string>
     <string name="verification_account_not_read">This account is not in a ready state yet.</string>
@@ -374,4 +372,5 @@
     <string name="login_view_model_missing_totp">TOTP token is missing</string>
     <string name="login_view_model_incorrect_totp">Incorrect TOTP token given</string>
     <string name="verification_failed_instance">This instance is experiencing internal server errors</string>
+    <string name="verification_failed_user_banned">Your account is banned until %s</string>
 </resources>


### PR DESCRIPTION
I am not 100% sure but I believe account approval and email approval should only be done during login. The instance owner could turn these on after they are logged in and then it should not impede the the user but these checks will.

I also added account banned but I am unsure if a banned user can still do actions with his account. So I assumed not.