### PR TITLE
Community: Add Share drop down in community view.

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -134,6 +134,7 @@ fun CommunityHeader(
     selectedSortType: SortType,
     selectedPostViewMode: PostViewMode,
     onClickCommunityInfo: () -> Unit,
+    onClickCommunityShare: () -> Unit,
     onClickBack: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
     siteVersion: String,
@@ -196,6 +197,7 @@ fun CommunityHeader(
                     onClickRefresh = onClickRefresh,
                     onBlockCommunityClick = onBlockCommunityClick,
                     onClickCommunityInfo = onClickCommunityInfo,
+                    onClickCommunityShare = onClickCommunityShare,
                     onClickPostViewMode = onClickPostViewMode,
                     selectedPostViewMode = selectedPostViewMode,
                     isBlocked = isBlocked,
@@ -233,6 +235,7 @@ fun CommunityMoreDropdown(
     onBlockCommunityClick: () -> Unit,
     onClickRefresh: () -> Unit,
     onClickCommunityInfo: () -> Unit,
+    onClickCommunityShare: () -> Unit,
     onClickPostViewMode: (PostViewMode) -> Unit,
     selectedPostViewMode: PostViewMode,
     isBlocked: Boolean,
@@ -277,6 +280,14 @@ fun CommunityMoreDropdown(
             onClick = {
                 onDismissRequest()
                 onClickCommunityInfo()
+            },
+        )
+        DropdownMenuItem(
+            text = { Text(stringResource(R.string.share)) },
+            leadingIcon = { Icon(Icons.Outlined.Share, contentDescription = null) },
+            onClick = {
+                onDismissRequest()
+                onClickCommunityShare()
             },
         )
         Divider()

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -49,6 +49,7 @@ import com.jerboa.datatypes.types.SubscribedType
 import com.jerboa.db.entity.getJWT
 import com.jerboa.db.entity.isAnon
 import com.jerboa.feat.doIfReadyElseDisplayInfo
+import com.jerboa.feat.shareLink
 import com.jerboa.hostName
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.AppSettingsViewModel
@@ -200,6 +201,7 @@ fun CommunityActivity(
                                 }
                             },
                             onClickCommunityInfo = { appState.toCommunitySideBar(communityRes.data.community_view) },
+                            onClickCommunityShare = { shareLink(communityRes.data.community_view.community.actor_id, ctx) },
                             onClickBack = appState::navigateUp,
                             selectedPostViewMode = getPostViewMode(appSettingsViewModel),
                             isBlocked = communityRes.data.community_view.blocked,


### PR DESCRIPTION
I found that there is no button to share a community url. This patch fixes that.
Not sure if this is the best way to create a community URL, let me know if I am missing something.
Also not sure if https can be expected from all instances. Didn't find any places were instance / community URLs are already created.