### PR TITLE
Fix zooming difficulties

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,9 @@ dependencies {
     implementation("io.coil-kt:coil-svg:2.4.0")
     // Allows for proper subsampling of large images
     implementation("me.saket.telephoto:zoomable-image-coil:0.6.0-20230904.055636-11")
-
+    // Allows to swipe close the image viewer, original approach used nested scroll
+    // Which causes weird behaviour as nested scroll is not supported in compose
+    implementation("me.saket.telephoto:flick:0.6.0-SNAPSHOT")
     // crash handling
     implementation("com.github.FunkyMuse:Crashy:1.2.0")
 


### PR DESCRIPTION
We used nested scrolling before to enable flick to exit behaviour, But nested scrolling doesn't work well compose and causes subtle issues. Thus I replaced it this with library which uses dragged instead.

see https://programming.dev/post/2375491

Fixes #1232

https://github.com/dessalines/jerboa/assets/67873169/c1ad26f5-3228-498e-8606-f629de7471ad


