### PR TITLE
Fix broken Japanese string format for AppBars_users_month

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -30,7 +30,7 @@
     <string name="AppBars_created">作成</string>
     <string name="AppBars_users_day">1日のユーザー%1$s名</string>
     <string name="AppBars_users_week">1週間のユーザー%1$s名</string>
-    <string name="AppBars_users_month">1ヶ月のユーザー%1$名</string>
+    <string name="AppBars_users_month">1ヶ月のユーザー%1$s名</string>
     <string name="AppBars_users_6_months">6ヶ月のユーザー%1$s名</string>
     <string name="AppBars_posts">%1$sの投稿</string>
     <string name="AppBars_comments">%1$sのコメント</string>


### PR DESCRIPTION
This caused a crash every time you entered Community Info if your phone language is set to Japanese.