### PR TITLE
Fix crash in share Media, fix failed download media

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1471,15 +1471,21 @@ fun <I, O> ComponentActivity.registerActivityResultLauncher(
 
 /**
  *  Returns a [InputStream] for the data of the URL, but it also checks the cache first!
+ *
+ *  Doesn't clean up the [InputStream]
+ *
+ *  @throws IOException
+ *  @throws IllegalArgumentException If this is not a well-formed HTTP or HTTPS URL.
  */
 @OptIn(ExperimentalCoilApi::class)
+@Throws(IOException::class)
 fun Context.getInputStream(url: String): InputStream {
     val snapshot = this.imageLoader.diskCache?.openSnapshot(url)
 
-    return snapshot?.use {
-        it.data.toFile().inputStream()
-    } ?: API.httpClient.newCall(Request(url.toHttpUrl())).execute().use { response ->
-        response.body.byteStream()
+    return if (snapshot != null) {
+        snapshot.data.toFile().inputStream()
+    } else {
+        API.httpClient.newCall(Request(url.toHttpUrl())).execute().body.byteStream()
     }
 }
 

--- a/app/src/main/java/com/jerboa/feat/UserActions.kt
+++ b/app/src/main/java/com/jerboa/feat/UserActions.kt
@@ -82,36 +82,38 @@ private suspend fun saveMedia(url: String, context: Context, mediaType: PostType
  * Shares the actual file from the link
  */
 fun shareMedia(scope: CoroutineScope, ctx: Context, url: String, mediaType: PostType) {
-    try {
-        val fileName = Uri.parse(url).pathSegments.last()
+    scope.launch(Dispatchers.Main) {
+        try {
+            val fileName = Uri.parse(url).pathSegments.last()
 
-        val file = File(ctx.cacheDir, fileName)
+            val file = File(ctx.cacheDir, fileName)
 
-        scope.launch(Dispatchers.IO) {
-            ctx.getInputStream(url).use { input ->
-                file.outputStream().use {
-                    input.copyTo(it)
+            withContext(Dispatchers.IO) {
+                ctx.getInputStream(url).use { input ->
+                    file.outputStream().use {
+                        input.copyTo(it)
+                    }
                 }
             }
-        }
 
-        val uri = FileProvider.getUriForFile(ctx, ctx.packageName + ".provider", file)
-        val shareIntent = Intent()
-        shareIntent.setAction(Intent.ACTION_SEND)
-        shareIntent.putExtra(Intent.EXTRA_STREAM, uri)
-        when (mediaType) {
-            PostType.Image -> shareIntent.setType("image/*")
-            PostType.Video -> shareIntent.setType("video/*")
-            PostType.Link -> shareIntent.setType("text/*")
+            val uri = FileProvider.getUriForFile(ctx, ctx.packageName + ".provider", file)
+            val shareIntent = Intent()
+            shareIntent.setAction(Intent.ACTION_SEND)
+            shareIntent.putExtra(Intent.EXTRA_STREAM, uri)
+            when (mediaType) {
+                PostType.Image -> shareIntent.setType("image/*")
+                PostType.Video -> shareIntent.setType("video/*")
+                PostType.Link -> shareIntent.setType("text/*")
+            }
+            shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            ctx.startActivitySafe(Intent.createChooser(shareIntent, ctx.getString(R.string.share)))
+        } catch (e: IOException) {
+            Log.d("shareMedia", "failed", e)
+            Toast.makeText(ctx, R.string.failed_sharing_media, Toast.LENGTH_SHORT).show()
+        } catch (e: Exception) {
+            Log.d("shareMedia", "invalid URL", e)
+            Toast.makeText(ctx, R.string.failed_sharing_media, Toast.LENGTH_SHORT).show()
         }
-        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-        ctx.startActivitySafe(Intent.createChooser(shareIntent, ctx.getString(R.string.share)))
-    } catch (e: IOException) {
-        Log.d("shareMedia", "failed", e)
-        Toast.makeText(ctx, R.string.failed_saving_media, Toast.LENGTH_SHORT).show()
-    } catch (e: Exception) {
-        Log.d("shareMedia", "invalid URL", e)
-        Toast.makeText(ctx, R.string.failed_saving_media, Toast.LENGTH_SHORT).show()
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,4 +413,5 @@
     <string name="no_activity_found">No activity (app) found that can open this link</string>
     <string name="markdownHelper_insertSpoiler">Insert spoiler</string>
     <string name="matrix_send_msg">Connect on Matrix</string>
+    <string name="failed_sharing_media">Failed to share media!</string>
 </resources>


### PR DESCRIPTION
Learned quite a bit from this. The original share/download since the introduction of the caching check was only really working in some instances due to some quirks. 

mistakes:
- scope.launch won't rethrow unhandled exceptions but will cancel its parents thus bypassing the try catch I had
- shareMedia used scope.launch for the IO part but it did not actually wait for this complete, thus it was sharing empty files at best crash at worst due to two sources reading/write to a cache file (only really worked in the rare instance its called from imageviewer where the image is loaded in cache and it wins the race condition on reading the file into the cached file)
-  Context.getInputStream shared a closed inputStream, the implementation for snapshot doesn't actually check if it is closed thus that worked. But the byteStream implementation did. Thus the cause of the `IOException: Closed` exception


Fixes #1204 