### PR TITLE
Woodpecker CI cache fixes

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -76,8 +76,8 @@ steps:
     secrets:
       [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
     when:
-      - event: push
-        branch: main
+      - path:
+          include: ["app/build.gradle.kts"]
 
   notify:
     image: alpine:3

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -75,7 +75,7 @@ steps:
         - ".gradle"
     secrets:
       [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
-    #when:
+    ##when:
     #  event: cron
 
   notify:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -22,7 +22,7 @@ steps:
       path-style: true
       backend_operation_timeout: 30m
       compression_level: 0
-      exit_code: true
+      #exit_code: true
       mount:
         - ".gradle"
     secrets:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -20,7 +20,7 @@ steps:
       region: us-east-1
       cache_key: "jerboa-cache"
       path-style: true
-      backend_operation_timeout: 30m
+      backend_operation_timeout: 15m
       compression_level: 0
       exit_code: true
       mount:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -22,7 +22,7 @@ steps:
       path-style: true
       backend_operation_timeout: 30m
       compression_level: 0
-      #exit_code: true
+      exit_code: true
       mount:
         - ".gradle"
     secrets:
@@ -75,8 +75,9 @@ steps:
         - ".gradle"
     secrets:
       [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
-    ##when:
-    #  event: cron
+    when:
+      - event: push
+        branch: main
 
   notify:
     image: alpine:3

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -20,6 +20,9 @@ steps:
       region: us-east-1
       cache_key: "jerboa-cache"
       path-style: true
+      backend_operation_timeout: 30m
+      compression_level: 0
+      exit_code: true
       mount:
         - ".gradle"
     secrets:
@@ -65,13 +68,15 @@ steps:
       cache_key: "jerboa-cache"
       region: us-east-1
       path-style: true
+      backend_operation_timeout: 60m
+      compression_level: 0
+      exit_code: true
       mount:
         - ".gradle"
     secrets:
       [MINIO_ENDPOINT, MINIO_WRITE_USER, MINIO_WRITE_PASSWORD, MINIO_BUCKET]
-    when:
-      - path:
-          include: ["app/build.gradle.kts"]
+    #when:
+    #  event: cron
 
   notify:
     image: alpine:3


### PR DESCRIPTION
Same as https://github.com/LemmyNet/lemmy/pull/4276:

- Fail CI run on cache error so that we can actually notice and fix problems
- Increase timeout for cache operations (default is only 3m)
- Disable cache compression (takes unnecessary time)

Also change cache rebuild to run only on main branch, to prevent random attackers from writing into the cache from a PR.