### PR TITLE
Change the default of isCurrentlyConnected

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1483,7 +1483,7 @@ fun ConnectivityManager?.isCurrentlyConnected(): Boolean =
     this?.activeNetwork
         ?.let(::getNetworkCapabilities)
         ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-        ?: false
+        ?: true
 
 /**
  * When calling this, you must call ActivityResultLauncher.unregister()


### PR DESCRIPTION
I changed it so that when it fails to retrieve `activeNetwork` due to possible revoke of the ACCES_NETWORK_STATE permission that it still passes the test. If the user actually has no internet the next steps will catch it in a real word api fetch.