### PR TITLE
Fix search list repopulating on return

### DIFF
--- a/app/src/main/java/com/jerboa/model/CommunityListViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/CommunityListViewModel.kt
@@ -4,7 +4,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.api.apiWrapper
@@ -19,7 +21,7 @@ import com.jerboa.serializeToMap
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
 
-class CommunityListViewModel : ViewModel() {
+class CommunityListViewModel(communities: ImmutableList<CommunityFollowerView>) : ViewModel() {
 
     var searchRes: ApiState<SearchResponse> by mutableStateOf(ApiState.Empty)
         private set
@@ -31,7 +33,11 @@ class CommunityListViewModel : ViewModel() {
         }
     }
 
-    fun setCommunityListFromFollowed(myFollows: ImmutableList<CommunityFollowerView>) {
+    init {
+        setCommunityListFromFollowed(communities)
+    }
+
+    private fun setCommunityListFromFollowed(myFollows: ImmutableList<CommunityFollowerView>) {
         // A hack to convert communityFollowerView into CommunityView
         val followsIntoCommunityViews = myFollows.map { cfv ->
             CommunityView(
@@ -63,5 +69,19 @@ class CommunityListViewModel : ViewModel() {
                 users = emptyList(),
             ),
         )
+    }
+
+    companion object {
+        class Factory(
+            private val followedCommunities: ImmutableList<CommunityFollowerView>,
+        ) : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(
+                modelClass: Class<T>,
+                extras: CreationExtras,
+            ): T {
+                return CommunityListViewModel(followedCommunities) as T
+            }
+        }
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListActivity.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -54,11 +53,8 @@ fun CommunityListActivity(
 
     val account = getCurrentAccount(accountViewModel = accountViewModel)
 
-    val communityListViewModel: CommunityListViewModel = viewModel()
-    LaunchedEffect(Unit) {
-        // Whenever navigating here, reset the list with your followed communities
-        communityListViewModel.setCommunityListFromFollowed(followList)
-    }
+    val communityListViewModel: CommunityListViewModel =
+        viewModel(factory = CommunityListViewModel.Companion.Factory(followList))
 
     var search by rememberSaveable { mutableStateOf("") }
 
@@ -118,6 +114,7 @@ fun CommunityListActivity(
                             blurNSFW = blurNSFW,
                         )
                     }
+
                     else -> {}
                 }
             },


### PR DESCRIPTION
This was a regression introduced in #1208. On return it would repopulate the searchlist with the user their followed communities. Now it only does it on navigation to the search.


https://github.com/dessalines/jerboa/assets/67873169/e1d1508e-c179-4515-8bbf-31a7c1f5a546

