### PR TITLE
Fix crash on creating Post

### DIFF
--- a/app/src/main/java/com/jerboa/JerboaAppState.kt
+++ b/app/src/main/java/com/jerboa/JerboaAppState.kt
@@ -259,7 +259,7 @@ class JerboaAppState(
      * This is important as, we could navigate further up the tree and back again
      * but when you consume on second return it will be gone
      */
-    inline fun <reified T : Any> getPrevReturnNullable(key: String): T? {
+    inline fun <reified T> getPrevReturnNullable(key: String): T? {
         val savedStateHandle = navController.previousBackStackEntry?.savedStateHandle
 
         if (savedStateHandle?.contains(key) == true) {
@@ -291,6 +291,13 @@ class JerboaAppState(
 }
 
 inline fun <reified T> getKotlinxSerializerSaver(): Saver<T, String> {
+    return Saver(
+        save = { Json.encodeToString(it) },
+        restore = { Json.decodeFromString<T>(it) },
+    )
+}
+
+inline fun <reified T> getKotlinxSerializerSaver3(): Saver<T?, String> {
     return Saver(
         save = { Json.encodeToString(it) },
         restore = { Json.decodeFromString<T>(it) },

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -399,7 +399,7 @@ class MainActivity : AppCompatActivity() {
                         var url = ""
                         var body = ""
                         if (Patterns.WEB_URL.matcher(text).matches()) {
-                            url = text
+                            url = text.padUrlWithHttps()
                         } else {
                             body = text
                         }

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1513,3 +1513,11 @@ fun String.toHttps(): String {
         this
     }
 }
+
+fun String.padUrlWithHttps(): String {
+    return if (this.contains("://")) {
+        this
+    } else {
+        "https://$this"
+    }
+}

--- a/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostActivity.kt
@@ -27,9 +27,11 @@ import com.jerboa.R
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
 import com.jerboa.db.entity.isAnon
+import com.jerboa.getKotlinxSerializerSaver
 import com.jerboa.imageInputStreamFromUri
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.CreatePostViewModel
+import com.jerboa.padUrlWithHttps
 import com.jerboa.ui.components.common.ActionTopBar
 import com.jerboa.ui.components.common.LoadingBar
 import com.jerboa.ui.components.common.getCurrentAccount
@@ -69,9 +71,9 @@ fun CreatePostActivity(
 
     val createPostViewModel: CreatePostViewModel = viewModel()
 
-    var selectedCommunity: Community? by rememberSaveable {
+    var selectedCommunity by rememberSaveable(stateSaver = getKotlinxSerializerSaver<Community?>()) {
         // Init return from Community post creation
-        mutableStateOf(appState.getPrevReturnNullable<Community>(CreatePostReturn.COMMUNITY_SEND))
+        mutableStateOf(appState.getPrevReturnNullable<Community?>(CreatePostReturn.COMMUNITY_SEND))
     }
 
     // On return from the community picker
@@ -133,7 +135,7 @@ fun CreatePostActivity(
                                 onSubmitClick(
                                     name = name,
                                     body = body,
-                                    url = url,
+                                    url = url.padUrlWithHttps(),
                                     isNsfw = isNsfw,
                                     createPostViewModel = createPostViewModel,
                                     selectedCommunity = selectedCommunity,
@@ -171,8 +173,8 @@ fun CreatePostActivity(
                         fetchSiteMetadataJob =
                             scope.launch {
                                 delay(DEBOUNCE_DELAY)
-                                if (Patterns.WEB_URL.matcher(cUrl).matches()) {
-                                    createPostViewModel.getSiteMetadata(GetSiteMetadata(cUrl))
+                                if (Patterns.WEB_URL.matcher(url).matches()) {
+                                    createPostViewModel.getSiteMetadata(GetSiteMetadata(url.padUrlWithHttps()))
                                 }
                             }
                     },

--- a/app/src/test/java/com/jerboa/UtilsKtTest.kt
+++ b/app/src/test/java/com/jerboa/UtilsKtTest.kt
@@ -290,4 +290,12 @@ class UtilsKtTest {
         assertEquals("0.1", getParentPath("0.1.2"))
         assertEquals("0.1.2", getParentPath("0.1.2.3"))
     }
+
+    @Test
+    fun shouldPadUrlWithHttps() {
+        assertEquals("https://example.com", "example.com".padUrlWithHttps())
+        assertEquals("http://example.com", "http://example.com".padUrlWithHttps())
+        assertEquals("https://example.com", "https://example.com".padUrlWithHttps())
+        assertEquals("ws://example.com", "ws://example.com".padUrlWithHttps())
+    }
 }


### PR DESCRIPTION
Fixes a crash on creating post. Since the datatypes are no longer a parcelable. They can't be saved directly into rememberSaveables. There might be more of these cases. 

Also fixed #1281 by appending https when needed