### PR TITLE
Add share functionality to imageviewer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,6 @@ dependencies {
     implementation("com.google.accompanist:accompanist-pager:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-pager-indicators:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-flowlayout:$accompanistVersion")
-    implementation("com.google.accompanist:accompanist-permissions:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-navigation-animation:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-systemuicontroller:$accompanistVersion")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -137,6 +137,16 @@
                 android:name="com.crazylegend.crashyreporter.initializer.CrashyInitializer"
                 android:value="androidx.startup" />
         </provider>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -690,7 +690,7 @@ class MainActivity : AppCompatActivity() {
                     ) {
                         val args = Route.ViewArgs(it)
 
-                        ImageViewer(url = args.url, onBackRequest = appState::popBackStack)
+                        ImageViewer(url = args.url, appState = appState)
                     }
 
                     composable(

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -18,6 +18,10 @@ import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
 import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -56,6 +60,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.navigation.NavController
 import arrow.core.compareTo
+import coil.annotation.ExperimentalCoilApi
+import coil.imageLoader
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.jerboa.api.API
@@ -77,6 +83,8 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 import org.ocpsoft.prettytime.PrettyTime
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserException
@@ -1516,3 +1524,30 @@ fun ConnectivityManager?.isCurrentlyConnected(): Boolean =
         ?.let(::getNetworkCapabilities)
         ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
         ?: false
+
+/**
+ * When calling this, you must call ActivityResultLauncher.unregister()
+ * on the returned ActivityResultLauncher when the launcher is no longer
+ * needed to release any values that might be captured in the registered callback.
+ */
+fun <I, O> ComponentActivity.registerActivityResultLauncher(
+    contract: ActivityResultContract<I, O>,
+    callback: ActivityResultCallback<O>,
+): ActivityResultLauncher<I> {
+    val key = UUID.randomUUID().toString()
+    return activityResultRegistry.register(key, contract, callback)
+}
+
+/**
+ *  Returns a [InputStream] for the data of the URL, but it also checks the cache first!
+ */
+@OptIn(ExperimentalCoilApi::class)
+fun Context.getInputStream(url: String): InputStream {
+    val snapshot = this.imageLoader.diskCache?.openSnapshot(url)
+
+    return snapshot?.use {
+        it.data.toFile().inputStream()
+    } ?: API.httpClient.newCall(Request(url.toHttpUrl())).execute().use { response ->
+        response.body.byteStream()
+    }
+}

--- a/app/src/main/java/com/jerboa/util/UserActions.kt
+++ b/app/src/main/java/com/jerboa/util/UserActions.kt
@@ -1,0 +1,105 @@
+package com.jerboa.util
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build.VERSION.SDK_INT
+import android.util.Log
+import android.webkit.MimeTypeMap
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
+import com.jerboa.MainActivity
+import com.jerboa.R
+import com.jerboa.getInputStream
+import com.jerboa.registerActivityResultLauncher
+import com.jerboa.saveBitmap
+import com.jerboa.saveBitmapP
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+
+fun storeImage(scope: CoroutineScope, ctx: Context, url: String) {
+    if (SDK_INT < 29 && ctx.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+        val appCompat = (ctx as MainActivity)
+
+        appCompat.registerActivityResultLauncher(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) {
+                actualStoreImage(scope, ctx, url)
+            } else {
+                Toast.makeText(ctx, ctx.getString(R.string.permission_denied), Toast.LENGTH_SHORT).show()
+            }
+        }.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    } else {
+        actualStoreImage(scope, ctx, url)
+    }
+}
+
+private fun actualStoreImage(scope: CoroutineScope, ctx: Context, url: String) {
+    scope.launch {
+        saveImage(url, ctx)
+    }
+}
+
+// Needs to check for permission before this for API 29 and below
+private suspend fun saveImage(url: String, context: Context) {
+    Toast.makeText(context, context.getString(R.string.saving_image), Toast.LENGTH_SHORT).show()
+
+    val fileName = Uri.parse(url).pathSegments.last()
+    val extension = MimeTypeMap.getFileExtensionFromUrl(url)
+    val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+
+    try {
+        withContext(Dispatchers.IO) {
+            context.getInputStream(url).use {
+                if (SDK_INT < 29) {
+                    saveBitmapP(context, it, mimeType, fileName)
+                } else {
+                    saveBitmap(context, it, mimeType, fileName)
+                }
+            }
+        }
+        Toast.makeText(context, context.getString(R.string.saved_image), Toast.LENGTH_SHORT).show()
+    } catch (e: IOException) {
+        Log.d("image", "failed saving image", e)
+        Toast.makeText(context, R.string.failed_saving_image, Toast.LENGTH_SHORT).show()
+    } catch (e: IllegalArgumentException) {
+        Log.d("image", "invalid URL", e)
+        Toast.makeText(context, R.string.failed_saving_image, Toast.LENGTH_SHORT).show()
+    }
+}
+
+fun shareImage(scope: CoroutineScope, ctx: Context, url: String) {
+    try {
+        val fileName = Uri.parse(url).pathSegments.last()
+
+        val file = File(ctx.cacheDir, fileName)
+
+        scope.launch(Dispatchers.IO) {
+            ctx.getInputStream(url).use { input ->
+                file.outputStream().use {
+                    input.copyTo(it)
+                }
+            }
+        }
+
+        val uri = FileProvider.getUriForFile(ctx, ctx.packageName + ".provider", file)
+        val shareIntent = Intent()
+        shareIntent.setAction(Intent.ACTION_SEND)
+        shareIntent.putExtra(Intent.EXTRA_STREAM, uri)
+        shareIntent.setType("image/*")
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        ctx.startActivity(Intent.createChooser(shareIntent, ctx.getString(R.string.share)))
+    } catch (e: IOException) {
+        Log.d("share", "failed", e)
+        Toast.makeText(ctx, R.string.failed_saving_image, Toast.LENGTH_SHORT).show()
+    } catch (e: Exception) {
+        Log.d("image", "invalid URL", e)
+        Toast.makeText(ctx, R.string.failed_saving_image, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,5 +377,6 @@
     <string name="login_view_model_incorrect_totp">Incorrect TOTP token given</string>
     <string name="verification_failed_instance">This instance (%s) is experiencing internal server errors</string>
     <string name="verification_failed_user_banned">Your account is banned until %s</string>
+    <string name="share">Share</string>
 
 </resources>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="cache" path="/" />
+</paths>


### PR DESCRIPTION
Add share button to the imageviewer,

also fixed the issue where it would cancel the download if you closed the imageviewer before it finishes. Also made the download now check the cache first to prevent unnecessary network call and it uses httpClient.

Remove permission dep, as I don't like permission stuff being a composable. Limits future reuse