### PR TITLE
Use modal bottom sheets for sorting options.

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/BottomSheets.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/BottomSheets.kt
@@ -1,0 +1,143 @@
+package com.jerboa.ui.components.common
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BarChart
+import androidx.compose.material.icons.outlined.BrightnessLow
+import androidx.compose.material.icons.outlined.FormatListNumbered
+import androidx.compose.material.icons.outlined.History
+import androidx.compose.material.icons.outlined.LocalFireDepartment
+import androidx.compose.material.icons.outlined.Moving
+import androidx.compose.material.icons.outlined.NewReleases
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import com.jerboa.R
+import com.jerboa.datatypes.types.CommentSortType
+import com.jerboa.datatypes.types.SortType
+import com.jerboa.getLocalizedSortingTypeLongName
+import com.jerboa.ui.theme.LARGE_PADDING
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun CommentSortOptionsModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    onClickSortType: (CommentSortType) -> Unit,
+    selectedSortType: CommentSortType,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column {
+            IconAndTextDrawerItem(
+                text = stringResource(R.string.dialogs_hot),
+                icon = Icons.Outlined.LocalFireDepartment,
+                onClick = { onClickSortType(CommentSortType.Hot) },
+                highlight = (selectedSortType == CommentSortType.Hot),
+            )
+            IconAndTextDrawerItem(
+                text = stringResource(R.string.dialogs_top),
+                icon = Icons.Outlined.BarChart,
+                onClick = { onClickSortType(CommentSortType.Top) },
+                highlight = (selectedSortType == CommentSortType.Top),
+            )
+            IconAndTextDrawerItem(
+                text = stringResource(R.string.dialogs_new),
+                icon = Icons.Outlined.NewReleases,
+                onClick = { onClickSortType(CommentSortType.New) },
+                highlight = (selectedSortType == CommentSortType.New),
+            )
+            IconAndTextDrawerItem(
+                text = stringResource(R.string.dialogs_old),
+                icon = Icons.Outlined.History,
+                onClick = { onClickSortType(CommentSortType.Old) },
+                highlight = (selectedSortType == CommentSortType.Old),
+            )
+            Spacer(modifier = Modifier.height(LARGE_PADDING))
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SortOptionsModalBottomSheet(
+    onDismissRequest: () -> Unit,
+    onClickSortType: (SortType) -> Unit,
+    selectedSortType: SortType,
+) {
+    val ctx = LocalContext.current
+
+    var showTopOptions by remember { mutableStateOf(false) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+    ) {
+        Column {
+            if (!showTopOptions) {
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_active),
+                    icon = Icons.Outlined.Moving,
+                    onClick = { onClickSortType(SortType.Active) },
+                    highlight = (selectedSortType == SortType.Active),
+                )
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_hot),
+                    icon = Icons.Outlined.LocalFireDepartment,
+                    onClick = { onClickSortType(SortType.Hot) },
+                    highlight = (selectedSortType == SortType.Hot),
+                )
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_new),
+                    icon = Icons.Outlined.BrightnessLow,
+                    onClick = { onClickSortType(SortType.New) },
+                    highlight = (selectedSortType == SortType.New),
+                )
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_old),
+                    icon = Icons.Outlined.History,
+                    onClick = { onClickSortType(SortType.Old) },
+                    highlight = (selectedSortType == SortType.Old),
+                )
+                IconAndTextDrawerItem(
+                    modifier = Modifier.testTag("jerboa:sortoption_mostcomments"),
+                    text = stringResource(R.string.dialogs_most_comments),
+                    icon = Icons.Outlined.FormatListNumbered,
+                    onClick = { onClickSortType(SortType.MostComments) },
+                    highlight = (selectedSortType == SortType.MostComments),
+                )
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_new_comments),
+                    icon = Icons.Outlined.NewReleases,
+                    onClick = { onClickSortType(SortType.NewComments) },
+                    highlight = (selectedSortType == SortType.NewComments),
+                )
+                IconAndTextDrawerItem(
+                    text = stringResource(R.string.dialogs_top),
+                    icon = Icons.Outlined.BarChart,
+                    onClick = { showTopOptions = !showTopOptions },
+                    more = true,
+                    highlight = (topSortTypes.contains(selectedSortType)),
+                )
+            } else {
+                topSortTypes.forEach {
+                    IconAndTextDrawerItem(
+                        text = getLocalizedSortingTypeLongName(ctx, it),
+                        onClick = { onClickSortType(it) },
+                        highlight = (selectedSortType == it),
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(LARGE_PADDING))
+        }
+    }
+}

--- a/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Dialogs.kt
@@ -5,14 +5,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.BarChart
-import androidx.compose.material.icons.outlined.BrightnessLow
-import androidx.compose.material.icons.outlined.FormatListNumbered
-import androidx.compose.material.icons.outlined.History
-import androidx.compose.material.icons.outlined.LocalFireDepartment
-import androidx.compose.material.icons.outlined.Moving
-import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -26,18 +18,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import androidx.compose.ui.tooling.preview.Preview
 import com.jerboa.PostViewMode
 import com.jerboa.R
 import com.jerboa.api.MINIMUM_API_VERSION
-import com.jerboa.datatypes.types.CommentSortType
 import com.jerboa.datatypes.types.SortType
-import com.jerboa.getLocalizedSortingTypeLongName
 import com.jerboa.model.AppSettingsViewModel
 
 val DONATION_MARKDOWN = """
@@ -53,154 +41,6 @@ val DONATION_MARKDOWN = """
 """.trimIndent()
 
 val topSortTypes = SortType.entries.filter { it.name.startsWith("Top") }
-
-@Composable
-fun SortTopOptionsDialog(
-    onDismissRequest: () -> Unit,
-    onClickSortType: (SortType) -> Unit,
-    selectedSortType: SortType,
-) {
-    val ctx = LocalContext.current
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        text = {
-            Column {
-                topSortTypes.forEach {
-                    IconAndTextDrawerItem(
-                        text = getLocalizedSortingTypeLongName(ctx, it),
-                        onClick = { onClickSortType(it) },
-                        highlight = (selectedSortType == it),
-                    )
-                }
-            }
-        },
-        confirmButton = {},
-    )
-}
-
-@Preview
-@Composable
-fun SortOptionsDialogPreview() {
-    SortOptionsDialog(
-        selectedSortType = SortType.Hot,
-        onDismissRequest = {},
-        onClickSortTopOptions = {},
-        onClickSortType = {},
-    )
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-fun SortOptionsDialog(
-    onDismissRequest: () -> Unit,
-    onClickSortType: (SortType) -> Unit,
-    onClickSortTopOptions: () -> Unit,
-    selectedSortType: SortType,
-) {
-    AlertDialog(
-        modifier = Modifier.semantics { testTagsAsResourceId = true },
-        onDismissRequest = onDismissRequest,
-        text = {
-            Column {
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_active),
-                    icon = Icons.Outlined.Moving,
-                    onClick = { onClickSortType(SortType.Active) },
-                    highlight = (selectedSortType == SortType.Active),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_hot),
-                    icon = Icons.Outlined.LocalFireDepartment,
-                    onClick = { onClickSortType(SortType.Hot) },
-                    highlight = (selectedSortType == SortType.Hot),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_new),
-                    icon = Icons.Outlined.BrightnessLow,
-                    onClick = { onClickSortType(SortType.New) },
-                    highlight = (selectedSortType == SortType.New),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_old),
-                    icon = Icons.Outlined.History,
-                    onClick = { onClickSortType(SortType.Old) },
-                    highlight = (selectedSortType == SortType.Old),
-                )
-                IconAndTextDrawerItem(
-                    modifier = Modifier.testTag("jerboa:sortoption_mostcomments"),
-                    text = stringResource(R.string.dialogs_most_comments),
-                    icon = Icons.Outlined.FormatListNumbered,
-                    onClick = { onClickSortType(SortType.MostComments) },
-                    highlight = (selectedSortType == SortType.MostComments),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_new_comments),
-                    icon = Icons.Outlined.NewReleases,
-                    onClick = { onClickSortType(SortType.NewComments) },
-                    highlight = (selectedSortType == SortType.NewComments),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_top),
-                    icon = Icons.Outlined.BarChart,
-                    onClick = onClickSortTopOptions,
-                    more = true,
-                    highlight = (topSortTypes.contains(selectedSortType)),
-                )
-            }
-        },
-        confirmButton = {},
-    )
-}
-
-@Preview
-@Composable
-fun CommentSortOptionsDialogPreview() {
-    CommentSortOptionsDialog(
-        selectedSortType = CommentSortType.Hot,
-        onDismissRequest = {},
-        onClickSortType = {},
-    )
-}
-
-@Composable
-fun CommentSortOptionsDialog(
-    onDismissRequest: () -> Unit,
-    onClickSortType: (CommentSortType) -> Unit,
-    selectedSortType: CommentSortType,
-) {
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        text = {
-            Column {
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_hot),
-                    icon = Icons.Outlined.LocalFireDepartment,
-                    onClick = { onClickSortType(CommentSortType.Hot) },
-                    highlight = (selectedSortType == CommentSortType.Hot),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_top),
-                    icon = Icons.Outlined.BarChart,
-                    onClick = { onClickSortType(CommentSortType.Top) },
-                    highlight = (selectedSortType == CommentSortType.Top),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_new),
-                    icon = Icons.Outlined.NewReleases,
-                    onClick = { onClickSortType(CommentSortType.New) },
-                    highlight = (selectedSortType == CommentSortType.New),
-                )
-                IconAndTextDrawerItem(
-                    text = stringResource(R.string.dialogs_old),
-                    icon = Icons.Outlined.History,
-                    onClick = { onClickSortType(CommentSortType.Old) },
-                    highlight = (selectedSortType == CommentSortType.Old),
-                )
-            }
-        },
-        confirmButton = {},
-    )
-}
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -23,8 +23,7 @@ import com.jerboa.ui.components.common.LargerCircularIcon
 import com.jerboa.ui.components.common.MenuItem
 import com.jerboa.ui.components.common.PictrsBannerImage
 import com.jerboa.ui.components.common.PostViewModeDialog
-import com.jerboa.ui.components.common.SortOptionsDialog
-import com.jerboa.ui.components.common.SortTopOptionsDialog
+import com.jerboa.ui.components.common.SortOptionsModalBottomSheet
 import com.jerboa.ui.theme.*
 
 @Composable
@@ -139,31 +138,15 @@ fun CommunityHeader(
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
-    var showTopOptions by remember { mutableStateOf(false) }
     var showMoreOptions by remember { mutableStateOf(false) }
     var showPostViewModeOptions by remember { mutableStateOf(false) }
 
     if (showSortOptions) {
-        SortOptionsDialog(
+        SortOptionsModalBottomSheet(
             selectedSortType = selectedSortType,
             onDismissRequest = { showSortOptions = false },
             onClickSortType = {
                 showSortOptions = false
-                onClickSortType(it)
-            },
-            onClickSortTopOptions = {
-                showSortOptions = false
-                showTopOptions = !showTopOptions
-            },
-        )
-    }
-
-    if (showTopOptions) {
-        SortTopOptionsDialog(
-            selectedSortType = selectedSortType,
-            onDismissRequest = { showTopOptions = false },
-            onClickSortType = {
-                showTopOptions = false
                 onClickSortType(it)
             },
         )

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -46,8 +46,7 @@ import com.jerboa.getLocalizedSortingTypeShortName
 import com.jerboa.ui.components.common.MenuItem
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.PostViewModeDialog
-import com.jerboa.ui.components.common.SortOptionsDialog
-import com.jerboa.ui.components.common.SortTopOptionsDialog
+import com.jerboa.ui.components.common.SortOptionsModalBottomSheet
 import com.jerboa.ui.theme.LARGE_PADDING
 import kotlinx.collections.immutable.ImmutableList
 
@@ -84,32 +83,16 @@ fun HomeHeader(
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
-    var showTopOptions by remember { mutableStateOf(false) }
     var showListingTypeOptions by remember { mutableStateOf(false) }
     var showMoreOptions by remember { mutableStateOf(false) }
     var showPostViewModeOptions by remember { mutableStateOf(false) }
 
     if (showSortOptions) {
-        SortOptionsDialog(
+        SortOptionsModalBottomSheet(
             selectedSortType = selectedSortType,
             onDismissRequest = { showSortOptions = false },
             onClickSortType = {
                 showSortOptions = false
-                onClickSortType(it)
-            },
-            onClickSortTopOptions = {
-                showSortOptions = false
-                showTopOptions = !showTopOptions
-            },
-        )
-    }
-
-    if (showTopOptions) {
-        SortTopOptionsDialog(
-            selectedSortType = selectedSortType,
-            onDismissRequest = { showTopOptions = false },
-            onClickSortType = {
-                showTopOptions = false
                 onClickSortType(it)
             },
         )

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -40,8 +40,7 @@ import com.jerboa.ui.components.common.LargerCircularIcon
 import com.jerboa.ui.components.common.MenuItem
 import com.jerboa.ui.components.common.MyMarkdownText
 import com.jerboa.ui.components.common.PictrsBannerImage
-import com.jerboa.ui.components.common.SortOptionsDialog
-import com.jerboa.ui.components.common.SortTopOptionsDialog
+import com.jerboa.ui.components.common.SortOptionsModalBottomSheet
 import com.jerboa.ui.components.common.TimeAgo
 import com.jerboa.ui.theme.MEDIUM_PADDING
 import com.jerboa.ui.theme.PROFILE_BANNER_SIZE
@@ -157,30 +156,14 @@ fun PersonProfileHeader(
     isLoggedIn: () -> Boolean,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
-    var showTopOptions by remember { mutableStateOf(false) }
     var showMoreOptions by remember { mutableStateOf(false) }
 
     if (showSortOptions) {
-        SortOptionsDialog(
+        SortOptionsModalBottomSheet(
             selectedSortType = selectedSortType,
             onDismissRequest = { showSortOptions = false },
             onClickSortType = {
                 showSortOptions = false
-                onClickSortType(it)
-            },
-            onClickSortTopOptions = {
-                showSortOptions = false
-                showTopOptions = !showTopOptions
-            },
-        )
-    }
-
-    if (showTopOptions) {
-        SortTopOptionsDialog(
-            selectedSortType = selectedSortType,
-            onDismissRequest = { showTopOptions = false },
-            onClickSortType = {
-                showTopOptions = false
                 onClickSortType(it)
             },
         )

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -95,7 +95,7 @@ import com.jerboa.ui.components.comment.edit.CommentEditReturn
 import com.jerboa.ui.components.comment.reply.CommentReplyReturn
 import com.jerboa.ui.components.common.ApiErrorText
 import com.jerboa.ui.components.common.CommentNavigationBottomAppBar
-import com.jerboa.ui.components.common.CommentSortOptionsDialog
+import com.jerboa.ui.components.common.CommentSortOptionsModalBottomSheet
 import com.jerboa.ui.components.common.JerboaSnackbarHost
 import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.apiErrorToast
@@ -209,7 +209,7 @@ fun PostActivity(
     )
 
     if (showSortOptions) {
-        CommentSortOptionsDialog(
+        CommentSortOptionsModalBottomSheet(
             selectedSortType = selectedSortType,
             onDismissRequest = { showSortOptions = false },
             onClickSortType = {


### PR DESCRIPTION
Experiment in changing sort options be modal bottom sheets rather than dialogs. Leaving draft since I'm not sure what the feeling is about bottom sheets vs menus and dialogs in this case.

![Screenshot_20230812_022320](https://github.com/dessalines/jerboa/assets/494446/23aadef6-6615-48bd-ae87-a5784acfcb2c)
![Screenshot_20230812_022353](https://github.com/dessalines/jerboa/assets/494446/bb731acd-2023-4105-a290-d26d91874423)
