### PR TITLE
Make nav text smaller

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
@@ -133,6 +134,7 @@ fun BottomAppBarAll(
                 label = {
                     if (showTextDescriptionsInNavbar) {
                         Text(
+                            textAlign = TextAlign.Center,
                             fontSize = TextUnit(10f, TextUnitType.Sp),
                             text = stringResource(tab.textId),
                             color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
 import com.jerboa.R
 import com.jerboa.datatypes.samplePerson
@@ -131,6 +133,7 @@ fun BottomAppBarAll(
                 label = {
                     if (showTextDescriptionsInNavbar) {
                         Text(
+                            fontSize = TextUnit(10f, TextUnitType.Sp),
                             text = stringResource(tab.textId),
                             color = MaterialTheme.colorScheme.onSurface,
                         )
@@ -627,7 +630,10 @@ fun LoadingBar(
     padding: PaddingValues = PaddingValues(0.dp),
 ) {
     LinearProgressIndicator(
-        modifier = Modifier.fillMaxWidth().padding(padding).testTag("jerboa:loading"),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(padding)
+            .testTag("jerboa:loading"),
     )
 }
 


### PR DESCRIPTION
![image](https://github.com/dessalines/jerboa/assets/67873169/820f09ad-5bff-4226-98f3-7d0986567e8a)

Still see lots of issues with nav text overlapping, I see that other G apps have also rather smaller nav text. So I changed ours to be smaller too. Hopefully this fixes all the issues.

Fixes #1180