### PR TITLE
Update community block msg to display unblock if blocked already

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1177,13 +1177,23 @@ fun showBlockCommunityToast(blockCommunityRes: ApiState<BlockCommunityResponse>,
         is ApiState.Success -> {
             Toast.makeText(
                 ctx,
-                "${blockCommunityRes.data.community_view.community.name} Blocked",
+                ctx.getString(
+                    if (blockCommunityRes.data.blocked) {
+                        R.string.blocked_community_toast
+                    } else R.string.unblocked_community_toast,
+                    blockCommunityRes.data.community_view.community.name,
+                ),
                 Toast.LENGTH_SHORT,
-            )
-                .show()
+            ).show()
         }
 
-        else -> {}
+        else -> {
+            Toast.makeText(
+                ctx,
+                ctx.getText(R.string.community_block_toast_failure),
+                Toast.LENGTH_SHORT,
+            ).show()
+        }
     }
 }
 

--- a/app/src/main/java/com/jerboa/model/CommunityViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/CommunityViewModel.kt
@@ -211,13 +211,12 @@ class CommunityViewModel : ViewModel(), Initializable {
     fun blockCommunity(form: BlockCommunity, ctx: Context) {
         viewModelScope.launch {
             blockCommunityRes = ApiState.Loading
-            blockCommunityRes =
-                apiWrapper(API.getInstance().blockCommunity(form))
+            blockCommunityRes = apiWrapper(API.getInstance().blockCommunity(form))
+
+            showBlockCommunityToast(blockCommunityRes, ctx)
 
             when (val blockCommunity = blockCommunityRes) {
                 is ApiState.Success -> {
-                    showBlockCommunityToast(blockCommunity, ctx)
-
                     when (val existing = communityRes) {
                         is ApiState.Success -> {
                             val newRes =

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -137,6 +137,7 @@ fun CommunityHeader(
     onClickCommunityInfo: () -> Unit,
     onClickBack: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
+    isBlocked: Boolean,
 ) {
     var showSortOptions by remember { mutableStateOf(false) }
     var showTopOptions by remember { mutableStateOf(false) }
@@ -227,6 +228,7 @@ fun CommunityHeader(
                         onBlockCommunityClick()
                     },
                     onClickCommunityInfo = onClickCommunityInfo,
+                    isBlocked = isBlocked,
                 )
             }
         },
@@ -262,6 +264,7 @@ fun CommunityMoreDropdown(
     onClickRefresh: () -> Unit,
     onClickCommunityInfo: () -> Unit,
     onClickShowPostViewModeDialog: () -> Unit,
+    isBlocked: Boolean,
 ) {
     DropdownMenu(
         expanded = expanded,
@@ -292,7 +295,11 @@ fun CommunityMoreDropdown(
             },
         )
         MenuItem(
-            text = stringResource(R.string.community_block_community),
+            text = stringResource(
+                if (isBlocked) {
+                    R.string.community_unblock_community
+                } else R.string.community_block_community,
+            ),
             icon = Icons.Outlined.Block,
             onClick = onBlockCommunityClick,
         )

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -240,6 +240,7 @@ fun CommunityActivity(
                             onClickCommunityInfo = appState::toCommunitySideBar,
                             onClickBack = appState::navigateUp,
                             selectedPostViewMode = getPostViewMode(appSettingsViewModel),
+                            isBlocked = communityRes.data.community_view.blocked,
                         )
                     }
                     else -> {}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,4 +392,8 @@
     <string name="post_actionbar_mode_short_right">Short righthand post actionbar</string>
     <string name="post_actionbar">Post actionbar mode</string>
     <string name="settings_autoplaygifs">Auto play GIFs</string>
+    <string name="community_unblock_community">Unblock Community</string>
+    <string name="blocked_community_toast">%1$s is blocked</string>
+    <string name="unblocked_community_toast">%1$s is unblocked</string>
+    <string name="community_block_toast_failure">Failed to (un)block this community</string>
 </resources>


### PR DESCRIPTION
- Made text not hardcoded anymore
- Display error on failure to block
- Update view to show unblock if community is blocked


https://github.com/dessalines/jerboa/assets/67873169/520d9b43-de7c-43f2-b07b-648c5f5e7f67

I tried to do the same for postlistings but PostView does not contain a field for blocked community and mapping it to a datatype that does contain it pretty complex and could be done easier when the API rework gets done.
Also see https://github.com/LemmyNet/lemmy/issues/3885