### PR TITLE
Change structure of look and feel section in settings

### DIFF
--- a/app/src/main/java/com/jerboa/JerboaAppState.kt
+++ b/app/src/main/java/com/jerboa/JerboaAppState.kt
@@ -76,6 +76,14 @@ class JerboaAppState(
 
     fun toAbout() = navController.navigate(Route.ABOUT)
 
+    fun toInterface() = navController.navigate(Route.LOOK_AND_FEEL_INTERFACE)
+
+    fun toTheme() = navController.navigate(Route.LOOK_AND_FEEL_THEME)
+
+    fun toSecurity() = navController.navigate(Route.LOOK_AND_FEEL_SECURITY)
+
+    fun toAccessibility() = navController.navigate(Route.LOOK_AND_FEEL_ACCESSIBILITY)
+
     fun toCrashLogs() = navController.navigate(Route.CRASH_LOGS)
 
     fun openImageViewer(url: String) {

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -68,7 +68,11 @@ import com.jerboa.ui.components.settings.SettingsActivity
 import com.jerboa.ui.components.settings.about.AboutActivity
 import com.jerboa.ui.components.settings.account.AccountSettingsActivity
 import com.jerboa.ui.components.settings.crashlogs.CrashLogsActivity
+import com.jerboa.ui.components.settings.lookandfeel.AccessibilityActivity
+import com.jerboa.ui.components.settings.lookandfeel.InterfaceActivity
 import com.jerboa.ui.components.settings.lookandfeel.LookAndFeelActivity
+import com.jerboa.ui.components.settings.lookandfeel.SecurityActivity
+import com.jerboa.ui.components.settings.lookandfeel.ThemeActivity
 import com.jerboa.ui.theme.JerboaTheme
 import com.jerboa.util.markwon.BetterLinkMovementMethod
 
@@ -586,8 +590,44 @@ class MainActivity : AppCompatActivity() {
 
                     composable(route = Route.LOOK_AND_FEEL) {
                         LookAndFeelActivity(
+                            onBack = appState::popBackStack,
+                            onClickInterface = appState::toInterface,
+                            onClickTheme = appState::toTheme,
+                            onClickSecurity = appState::toSecurity,
+                            onClickAccessibility = appState::toAccessibility,
+                        )
+                    }
+
+                    composable(route = Route.LOOK_AND_FEEL_INTERFACE) {
+                        InterfaceActivity(
                             appSettingsViewModel = appSettingsViewModel,
                             onBack = appState::popBackStack,
+                        )
+                    }
+
+                    composable(route = Route.LOOK_AND_FEEL_THEME) {
+                        ThemeActivity(
+                            onBack = appState::popBackStack,
+                            onClickCrashLogs = appState::toCrashLogs,
+                            appSettingsViewModel = appSettingsViewModel,
+                        )
+                    }
+
+                    composable(route = Route.LOOK_AND_FEEL_SECURITY) {
+                        SecurityActivity(
+                            onBack = appState::popBackStack,
+                            onClickCrashLogs = appState::toCrashLogs,
+                            appSettingsViewModel = appSettingsViewModel,
+                        )
+                    }
+
+                    composable(route = Route.LOOK_AND_FEEL_ACCESSIBILITY) {
+                        AccessibilityActivity(
+                            useCustomTabs = appSettings.useCustomTabs,
+                            usePrivateTabs = appSettings.usePrivateTabs,
+                            onBack = appState::popBackStack,
+                            onClickCrashLogs = appState::toCrashLogs,
+                            openLinkRaw = appState::openLinkRaw,
                         )
                     }
 

--- a/app/src/main/java/com/jerboa/MainActivity.kt
+++ b/app/src/main/java/com/jerboa/MainActivity.kt
@@ -6,7 +6,6 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Patterns
 import android.widget.TextView
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -623,11 +622,8 @@ class MainActivity : AppCompatActivity() {
 
                     composable(route = Route.LOOK_AND_FEEL_ACCESSIBILITY) {
                         AccessibilityActivity(
-                            useCustomTabs = appSettings.useCustomTabs,
-                            usePrivateTabs = appSettings.usePrivateTabs,
                             onBack = appState::popBackStack,
                             onClickCrashLogs = appState::toCrashLogs,
-                            openLinkRaw = appState::openLinkRaw,
                         )
                     }
 

--- a/app/src/main/java/com/jerboa/ui/components/common/Route.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Route.kt
@@ -39,6 +39,10 @@ object Route {
 
     const val SETTINGS = "settings"
     const val LOOK_AND_FEEL = "lookAndFeel"
+    const val LOOK_AND_FEEL_INTERFACE = "interface"
+    const val LOOK_AND_FEEL_THEME = "theme"
+    const val LOOK_AND_FEEL_SECURITY = "security"
+    const val LOOK_AND_FEEL_ACCESSIBILITY = "accessibility"
     const val ACCOUNT_SETTINGS = "accountSettings"
     const val ABOUT = "about"
     const val CRASH_LOGS = "crashLogs"

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/AccessibilityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/AccessibilityActivity.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -20,11 +18,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.core.os.LocaleListCompat
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
 import com.alorma.compose.settings.ui.SettingsListDropdown
@@ -36,11 +32,8 @@ import com.jerboa.ui.components.common.SimpleTopAppBar
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccessibilityActivity(
-    useCustomTabs: Boolean,
-    usePrivateTabs: Boolean,
     onBack: () -> Unit,
-    onClickCrashLogs: () -> Unit,
-    openLinkRaw: (String, Boolean, Boolean) -> Unit,
+    onClickCrashLogs: () -> Unit
 ) {
     Log.d("jerboa", "Got to About activity")
 
@@ -55,10 +48,6 @@ fun AccessibilityActivity(
     val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
 
     val snackbarHostState = remember { SnackbarHostState() }
-
-    fun openLink(link: String) {
-        openLinkRaw(link, useCustomTabs, usePrivateTabs)
-    }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -95,31 +84,11 @@ fun AccessibilityActivity(
     )
 }
 
-@Composable
-fun SettingsDivider() {
-    Divider(modifier = Modifier.padding(vertical = 10.dp))
-}
-
-@Composable
-fun SettingsHeader(
-    text: String,
-    color: Color = MaterialTheme.colorScheme.primary,
-) {
-    Text(
-        text,
-        modifier = Modifier.padding(start = 64.dp),
-        color = color,
-    )
-}
-
 @Preview
 @Composable
 fun AccessibilityPreview() {
     AccessibilityActivity(
-        useCustomTabs = false,
-        usePrivateTabs = false,
         onBack = {},
-        onClickCrashLogs = {},
-        openLinkRaw = { _: String, _: Boolean, _: Boolean -> },
+        onClickCrashLogs = {}
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/AccessibilityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/AccessibilityActivity.kt
@@ -1,0 +1,125 @@
+
+package com.jerboa.ui.components.settings.lookandfeel
+
+import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.alorma.compose.settings.ui.SettingsListDropdown
+import com.jerboa.R
+import com.jerboa.getLangPreferenceDropdownEntries
+import com.jerboa.matchLocale
+import com.jerboa.ui.components.common.SimpleTopAppBar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AccessibilityActivity(
+    useCustomTabs: Boolean,
+    usePrivateTabs: Boolean,
+    onBack: () -> Unit,
+    onClickCrashLogs: () -> Unit,
+    openLinkRaw: (String, Boolean, Boolean) -> Unit,
+) {
+    Log.d("jerboa", "Got to About activity")
+
+    val ctx = LocalContext.current
+
+    val localeMap =
+        remember {
+            getLangPreferenceDropdownEntries(ctx)
+        }
+
+    val currentAppLocale = matchLocale(localeMap)
+    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    fun openLink(link: String) {
+        openLinkRaw(link, useCustomTabs, usePrivateTabs)
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            SimpleTopAppBar(text = "Accessibility", onClickBack = onBack)
+        },
+        content = { padding ->
+            Column(
+                modifier =
+                    Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(padding),
+            ) {
+                SettingsListDropdown(
+                    title = {
+                        Text(text = stringResource(R.string.lang_language))
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Language,
+                            contentDescription = stringResource(R.string.lang_language),
+                        )
+                    },
+                    state = langState,
+                    items = localeMap.values.toList(),
+                    onItemSelected = { i, _ ->
+                        AppCompatDelegate.setApplicationLocales(
+                            LocaleListCompat.create(localeMap.keys.elementAt(i)),
+                        )
+                    },
+                )
+            }
+        },
+    )
+}
+
+@Composable
+fun SettingsDivider() {
+    Divider(modifier = Modifier.padding(vertical = 10.dp))
+}
+
+@Composable
+fun SettingsHeader(
+    text: String,
+    color: Color = MaterialTheme.colorScheme.primary,
+) {
+    Text(
+        text,
+        modifier = Modifier.padding(start = 64.dp),
+        color = color,
+    )
+}
+
+@Preview
+@Composable
+fun AccessibilityPreview() {
+    AccessibilityActivity(
+        useCustomTabs = false,
+        usePrivateTabs = false,
+        onBack = {},
+        onClickCrashLogs = {},
+        openLinkRaw = { _: String, _: Boolean, _: Boolean -> },
+    )
+}

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/InterfaceActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/InterfaceActivity.kt
@@ -1,0 +1,295 @@
+package com.jerboa.ui.components.settings.lookandfeel
+
+import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Colorize
+import androidx.compose.material.icons.outlined.ExitToApp
+import androidx.compose.material.icons.outlined.FormatSize
+import androidx.compose.material.icons.outlined.Forum
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material.icons.outlined.LensBlur
+import androidx.compose.material.icons.outlined.Palette
+import androidx.compose.material.icons.outlined.Swipe
+import androidx.compose.material.icons.outlined.ViewList
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
+import com.alorma.compose.settings.storage.base.rememberFloatSettingState
+import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.alorma.compose.settings.ui.SettingsCheckbox
+import com.alorma.compose.settings.ui.SettingsList
+import com.alorma.compose.settings.ui.SettingsListDropdown
+import com.alorma.compose.settings.ui.SettingsSlider
+import com.jerboa.PostViewMode
+import com.jerboa.R
+import com.jerboa.ThemeColor
+import com.jerboa.ThemeMode
+import com.jerboa.db.APP_SETTINGS_DEFAULT
+import com.jerboa.db.entity.AppSettings
+import com.jerboa.feat.BackConfirmationMode
+import com.jerboa.feat.BlurTypes
+import com.jerboa.feat.PostActionbarMode
+import com.jerboa.feat.PostNavigationGestureMode
+import com.jerboa.getLangPreferenceDropdownEntries
+import com.jerboa.matchLocale
+import com.jerboa.model.AppSettingsViewModel
+import com.jerboa.ui.components.common.JerboaSnackbarHost
+import com.jerboa.ui.components.common.SimpleTopAppBar
+import com.jerboa.ui.components.settings.about.SettingsDivider
+import com.jerboa.ui.components.settings.about.SettingsHeader
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InterfaceActivity(
+    appSettingsViewModel: AppSettingsViewModel,
+    onBack: () -> Unit,
+) {
+    Log.d("jerboa", "Got to interface activity")
+    val ctx = LocalContext.current
+
+    val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
+    val themeState = rememberIntSettingState(settings.theme)
+    val themeColorState = rememberIntSettingState(settings.themeColor)
+
+    val localeMap =
+        remember {
+            getLangPreferenceDropdownEntries(ctx)
+        }
+
+    val currentAppLocale = matchLocale(localeMap)
+    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
+
+    val fontSizeState =
+        rememberFloatSettingState(
+            settings.fontSize.toFloat(),
+        )
+    val postViewModeState = rememberIntSettingState(settings.postViewMode)
+    val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
+    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
+    val showTextDescriptionsInNavbar = rememberBooleanSettingState(settings.showTextDescriptionsInNavbar)
+    val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
+    val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
+    val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
+    val showParentCommentNavigationButtonsState =
+        rememberBooleanSettingState(
+            settings.showParentCommentNavigationButtons,
+        )
+    val navigateParentCommentsWithVolumeButtonsState =
+        rememberBooleanSettingState(
+            settings.navigateParentCommentsWithVolumeButtons,
+        )
+    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
+    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
+
+    val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
+    val blurNSFW = rememberIntSettingState(settings.blurNSFW)
+    val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
+    val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
+    val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val scrollState = rememberScrollState()
+
+    val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
+    val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
+
+    fun updateAppSettings() {
+        appSettingsViewModel.update(
+            AppSettings(
+                id = 1,
+                viewedChangelog = settings.viewedChangelog,
+                theme = themeState.value,
+                themeColor = themeColorState.value,
+                fontSize = fontSizeState.value.toInt(),
+                postViewMode = postViewModeState.value,
+                showBottomNav = showBottomNavState.value,
+                showCollapsedCommentContent = showCollapsedCommentContentState.value,
+                showCommentActionBarByDefault = showCommentActionBarByDefaultState.value,
+                showVotingArrowsInListView = showVotingArrowsInListViewState.value,
+                showParentCommentNavigationButtons = showParentCommentNavigationButtonsState.value,
+                navigateParentCommentsWithVolumeButtons = navigateParentCommentsWithVolumeButtonsState.value,
+                useCustomTabs = useCustomTabsState.value,
+                usePrivateTabs = usePrivateTabsState.value,
+                secureWindow = secureWindowState.value,
+                showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
+                blurNSFW = blurNSFW.value,
+                backConfirmationMode = backConfirmationMode.value,
+                showPostLinkPreviews = showPostLinkPreviewMode.value,
+                markAsReadOnScroll = markAsReadOnScroll.value,
+                postActionbarMode = postActionbarMode.value,
+                autoPlayGifs = autoPlayGifs.value,
+                postNavigationGestureMode = postNavigationGestureModeState.value,
+            ),
+        )
+    }
+
+    Scaffold(
+        snackbarHost = { JerboaSnackbarHost(snackbarHostState) },
+        topBar = {
+            SimpleTopAppBar(text = "Interface", onClickBack = onBack)
+        },
+        content = { padding ->
+            Column(
+                modifier =
+                Modifier
+                    .verticalScroll(scrollState)
+                    .padding(padding),
+            ) {
+                SettingsHeader(text = "Font")
+                SettingsSlider(
+                    modifier = Modifier.padding(top = 10.dp),
+                    valueRange = 8f..48f,
+                    state = fontSizeState,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.FormatSize,
+                            contentDescription = null,
+                        )
+                    },
+                    title = {
+                        Text(
+                            text =
+                            stringResource(
+                                R.string.look_and_feel_font_size,
+                                fontSizeState.value.toInt(),
+                            ),
+                        )
+                    },
+                    onValueChangeFinished = { updateAppSettings() },
+                )
+                SettingsDivider()
+                SettingsHeader(text = "Posts")
+                SettingsList(
+                    state = postViewModeState,
+                    items = PostViewMode.entries.map { stringResource(it.mode) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.ViewList,
+                            contentDescription = null,
+                        )
+                    },
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_post_view))
+                    },
+                    onItemSelected = { i, _ ->
+                        postViewModeState.value = i
+                        updateAppSettings()
+                    },
+                )
+                SettingsList(
+                    title = {
+                        Text(text = stringResource(R.string.post_actionbar))
+                    },
+                    state = postActionbarMode,
+                    items = PostActionbarMode.entries.map { stringResource(it.resId) },
+                    onItemSelected = { i, _ ->
+                        postActionbarMode.value = i
+                        updateAppSettings()
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Forum,
+                            contentDescription = null,
+                        )
+                    },
+                )
+                SettingsCheckbox(
+                    state = showVotingArrowsInListViewState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_show_voting_arrows_list_view))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsListDropdown(
+                    state = blurNSFW,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.LensBlur,
+                            contentDescription = null,
+                        )
+                    },
+                    title = { Text(stringResource(id = R.string.blur_nsfw)) },
+                    items = BlurTypes.entries.map { stringResource(it.resId) },
+                    onItemSelected = { _, _ -> updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = showPostLinkPreviewMode,
+                    title = {
+                        Text(stringResource(id = R.string.show_post_link_previews))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = markAsReadOnScroll,
+                    title = {
+                        Text(stringResource(id = R.string.mark_as_read_on_scroll))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsDivider()
+                SettingsHeader(text = "Comments")
+                SettingsCheckbox(
+                    state = showCollapsedCommentContentState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_activity_show_content_for_collapsed_comments))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = showCommentActionBarByDefaultState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_show_action_bar_for_comments))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = showParentCommentNavigationButtonsState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_show_parent_comment_navigation_buttons))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = navigateParentCommentsWithVolumeButtonsState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_navigate_parent_comments_with_volume_buttons))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsDivider()
+                SettingsHeader(text = "Navigation Bar")
+                SettingsCheckbox(
+                    state = showBottomNavState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_show_navigation_bar))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = showTextDescriptionsInNavbar,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_show_text_descriptions_in_navbar))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                    enabled = showBottomNavState.value,
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/InterfaceActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/InterfaceActivity.kt
@@ -1,20 +1,14 @@
 package com.jerboa.ui.components.settings.lookandfeel
 
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Colorize
-import androidx.compose.material.icons.outlined.ExitToApp
 import androidx.compose.material.icons.outlined.FormatSize
 import androidx.compose.material.icons.outlined.Forum
-import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LensBlur
-import androidx.compose.material.icons.outlined.Palette
-import androidx.compose.material.icons.outlined.Swipe
 import androidx.compose.material.icons.outlined.ViewList
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -24,10 +18,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.os.LocaleListCompat
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
 import com.alorma.compose.settings.storage.base.rememberFloatSettingState
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
@@ -37,16 +29,10 @@ import com.alorma.compose.settings.ui.SettingsListDropdown
 import com.alorma.compose.settings.ui.SettingsSlider
 import com.jerboa.PostViewMode
 import com.jerboa.R
-import com.jerboa.ThemeColor
-import com.jerboa.ThemeMode
 import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.entity.AppSettings
-import com.jerboa.feat.BackConfirmationMode
 import com.jerboa.feat.BlurTypes
 import com.jerboa.feat.PostActionbarMode
-import com.jerboa.feat.PostNavigationGestureMode
-import com.jerboa.getLangPreferenceDropdownEntries
-import com.jerboa.matchLocale
 import com.jerboa.model.AppSettingsViewModel
 import com.jerboa.ui.components.common.JerboaSnackbarHost
 import com.jerboa.ui.components.common.SimpleTopAppBar
@@ -60,24 +46,12 @@ fun InterfaceActivity(
     onBack: () -> Unit,
 ) {
     Log.d("jerboa", "Got to interface activity")
-    val ctx = LocalContext.current
 
+    // App settings variables
     val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
     val themeState = rememberIntSettingState(settings.theme)
     val themeColorState = rememberIntSettingState(settings.themeColor)
-
-    val localeMap =
-        remember {
-            getLangPreferenceDropdownEntries(ctx)
-        }
-
-    val currentAppLocale = matchLocale(localeMap)
-    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
-
-    val fontSizeState =
-        rememberFloatSettingState(
-            settings.fontSize.toFloat(),
-        )
+    val fontSizeState = rememberFloatSettingState(settings.fontSize.toFloat())
     val postViewModeState = rememberIntSettingState(settings.postViewMode)
     val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
     val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
@@ -85,29 +59,21 @@ fun InterfaceActivity(
     val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
     val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
     val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
-    val showParentCommentNavigationButtonsState =
-        rememberBooleanSettingState(
-            settings.showParentCommentNavigationButtons,
-        )
-    val navigateParentCommentsWithVolumeButtonsState =
-        rememberBooleanSettingState(
-            settings.navigateParentCommentsWithVolumeButtons,
-        )
+    val showParentCommentNavigationButtonsState = rememberBooleanSettingState(settings.showParentCommentNavigationButtons)
+    val navigateParentCommentsWithVolumeButtonsState = rememberBooleanSettingState(settings.navigateParentCommentsWithVolumeButtons)
     val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
     val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
-
     val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
     val blurNSFW = rememberIntSettingState(settings.blurNSFW)
     val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
     val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
     val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
+    val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
+    val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
 
     val snackbarHostState = remember { SnackbarHostState() }
 
     val scrollState = rememberScrollState()
-
-    val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
-    val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
 
     fun updateAppSettings() {
         appSettingsViewModel.update(

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -7,11 +7,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.GridView
-import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Translate
-import androidx.compose.material.icons.outlined.WheelchairPickup
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -1,21 +1,17 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.jerboa.ui.components.settings.lookandfeel
 
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Colorize
-import androidx.compose.material.icons.outlined.ExitToApp
-import androidx.compose.material.icons.outlined.FormatSize
-import androidx.compose.material.icons.outlined.Forum
+import androidx.compose.material.icons.outlined.GridView
 import androidx.compose.material.icons.outlined.Language
-import androidx.compose.material.icons.outlined.LensBlur
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Palette
-import androidx.compose.material.icons.outlined.Swipe
-import androidx.compose.material.icons.outlined.ViewList
+import androidx.compose.material.icons.outlined.Translate
+import androidx.compose.material.icons.outlined.WheelchairPickup
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -24,375 +20,71 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.core.os.LocaleListCompat
-import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
-import com.alorma.compose.settings.storage.base.rememberFloatSettingState
-import com.alorma.compose.settings.storage.base.rememberIntSettingState
-import com.alorma.compose.settings.ui.SettingsCheckbox
-import com.alorma.compose.settings.ui.SettingsList
-import com.alorma.compose.settings.ui.SettingsListDropdown
-import com.alorma.compose.settings.ui.SettingsSlider
-import com.jerboa.PostViewMode
+import com.alorma.compose.settings.ui.SettingsMenuLink
 import com.jerboa.R
-import com.jerboa.ThemeColor
-import com.jerboa.ThemeMode
-import com.jerboa.db.APP_SETTINGS_DEFAULT
-import com.jerboa.db.entity.AppSettings
-import com.jerboa.feat.BackConfirmationMode
-import com.jerboa.feat.BlurTypes
-import com.jerboa.feat.PostActionbarMode
-import com.jerboa.feat.PostNavigationGestureMode
-import com.jerboa.getLangPreferenceDropdownEntries
-import com.jerboa.matchLocale
-import com.jerboa.model.AppSettingsViewModel
 import com.jerboa.ui.components.common.JerboaSnackbarHost
 import com.jerboa.ui.components.common.SimpleTopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LookAndFeelActivity(
-    appSettingsViewModel: AppSettingsViewModel,
     onBack: () -> Unit,
+    onClickInterface: () -> Unit,
+    onClickTheme: () -> Unit,
+    onClickSecurity: () -> Unit,
+    onClickAccessibility: () -> Unit
 ) {
     Log.d("jerboa", "Got to lookAndFeel activity")
-    val ctx = LocalContext.current
-
-    val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
-    val themeState = rememberIntSettingState(settings.theme)
-    val themeColorState = rememberIntSettingState(settings.themeColor)
-
-    val localeMap =
-        remember {
-            getLangPreferenceDropdownEntries(ctx)
-        }
-
-    val currentAppLocale = matchLocale(localeMap)
-    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
-
-    val fontSizeState =
-        rememberFloatSettingState(
-            settings.fontSize.toFloat(),
-        )
-    val postViewModeState = rememberIntSettingState(settings.postViewMode)
-    val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
-    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
-    val showTextDescriptionsInNavbar = rememberBooleanSettingState(settings.showTextDescriptionsInNavbar)
-    val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
-    val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
-    val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
-    val showParentCommentNavigationButtonsState =
-        rememberBooleanSettingState(
-            settings.showParentCommentNavigationButtons,
-        )
-    val navigateParentCommentsWithVolumeButtonsState =
-        rememberBooleanSettingState(
-            settings.navigateParentCommentsWithVolumeButtons,
-        )
-    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
-    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
-
-    val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
-    val blurNSFW = rememberIntSettingState(settings.blurNSFW)
-    val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
-    val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
-    val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
 
     val snackbarHostState = remember { SnackbarHostState() }
-
-    val scrollState = rememberScrollState()
-
-    val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
-    val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
-
-    fun updateAppSettings() {
-        appSettingsViewModel.update(
-            AppSettings(
-                id = 1,
-                viewedChangelog = settings.viewedChangelog,
-                theme = themeState.value,
-                themeColor = themeColorState.value,
-                fontSize = fontSizeState.value.toInt(),
-                postViewMode = postViewModeState.value,
-                showBottomNav = showBottomNavState.value,
-                showCollapsedCommentContent = showCollapsedCommentContentState.value,
-                showCommentActionBarByDefault = showCommentActionBarByDefaultState.value,
-                showVotingArrowsInListView = showVotingArrowsInListViewState.value,
-                showParentCommentNavigationButtons = showParentCommentNavigationButtonsState.value,
-                navigateParentCommentsWithVolumeButtons = navigateParentCommentsWithVolumeButtonsState.value,
-                useCustomTabs = useCustomTabsState.value,
-                usePrivateTabs = usePrivateTabsState.value,
-                secureWindow = secureWindowState.value,
-                showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
-                blurNSFW = blurNSFW.value,
-                backConfirmationMode = backConfirmationMode.value,
-                showPostLinkPreviews = showPostLinkPreviewMode.value,
-                markAsReadOnScroll = markAsReadOnScroll.value,
-                postActionbarMode = postActionbarMode.value,
-                autoPlayGifs = autoPlayGifs.value,
-                postNavigationGestureMode = postNavigationGestureModeState.value,
-            ),
-        )
-    }
 
     Scaffold(
         snackbarHost = { JerboaSnackbarHost(snackbarHostState) },
         topBar = {
-            SimpleTopAppBar(text = stringResource(R.string.look_and_feel_look_and_feel), onClickBack = onBack)
+            SimpleTopAppBar(text = stringResource(R.string.settings_activity_look_and_feel), onClickBack = onBack)
         },
         content = { padding ->
-            Column(
-                modifier =
-                    Modifier
-                        .verticalScroll(scrollState)
-                        .padding(padding),
-            ) {
-                SettingsListDropdown(
-                    title = {
-                        Text(text = stringResource(R.string.lang_language))
-                    },
+            Column(modifier = Modifier.padding(padding)) {
+                SettingsMenuLink(
+                    title = { Text("Interface") },
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.Language,
-                            contentDescription = stringResource(R.string.lang_language),
-                        )
-                    },
-                    state = langState,
-                    items = localeMap.values.toList(),
-                    onItemSelected = { i, _ ->
-                        AppCompatDelegate.setApplicationLocales(
-                            LocaleListCompat.create(localeMap.keys.elementAt(i)),
-                        )
-                    },
-                )
-                SettingsSlider(
-                    modifier = Modifier.padding(top = 10.dp),
-                    valueRange = 8f..48f,
-                    state = fontSizeState,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.FormatSize,
+                            imageVector = Icons.Outlined.GridView,
                             contentDescription = null,
                         )
                     },
-                    title = {
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.look_and_feel_font_size,
-                                    fontSizeState.value.toInt(),
-                                ),
-                        )
-                    },
-                    onValueChangeFinished = { updateAppSettings() },
+                    onClick = onClickInterface,
                 )
-                SettingsList(
-                    state = themeState,
-                    items = ThemeMode.entries.map { stringResource(it.mode) },
+                SettingsMenuLink(
+                    title = { Text("Theme") },
                     icon = {
                         Icon(
                             imageVector = Icons.Outlined.Palette,
                             contentDescription = null,
                         )
                     },
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_theme))
-                    },
-                    onItemSelected = { i, _ ->
-                        themeState.value = i
-                        updateAppSettings()
-                    },
+                    onClick = onClickTheme,
                 )
-                SettingsList(
-                    state = themeColorState,
-                    items = ThemeColor.entries.map { stringResource(it.mode) },
+                SettingsMenuLink(
+                    title = { Text("Security") },
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.Colorize,
+                            imageVector = Icons.Outlined.Lock,
                             contentDescription = null,
                         )
                     },
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_theme_color))
-                    },
-                    onItemSelected = { i, _ ->
-                        themeColorState.value = i
-                        updateAppSettings()
-                    },
+                    onClick = onClickSecurity,
                 )
-                SettingsList(
-                    state = postViewModeState,
-                    items = PostViewMode.entries.map { stringResource(it.mode) },
+                SettingsMenuLink(
+                    title = { Text("Accessibility") },
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.ViewList,
+                            imageVector = Icons.Outlined.Translate,
                             contentDescription = null,
                         )
                     },
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_post_view))
-                    },
-                    onItemSelected = { i, _ ->
-                        postViewModeState.value = i
-                        updateAppSettings()
-                    },
-                )
-                SettingsList(
-                    state = postNavigationGestureModeState,
-                    items = PostNavigationGestureMode.entries.map { stringResource(it.mode) },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Swipe,
-                            contentDescription = null,
-                        )
-                    },
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_post_navigation_gesture_mode))
-                    },
-                    onItemSelected = { i, _ ->
-                        postNavigationGestureModeState.value = i
-                        updateAppSettings()
-                    },
-                )
-                SettingsList(
-                    title = {
-                        Text(text = stringResource(R.string.confirm_exit))
-                    },
-                    state = backConfirmationMode,
-                    items = BackConfirmationMode.entries.map { stringResource(it.resId) },
-                    onItemSelected = { i, _ ->
-                        backConfirmationMode.value = i
-                        updateAppSettings()
-                    },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.ExitToApp,
-                            contentDescription = null,
-                        )
-                    },
-                )
-                SettingsList(
-                    title = {
-                        Text(text = stringResource(R.string.post_actionbar))
-                    },
-                    state = postActionbarMode,
-                    items = PostActionbarMode.entries.map { stringResource(it.resId) },
-                    onItemSelected = { i, _ ->
-                        postActionbarMode.value = i
-                        updateAppSettings()
-                    },
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.Forum,
-                            contentDescription = null,
-                        )
-                    },
-                )
-                SettingsListDropdown(
-                    state = blurNSFW,
-                    icon = {
-                        Icon(
-                            imageVector = Icons.Outlined.LensBlur,
-                            contentDescription = null,
-                        )
-                    },
-                    title = { Text(stringResource(id = R.string.blur_nsfw)) },
-                    items = BlurTypes.entries.map { stringResource(it.resId) },
-                    onItemSelected = { _, _ -> updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = showBottomNavState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_show_navigation_bar))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = showTextDescriptionsInNavbar,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_show_text_descriptions_in_navbar))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                    enabled = showBottomNavState.value,
-                )
-                SettingsCheckbox(
-                    state = showCollapsedCommentContentState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_activity_show_content_for_collapsed_comments))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = showCommentActionBarByDefaultState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_show_action_bar_for_comments))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = showVotingArrowsInListViewState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_show_voting_arrows_list_view))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = showParentCommentNavigationButtonsState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_show_parent_comment_navigation_buttons))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = navigateParentCommentsWithVolumeButtonsState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_navigate_parent_comments_with_volume_buttons))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = useCustomTabsState,
-                    title = {
-                        Text(text = stringResource(id = R.string.look_and_feel_use_custom_tabs))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = usePrivateTabsState,
-                    title = {
-                        Text(text = stringResource(id = R.string.look_and_feel_use_private_tabs))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = secureWindowState,
-                    title = {
-                        Text(text = stringResource(R.string.look_and_feel_secure_window))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = showPostLinkPreviewMode,
-                    title = {
-                        Text(stringResource(id = R.string.show_post_link_previews))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = markAsReadOnScroll,
-                    title = {
-                        Text(stringResource(id = R.string.mark_as_read_on_scroll))
-                    },
-                    onCheckedChange = { updateAppSettings() },
-                )
-                SettingsCheckbox(
-                    state = autoPlayGifs,
-                    title = {
-                        Text(stringResource(id = R.string.settings_autoplaygifs))
-                    },
-                    onCheckedChange = { updateAppSettings() },
+                    onClick = onClickAccessibility,
                 )
             }
         },

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/SecurityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/SecurityActivity.kt
@@ -1,0 +1,168 @@
+
+package com.jerboa.ui.components.settings.lookandfeel
+
+import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.alorma.compose.settings.ui.SettingsList
+import com.alorma.compose.settings.ui.SettingsListDropdown
+import com.jerboa.R
+import com.jerboa.getLangPreferenceDropdownEntries
+import com.jerboa.matchLocale
+import com.jerboa.model.AppSettingsViewModel
+import com.jerboa.db.APP_SETTINGS_DEFAULT
+import com.jerboa.db.entity.AppSettings
+import com.jerboa.ThemeColor
+import com.jerboa.ThemeMode
+import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
+import com.alorma.compose.settings.storage.base.rememberFloatSettingState
+import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.alorma.compose.settings.ui.SettingsCheckbox
+import com.jerboa.ui.components.common.SimpleTopAppBar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SecurityActivity(
+    onBack: () -> Unit,
+    onClickCrashLogs: () -> Unit,
+    appSettingsViewModel: AppSettingsViewModel,
+) {
+    Log.d("jerboa", "Got to About activity")
+
+    val ctx = LocalContext.current
+
+    val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
+    val themeState = rememberIntSettingState(settings.theme)
+    val themeColorState = rememberIntSettingState(settings.themeColor)
+
+    val localeMap =
+        remember {
+            getLangPreferenceDropdownEntries(ctx)
+        }
+
+    val currentAppLocale = matchLocale(localeMap)
+    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
+
+    val fontSizeState =
+        rememberFloatSettingState(
+            settings.fontSize.toFloat(),
+        )
+    val postViewModeState = rememberIntSettingState(settings.postViewMode)
+    val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
+    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
+    val showTextDescriptionsInNavbar = rememberBooleanSettingState(settings.showTextDescriptionsInNavbar)
+    val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
+    val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
+    val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
+    val showParentCommentNavigationButtonsState =
+        rememberBooleanSettingState(
+            settings.showParentCommentNavigationButtons,
+        )
+    val navigateParentCommentsWithVolumeButtonsState =
+        rememberBooleanSettingState(
+            settings.navigateParentCommentsWithVolumeButtons,
+        )
+    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
+    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
+
+    val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
+    val blurNSFW = rememberIntSettingState(settings.blurNSFW)
+    val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
+    val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
+    val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
+    val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
+
+    fun updateAppSettings() {
+        appSettingsViewModel.update(
+            AppSettings(
+                id = 1,
+                viewedChangelog = settings.viewedChangelog,
+                theme = themeState.value,
+                themeColor = themeColorState.value,
+                fontSize = fontSizeState.value.toInt(),
+                postViewMode = postViewModeState.value,
+                showBottomNav = showBottomNavState.value,
+                showCollapsedCommentContent = showCollapsedCommentContentState.value,
+                showCommentActionBarByDefault = showCommentActionBarByDefaultState.value,
+                showVotingArrowsInListView = showVotingArrowsInListViewState.value,
+                showParentCommentNavigationButtons = showParentCommentNavigationButtonsState.value,
+                navigateParentCommentsWithVolumeButtons = navigateParentCommentsWithVolumeButtonsState.value,
+                useCustomTabs = useCustomTabsState.value,
+                usePrivateTabs = usePrivateTabsState.value,
+                secureWindow = secureWindowState.value,
+                showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
+                blurNSFW = blurNSFW.value,
+                backConfirmationMode = backConfirmationMode.value,
+                showPostLinkPreviews = showPostLinkPreviewMode.value,
+                markAsReadOnScroll = markAsReadOnScroll.value,
+                postActionbarMode = postActionbarMode.value,
+                autoPlayGifs = autoPlayGifs.value,
+                postNavigationGestureMode = postNavigationGestureModeState.value,
+            ),
+        )
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            SimpleTopAppBar(text = "Theme", onClickBack = onBack)
+        },
+        content = { padding ->
+            Column(
+                modifier =
+                    Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(padding),
+            ) {
+                SettingsCheckbox(
+                    state = secureWindowState,
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_secure_window))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = useCustomTabsState,
+                    title = {
+                        Text(text = stringResource(id = R.string.look_and_feel_use_custom_tabs))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+                SettingsCheckbox(
+                    state = usePrivateTabsState,
+                    title = {
+                        Text(text = stringResource(id = R.string.look_and_feel_use_private_tabs))
+                    },
+                    onCheckedChange = { updateAppSettings() },
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/SecurityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/SecurityActivity.kt
@@ -2,17 +2,11 @@
 package com.jerboa.ui.components.settings.lookandfeel
 
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -20,26 +14,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.core.os.LocaleListCompat
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
-import com.alorma.compose.settings.ui.SettingsList
-import com.alorma.compose.settings.ui.SettingsListDropdown
 import com.jerboa.R
-import com.jerboa.getLangPreferenceDropdownEntries
-import com.jerboa.matchLocale
 import com.jerboa.model.AppSettingsViewModel
 import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.entity.AppSettings
-import com.jerboa.ThemeColor
-import com.jerboa.ThemeMode
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
 import com.alorma.compose.settings.storage.base.rememberFloatSettingState
-import com.alorma.compose.settings.storage.base.rememberIntSettingState
 import com.alorma.compose.settings.ui.SettingsCheckbox
 import com.jerboa.ui.components.common.SimpleTopAppBar
 
@@ -52,24 +34,11 @@ fun SecurityActivity(
 ) {
     Log.d("jerboa", "Got to About activity")
 
-    val ctx = LocalContext.current
-
+    // App settings variables
     val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
     val themeState = rememberIntSettingState(settings.theme)
     val themeColorState = rememberIntSettingState(settings.themeColor)
-
-    val localeMap =
-        remember {
-            getLangPreferenceDropdownEntries(ctx)
-        }
-
-    val currentAppLocale = matchLocale(localeMap)
-    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
-
-    val fontSizeState =
-        rememberFloatSettingState(
-            settings.fontSize.toFloat(),
-        )
+    val fontSizeState = rememberFloatSettingState(settings.fontSize.toFloat())
     val postViewModeState = rememberIntSettingState(settings.postViewMode)
     val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
     val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
@@ -77,27 +46,19 @@ fun SecurityActivity(
     val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
     val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
     val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
-    val showParentCommentNavigationButtonsState =
-        rememberBooleanSettingState(
-            settings.showParentCommentNavigationButtons,
-        )
-    val navigateParentCommentsWithVolumeButtonsState =
-        rememberBooleanSettingState(
-            settings.navigateParentCommentsWithVolumeButtons,
-        )
+    val showParentCommentNavigationButtonsState = rememberBooleanSettingState(settings.showParentCommentNavigationButtons)
+    val navigateParentCommentsWithVolumeButtonsState = rememberBooleanSettingState(settings.navigateParentCommentsWithVolumeButtons)
     val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
     val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
-
     val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
     val blurNSFW = rememberIntSettingState(settings.blurNSFW)
     val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
     val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
     val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
-
-    val snackbarHostState = remember { SnackbarHostState() }
-
     val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
     val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
+
+    val snackbarHostState = remember { SnackbarHostState() }
 
     fun updateAppSettings() {
         appSettingsViewModel.update(

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/ThemeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/ThemeActivity.kt
@@ -1,0 +1,180 @@
+
+package com.jerboa.ui.components.settings.lookandfeel
+
+import android.util.Log
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.*
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.alorma.compose.settings.ui.SettingsList
+import com.alorma.compose.settings.ui.SettingsListDropdown
+import com.jerboa.R
+import com.jerboa.getLangPreferenceDropdownEntries
+import com.jerboa.matchLocale
+import com.jerboa.model.AppSettingsViewModel
+import com.jerboa.db.APP_SETTINGS_DEFAULT
+import com.jerboa.db.entity.AppSettings
+import com.jerboa.ThemeColor
+import com.jerboa.ThemeMode
+import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
+import com.alorma.compose.settings.storage.base.rememberFloatSettingState
+import com.alorma.compose.settings.storage.base.rememberIntSettingState
+import com.jerboa.ui.components.common.SimpleTopAppBar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ThemeActivity(
+    onBack: () -> Unit,
+    onClickCrashLogs: () -> Unit,
+    appSettingsViewModel: AppSettingsViewModel,
+) {
+    Log.d("jerboa", "Got to About activity")
+
+    val ctx = LocalContext.current
+
+    val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
+    val themeState = rememberIntSettingState(settings.theme)
+    val themeColorState = rememberIntSettingState(settings.themeColor)
+
+    val localeMap =
+        remember {
+            getLangPreferenceDropdownEntries(ctx)
+        }
+
+    val currentAppLocale = matchLocale(localeMap)
+    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
+
+    val fontSizeState =
+        rememberFloatSettingState(
+            settings.fontSize.toFloat(),
+        )
+    val postViewModeState = rememberIntSettingState(settings.postViewMode)
+    val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
+    val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
+    val showTextDescriptionsInNavbar = rememberBooleanSettingState(settings.showTextDescriptionsInNavbar)
+    val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
+    val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
+    val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
+    val showParentCommentNavigationButtonsState =
+        rememberBooleanSettingState(
+            settings.showParentCommentNavigationButtons,
+        )
+    val navigateParentCommentsWithVolumeButtonsState =
+        rememberBooleanSettingState(
+            settings.navigateParentCommentsWithVolumeButtons,
+        )
+    val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
+    val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
+
+    val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
+    val blurNSFW = rememberIntSettingState(settings.blurNSFW)
+    val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
+    val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
+    val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
+
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
+    val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
+
+    fun updateAppSettings() {
+        appSettingsViewModel.update(
+            AppSettings(
+                id = 1,
+                viewedChangelog = settings.viewedChangelog,
+                theme = themeState.value,
+                themeColor = themeColorState.value,
+                fontSize = fontSizeState.value.toInt(),
+                postViewMode = postViewModeState.value,
+                showBottomNav = showBottomNavState.value,
+                showCollapsedCommentContent = showCollapsedCommentContentState.value,
+                showCommentActionBarByDefault = showCommentActionBarByDefaultState.value,
+                showVotingArrowsInListView = showVotingArrowsInListViewState.value,
+                showParentCommentNavigationButtons = showParentCommentNavigationButtonsState.value,
+                navigateParentCommentsWithVolumeButtons = navigateParentCommentsWithVolumeButtonsState.value,
+                useCustomTabs = useCustomTabsState.value,
+                usePrivateTabs = usePrivateTabsState.value,
+                secureWindow = secureWindowState.value,
+                showTextDescriptionsInNavbar = showTextDescriptionsInNavbar.value,
+                blurNSFW = blurNSFW.value,
+                backConfirmationMode = backConfirmationMode.value,
+                showPostLinkPreviews = showPostLinkPreviewMode.value,
+                markAsReadOnScroll = markAsReadOnScroll.value,
+                postActionbarMode = postActionbarMode.value,
+                autoPlayGifs = autoPlayGifs.value,
+                postNavigationGestureMode = postNavigationGestureModeState.value,
+            ),
+        )
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            SimpleTopAppBar(text = "Theme", onClickBack = onBack)
+        },
+        content = { padding ->
+            Column(
+                modifier =
+                    Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(padding),
+            ) {
+                SettingsList(
+                    state = themeState,
+                    items = ThemeMode.entries.map { stringResource(it.mode) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Palette,
+                            contentDescription = null,
+                        )
+                    },
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_theme))
+                    },
+                    onItemSelected = { i, _ ->
+                        themeState.value = i
+                        updateAppSettings()
+                    },
+                )
+                SettingsList(
+                    state = themeColorState,
+                    items = ThemeColor.entries.map { stringResource(it.mode) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Colorize,
+                            contentDescription = null,
+                        )
+                    },
+                    title = {
+                        Text(text = stringResource(R.string.look_and_feel_theme_color))
+                    },
+                    onItemSelected = { i, _ ->
+                        themeColorState.value = i
+                        updateAppSettings()
+                    },
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/ThemeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/ThemeActivity.kt
@@ -2,17 +2,14 @@
 package com.jerboa.ui.components.settings.lookandfeel
 
 import android.util.Log
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -20,15 +17,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.core.os.LocaleListCompat
 import com.alorma.compose.settings.storage.base.rememberIntSettingState
 import com.alorma.compose.settings.ui.SettingsList
-import com.alorma.compose.settings.ui.SettingsListDropdown
 import com.jerboa.R
 import com.jerboa.getLangPreferenceDropdownEntries
 import com.jerboa.matchLocale
@@ -39,7 +31,6 @@ import com.jerboa.ThemeColor
 import com.jerboa.ThemeMode
 import com.alorma.compose.settings.storage.base.rememberBooleanSettingState
 import com.alorma.compose.settings.storage.base.rememberFloatSettingState
-import com.alorma.compose.settings.storage.base.rememberIntSettingState
 import com.jerboa.ui.components.common.SimpleTopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -51,24 +42,11 @@ fun ThemeActivity(
 ) {
     Log.d("jerboa", "Got to About activity")
 
-    val ctx = LocalContext.current
-
+    // App settings variables
     val settings = appSettingsViewModel.appSettings.value ?: APP_SETTINGS_DEFAULT
     val themeState = rememberIntSettingState(settings.theme)
     val themeColorState = rememberIntSettingState(settings.themeColor)
-
-    val localeMap =
-        remember {
-            getLangPreferenceDropdownEntries(ctx)
-        }
-
-    val currentAppLocale = matchLocale(localeMap)
-    val langState = rememberIntSettingState(localeMap.keys.indexOf(currentAppLocale))
-
-    val fontSizeState =
-        rememberFloatSettingState(
-            settings.fontSize.toFloat(),
-        )
+    val fontSizeState = rememberFloatSettingState(settings.fontSize.toFloat())
     val postViewModeState = rememberIntSettingState(settings.postViewMode)
     val postNavigationGestureModeState = rememberIntSettingState(settings.postNavigationGestureMode)
     val showBottomNavState = rememberBooleanSettingState(settings.showBottomNav)
@@ -76,27 +54,19 @@ fun ThemeActivity(
     val showCollapsedCommentContentState = rememberBooleanSettingState(settings.showCollapsedCommentContent)
     val showCommentActionBarByDefaultState = rememberBooleanSettingState(settings.showCommentActionBarByDefault)
     val showVotingArrowsInListViewState = rememberBooleanSettingState(settings.showVotingArrowsInListView)
-    val showParentCommentNavigationButtonsState =
-        rememberBooleanSettingState(
-            settings.showParentCommentNavigationButtons,
-        )
-    val navigateParentCommentsWithVolumeButtonsState =
-        rememberBooleanSettingState(
-            settings.navigateParentCommentsWithVolumeButtons,
-        )
+    val showParentCommentNavigationButtonsState = rememberBooleanSettingState(settings.showParentCommentNavigationButtons)
+    val navigateParentCommentsWithVolumeButtonsState = rememberBooleanSettingState(settings.navigateParentCommentsWithVolumeButtons)
     val useCustomTabsState = rememberBooleanSettingState(settings.useCustomTabs)
     val usePrivateTabsState = rememberBooleanSettingState(settings.usePrivateTabs)
-
     val secureWindowState = rememberBooleanSettingState(settings.secureWindow)
     val blurNSFW = rememberIntSettingState(settings.blurNSFW)
     val backConfirmationMode = rememberIntSettingState(settings.backConfirmationMode)
     val showPostLinkPreviewMode = rememberBooleanSettingState(settings.showPostLinkPreviews)
     val postActionbarMode = rememberIntSettingState(settings.postActionbarMode)
-
-    val snackbarHostState = remember { SnackbarHostState() }
-
     val markAsReadOnScroll = rememberBooleanSettingState(settings.markAsReadOnScroll)
     val autoPlayGifs = rememberBooleanSettingState(settings.autoPlayGifs)
+
+    val snackbarHostState = remember { SnackbarHostState() }
 
     fun updateAppSettings() {
         appSettingsViewModel.update(


### PR DESCRIPTION
**THIS IS WORK IN PROGRESS, NOT FINISHED. CURRENT TODOS:**
- [ ] Replace all references of `SettingsHeader(text = "XXX")` with proper `stringResource(R.string.XXX)`
  - [ ] Line 66, AccessibilityActivity
  - [ ] Lines (145, 154, 177, 246, 276), InterfaceActivity
  - [ ] Line 135, SecurityActivity
  - [ ] Line 134, ThemeActivity
- [x] remove unused imports and functions

I held off on making new lines in the strings file because I didn't know what to name them / where to place them in the file according to you guys' standards

There's some useless imports/functions/variables in the code atm because I copied files around. Will fix those in a bit. Also my formatting in general is probably bad.
Also I'm not sure about the naming of the files (InterfaceActivity in particular)

This code however is functional from my testing.

PR for #1161