### PR TITLE
Better fix for API creation in Verification procedure

### DIFF
--- a/app/src/main/java/com/jerboa/api/Http.kt
+++ b/app/src/main/java/com/jerboa/api/Http.kt
@@ -121,7 +121,6 @@ object API {
         }
     }
 
-
     suspend fun createTempInstance(
         host: String,
         auth: String? = null,

--- a/app/src/main/java/com/jerboa/api/Http.kt
+++ b/app/src/main/java/com/jerboa/api/Http.kt
@@ -108,6 +108,20 @@ object API {
         initialized.complete(Unit)
     }
 
+    suspend fun createTempInstanceSafe(
+        host: String,
+        auth: String? = null,
+        overrideVersion: String = DEFAULT_VERSION,
+    ): LemmyApiV19 {
+        return try {
+            createTempInstance(host, auth)
+        } catch (e: Throwable) {
+            Log.i("createTempInstanceSafe", "Failed to set lemmy instance", e)
+            createTempInstanceVersion(host, overrideVersion, auth)
+        }
+    }
+
+
     suspend fun createTempInstance(
         host: String,
         auth: String? = null,

--- a/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
+++ b/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
@@ -219,12 +219,7 @@ suspend fun Account.checkAccountVerification(
 ): Pair<AccountVerificationState, CheckState> {
     Log.d("verification", "Verification started")
 
-    val api =
-        if (this.isAnon()) {
-            API.createTempInstanceVersion(DEFAULT_INSTANCE, DEFAULT_VERSION)
-        } else {
-            API.createTempInstance(this.instance, this.jwt)
-        }
+    lateinit var api: LemmyApi
 
     var checkState: CheckState = CheckState.Passed
     var curVerificationState: Int =
@@ -248,7 +243,9 @@ suspend fun Account.checkAccountVerification(
 
                 AccountVerificationState.HAS_INTERNET -> checkInternet(ctx)
                 AccountVerificationState.INSTANCE_ALIVE -> checkInstance(this.instance)
+
                 AccountVerificationState.ACCOUNT_DELETED -> {
+                    api = API.createTempInstanceSafe(this.instance, this.jwt)
                     val p = checkIfAccountIsDeleted(this, api)
                     userRes = p.second
                     p.first

--- a/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
+++ b/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
@@ -13,8 +13,6 @@ import com.jerboa.MainActivity
 import com.jerboa.R
 import com.jerboa.api.API
 import com.jerboa.api.ApiState
-import com.jerboa.api.DEFAULT_INSTANCE
-import com.jerboa.api.DEFAULT_VERSION
 import com.jerboa.db.entity.Account
 import com.jerboa.db.entity.isAnon
 import com.jerboa.db.entity.isReady
@@ -243,7 +241,6 @@ suspend fun Account.checkAccountVerification(
 
                 AccountVerificationState.HAS_INTERNET -> checkInternet(ctx)
                 AccountVerificationState.INSTANCE_ALIVE -> checkInstance(this.instance)
-
                 AccountVerificationState.ACCOUNT_DELETED -> {
                     api = API.createTempInstanceSafe(this.instance, this.jwt)
                     val p = checkIfAccountIsDeleted(this, api)


### PR DESCRIPTION
It was easier to solve than I originally thought. We already check if the instance is alive. So only after we make the API (In a safe manner)

Fix  #1289