### PR TITLE
Make app bar 'more' buttons use dropdowns rather than dialogs

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/DropdownMenu.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/DropdownMenu.kt
@@ -1,6 +1,7 @@
 package com.jerboa.ui.components.common
 
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,7 +15,12 @@ fun MenuItem(
     onClick: () -> Unit,
 ) {
     DropdownMenuItem(
-        text = { Text(text) },
+        text = {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
         leadingIcon = {
             icon?.also { ico ->
                 InboxIconAndBadge(

--- a/app/src/main/java/com/jerboa/ui/components/common/DropdownMenu.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/DropdownMenu.kt
@@ -1,0 +1,30 @@
+package com.jerboa.ui.components.common
+
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+
+@Composable
+fun MenuItem(
+    text: String,
+    modifier: Modifier = Modifier,
+    icon: ImageVector? = null,
+    onClick: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = { Text(text) },
+        leadingIcon = {
+            icon?.also { ico ->
+                InboxIconAndBadge(
+                    icon = ico,
+                    contentDescription = text,
+                    iconBadgeCount = null,
+                )
+            }
+        },
+        onClick = onClick,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -18,8 +18,8 @@ import com.jerboa.datatypes.types.CommunityView
 import com.jerboa.datatypes.types.SortType
 import com.jerboa.datatypes.types.SubscribedType
 import com.jerboa.getLocalizedSortingTypeShortName
-import com.jerboa.ui.components.common.IconAndTextDrawerItem
 import com.jerboa.ui.components.common.LargerCircularIcon
+import com.jerboa.ui.components.common.MenuItem
 import com.jerboa.ui.components.common.PictrsBannerImage
 import com.jerboa.ui.components.common.SortOptionsDialog
 import com.jerboa.ui.components.common.SortTopOptionsDialog
@@ -164,18 +164,6 @@ fun CommunityHeader(
         )
     }
 
-    if (showMoreOptions) {
-        CommunityMoreDialog(
-            onDismissRequest = { showMoreOptions = false },
-            onClickRefresh = onClickRefresh,
-            onBlockCommunityClick = {
-                showMoreOptions = false
-                onBlockCommunityClick()
-            },
-            onClickCommunityInfo = onClickCommunityInfo,
-        )
-    }
-
     TopAppBar(
         scrollBehavior = scrollBehavior,
         title = {
@@ -201,12 +189,24 @@ fun CommunityHeader(
                     contentDescription = stringResource(R.string.community_sortBy),
                 )
             }
-            IconButton(onClick = {
-                showMoreOptions = !showMoreOptions
-            }) {
-                Icon(
-                    Icons.Outlined.MoreVert,
-                    contentDescription = stringResource(R.string.moreOptions),
+            Box {
+                IconButton(onClick = {
+                    showMoreOptions = !showMoreOptions
+                }) {
+                    Icon(
+                        Icons.Outlined.MoreVert,
+                        contentDescription = stringResource(R.string.moreOptions),
+                    )
+                }
+                CommunityMoreDropdown(
+                    expanded = showMoreOptions,
+                    onDismissRequest = { showMoreOptions = false },
+                    onClickRefresh = onClickRefresh,
+                    onBlockCommunityClick = {
+                        showMoreOptions = false
+                        onBlockCommunityClick()
+                    },
+                    onClickCommunityInfo = onClickCommunityInfo,
                 )
             }
         },
@@ -235,39 +235,37 @@ fun CommunityHeaderTitle(
 }
 
 @Composable
-fun CommunityMoreDialog(
+fun CommunityMoreDropdown(
+    expanded: Boolean,
     onDismissRequest: () -> Unit,
     onBlockCommunityClick: () -> Unit,
     onClickRefresh: () -> Unit,
     onClickCommunityInfo: () -> Unit,
 ) {
-    AlertDialog(
+    DropdownMenu(
+        expanded = expanded,
         onDismissRequest = onDismissRequest,
-        text = {
-            Column {
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.community_refresh),
-                    icon = Icons.Outlined.Refresh,
-                    onClick = {
-                        onDismissRequest()
-                        onClickRefresh()
-                    },
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.community_community_info),
-                    icon = Icons.Outlined.Info,
-                    onClick = {
-                        onClickCommunityInfo()
-                        onDismissRequest()
-                    },
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.community_block_community),
-                    icon = Icons.Outlined.Block,
-                    onClick = onBlockCommunityClick,
-                )
-            }
-        },
-        confirmButton = {},
-    )
+    ) {
+        MenuItem(
+            text = stringResource(R.string.community_refresh),
+            icon = Icons.Outlined.Refresh,
+            onClick = {
+                onDismissRequest()
+                onClickRefresh()
+            },
+        )
+        MenuItem(
+            text = stringResource(R.string.community_community_info),
+            icon = Icons.Outlined.Info,
+            onClick = {
+                onClickCommunityInfo()
+                onDismissRequest()
+            },
+        )
+        MenuItem(
+            text = stringResource(R.string.community_block_community),
+            icon = Icons.Outlined.Block,
+            onClick = onBlockCommunityClick,
+        )
+    }
 }

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -1,5 +1,6 @@
 package com.jerboa.ui.components.home
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -10,7 +11,7 @@ import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Sort
 import androidx.compose.material.icons.outlined.ViewAgenda
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,8 +40,8 @@ import com.jerboa.datatypes.types.SortType
 import com.jerboa.datatypes.types.Tagline
 import com.jerboa.getLocalizedListingTypeName
 import com.jerboa.getLocalizedSortingTypeShortName
-import com.jerboa.ui.components.common.IconAndTextDrawerItem
 import com.jerboa.ui.components.common.ListingTypeOptionsDialog
+import com.jerboa.ui.components.common.MenuItem
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.PostViewModeDialog
 import com.jerboa.ui.components.common.SortOptionsDialog
@@ -122,18 +123,6 @@ fun HomeHeader(
         )
     }
 
-    if (showMoreOptions) {
-        HomeMoreDialog(
-            onDismissRequest = { showMoreOptions = false },
-            onClickRefresh = onClickRefresh,
-            onClickShowPostViewModeDialog = {
-                showMoreOptions = false
-                showPostViewModeOptions = !showPostViewModeOptions
-            },
-            onClickSiteInfo = onClickSiteInfo,
-        )
-    }
-
     if (showPostViewModeOptions) {
         PostViewModeDialog(
             onDismissRequest = { showPostViewModeOptions = false },
@@ -178,12 +167,25 @@ fun HomeHeader(
                     contentDescription = stringResource(R.string.selectSort),
                 )
             }
-            IconButton(modifier = Modifier.testTag("jerboa:options"), onClick = {
-                showMoreOptions = !showMoreOptions
-            }) {
-                Icon(
-                    Icons.Outlined.MoreVert,
-                    contentDescription = stringResource(R.string.moreOptions),
+            Box {
+                IconButton(
+                    modifier = Modifier.testTag("jerboa:options"),
+                    onClick = { showMoreOptions = !showMoreOptions },
+                ) {
+                    Icon(
+                        Icons.Outlined.MoreVert,
+                        contentDescription = stringResource(R.string.moreOptions),
+                    )
+                }
+                HomeMoreDropdown(
+                    expanded = showMoreOptions,
+                    onDismissRequest = { showMoreOptions = false },
+                    onClickRefresh = onClickRefresh,
+                    onClickShowPostViewModeDialog = {
+                        showMoreOptions = false
+                        showPostViewModeOptions = !showPostViewModeOptions
+                    },
+                    onClickSiteInfo = onClickSiteInfo,
                 )
             }
         },
@@ -210,47 +212,45 @@ fun HomeHeaderPreview() {
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun HomeMoreDialog(
+fun HomeMoreDropdown(
+    expanded: Boolean,
     onDismissRequest: () -> Unit,
     onClickSiteInfo: () -> Unit,
     onClickRefresh: () -> Unit,
     onClickShowPostViewModeDialog: () -> Unit,
 ) {
-    AlertDialog(
+    DropdownMenu(
+        expanded = expanded,
         onDismissRequest = onDismissRequest,
         modifier = Modifier.semantics { testTagsAsResourceId = true },
-        text = {
-            Column {
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.home_refresh),
-                    icon = Icons.Outlined.Refresh,
-                    onClick = {
-                        onDismissRequest()
-                        onClickRefresh()
-                    },
-                    modifier = Modifier.testTag("jerboa:refresh"),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.home_post_view_mode),
-                    icon = Icons.Outlined.ViewAgenda,
-                    onClick = {
-                        onDismissRequest()
-                        onClickShowPostViewModeDialog()
-                    },
-                    modifier = Modifier.testTag("jerboa:postviewmode"),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.home_site_info),
-                    icon = Icons.Outlined.Info,
-                    onClick = {
-                        onClickSiteInfo()
-                        onDismissRequest()
-                    },
-                )
-            }
-        },
-        confirmButton = {},
-    )
+    ) {
+        MenuItem(
+            text = stringResource(R.string.home_refresh),
+            icon = Icons.Outlined.Refresh,
+            onClick = {
+                onDismissRequest()
+                onClickRefresh()
+            },
+            modifier = Modifier.testTag("jerboa:refresh"),
+        )
+        MenuItem(
+            text = stringResource(R.string.home_post_view_mode),
+            icon = Icons.Outlined.ViewAgenda,
+            onClick = {
+                onDismissRequest()
+                onClickShowPostViewModeDialog()
+            },
+            modifier = Modifier.testTag("jerboa:postviewmode"),
+        )
+        MenuItem(
+            text = stringResource(R.string.home_site_info),
+            icon = Icons.Outlined.Info,
+            onClick = {
+                onClickSiteInfo()
+                onDismissRequest()
+            },
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -36,8 +36,8 @@ import com.jerboa.datatypes.types.SortType
 import com.jerboa.getLocalizedSortingTypeShortName
 import com.jerboa.personNameShown
 import com.jerboa.ui.components.common.DotSpacer
-import com.jerboa.ui.components.common.IconAndTextDrawerItem
 import com.jerboa.ui.components.common.LargerCircularIcon
+import com.jerboa.ui.components.common.MenuItem
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.PictrsBannerImage
 import com.jerboa.ui.components.common.SortOptionsDialog
@@ -186,24 +186,6 @@ fun PersonProfileHeader(
         )
     }
 
-    if (showMoreOptions) {
-        PersonProfileMoreDialog(
-            onDismissRequest = { showMoreOptions = false },
-            onBlockPersonClick = {
-                showMoreOptions = false
-                onBlockPersonClick()
-            },
-            onReportPersonClick = {
-                showMoreOptions = false
-                onReportPersonClick()
-            },
-            onMessagePersonClick = {
-                showMoreOptions = false
-                onMessagePersonClick()
-            },
-        )
-    }
-
     TopAppBar(
         scrollBehavior = scrollBehavior,
         title = {
@@ -239,12 +221,30 @@ fun PersonProfileHeader(
                 )
             }
             if (!myProfile && isLoggedIn()) {
-                IconButton(onClick = {
-                    showMoreOptions = !showMoreOptions
-                }) {
-                    Icon(
-                        Icons.Outlined.MoreVert,
-                        contentDescription = stringResource(R.string.moreOptions),
+                Box {
+                    IconButton(onClick = {
+                        showMoreOptions = !showMoreOptions
+                    }) {
+                        Icon(
+                            Icons.Outlined.MoreVert,
+                            contentDescription = stringResource(R.string.moreOptions),
+                        )
+                    }
+                    PersonProfileMoreDropdown(
+                        expanded = showMoreOptions,
+                        onDismissRequest = { showMoreOptions = false },
+                        onBlockPersonClick = {
+                            showMoreOptions = false
+                            onBlockPersonClick()
+                        },
+                        onReportPersonClick = {
+                            showMoreOptions = false
+                            onReportPersonClick()
+                        },
+                        onMessagePersonClick = {
+                            showMoreOptions = false
+                            onMessagePersonClick()
+                        },
                     )
                 }
             }
@@ -270,33 +270,31 @@ fun PersonProfileHeaderTitle(
 }
 
 @Composable
-fun PersonProfileMoreDialog(
+fun PersonProfileMoreDropdown(
+    expanded: Boolean,
     onDismissRequest: () -> Unit,
     onBlockPersonClick: () -> Unit,
     onReportPersonClick: () -> Unit,
     onMessagePersonClick: () -> Unit,
 ) {
-    AlertDialog(
+    DropdownMenu(
+        expanded = expanded,
         onDismissRequest = onDismissRequest,
-        text = {
-            Column {
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.person_profile_dm_person),
-                    onClick = onMessagePersonClick,
-                    icon = Icons.Outlined.Message,
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.person_profile_block_person),
-                    icon = Icons.Outlined.Block,
-                    onClick = onBlockPersonClick,
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.person_profile_report_person),
-                    icon = Icons.Outlined.Flag,
-                    onClick = onReportPersonClick,
-                )
-            }
-        },
-        confirmButton = {},
-    )
+    ) {
+        MenuItem(
+            text = stringResource(R.string.person_profile_dm_person),
+            onClick = onMessagePersonClick,
+            icon = Icons.Outlined.Message,
+        )
+        MenuItem(
+            text = stringResource(R.string.person_profile_block_person),
+            onClick = onBlockPersonClick,
+            icon = Icons.Outlined.Block,
+        )
+        MenuItem(
+            text = stringResource(R.string.person_profile_report_person),
+            onClick = onReportPersonClick,
+            icon = Icons.Outlined.Flag,
+        )
+    }
 }


### PR DESCRIPTION
This does some of the work for #1065 by moving more/three-dot buttons on top app bars over to use dropdowns rather than dialogs.

Whether to move other dialogs to dropdowns has some concerns in that issue (such as scrollable areas) and might be facilitated by other components, so this is limited intentionally.