### PR TITLE
Fix logging in failing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,7 +187,7 @@ dependencies {
 
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.6")
 
-    implementation("it.vercruysse.lemmyapi:lemmy-api-jvm:0.1.0-SNAPSHOT")
+    implementation("it.vercruysse.lemmyapi:lemmy-api:0.2.0-SNAPSHOT")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.1")
     // Ktor uses SLF4J
     implementation("org.slf4j:slf4j-api:2.0.9")

--- a/app/src/main/java/com/jerboa/db/entity/Account.kt
+++ b/app/src/main/java/com/jerboa/db/entity/Account.kt
@@ -49,6 +49,3 @@ fun Account.isReady(): Boolean {
     return this.verificationState == AccountVerificationState.CHECKS_COMPLETE.ordinal
 }
 
-fun Account.getJWT(): String? {
-    return if (isAnon()) null else this.jwt
-}

--- a/app/src/main/java/com/jerboa/db/entity/Account.kt
+++ b/app/src/main/java/com/jerboa/db/entity/Account.kt
@@ -48,4 +48,3 @@ fun Account.isAnon(): Boolean {
 fun Account.isReady(): Boolean {
     return this.verificationState == AccountVerificationState.CHECKS_COMPLETE.ordinal
 }
-

--- a/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
+++ b/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
@@ -430,7 +430,6 @@ suspend fun Account.isReadyAndIfNotDisplayInfo(
                             accountVM.deleteAccountAndSwapCurrent(this, swapToAnon = true).invokeOnCompletion {
                                 appState.toLogin()
                             }
-
                         }
 
                         else ->

--- a/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
+++ b/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
@@ -157,7 +157,7 @@ suspend fun checkIfJWTValid(api: LemmyApi): CheckState {
         val resp = api.validateAuth()
 
         return@withContext if (resp.isSuccess) {
-            CheckState.Failed
+            CheckState.Passed
             //  Could check for exact body response `{"error":"not_logged_in"}` but could change over time and is unneeded
         } else if ((resp.exceptionOrNull() as? LemmyBadRequestException)?.code in 400..499) {
             CheckState.Failed


### PR DESCRIPTION
Fix #1294

Also fix a weird edge case were it seemed it didn't delete the existing user on trying to login again through the Verification action (It deletes your account)

Another thing we might want to do. Currently it throws a error with already signed in with this account error if trying to login again. We can give an option to replace the existing account?