### PR TITLE
Fix unread count not resetting when swapping to anon

### DIFF
--- a/app/src/main/java/com/jerboa/model/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/SiteViewModel.kt
@@ -66,6 +66,8 @@ class SiteViewModel(private val accountRepository: AccountRepository) : ViewMode
 
                     if (!it.isAnon()) {
                         fetchUnreadCounts(GetUnreadCount(auth = it.jwt))
+                    } else { // Reset the unread count if we're anonymous
+                        unreadCountRes = ApiState.Empty
                     }
                 }
         }


### PR DESCRIPTION

Fixes #1222 

@0xFOSSMan 

Sorry about before but this one can be trivially solved by resetting the unreadCount response to empty again.

Since we using derivativedState it will trigger on changes to unreadCountRes. Where `getUnreadCountTotal` sets it to zero for that ApiState

