### PR TITLE
Swipe post/comment to upvote/downvote/reply/save

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -27,9 +27,14 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Bookmark
+import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material3.DrawerState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -38,6 +43,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -55,6 +62,7 @@ import com.jerboa.db.APP_SETTINGS_DEFAULT
 import com.jerboa.db.entity.AppSettings
 import com.jerboa.ui.components.common.Route
 import com.jerboa.ui.theme.SMALL_PADDING
+import com.jerboa.ui.theme.jerboaColorScheme
 import it.vercruysse.lemmyapi.v0x19.datatypes.*
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -950,6 +958,43 @@ enum class PostType {
             Image -> Environment.DIRECTORY_PICTURES
             Video -> Environment.DIRECTORY_MOVIES
             Link -> Environment.DIRECTORY_DOCUMENTS
+        }
+    }
+}
+
+enum class SwipeActionType() {
+    Upvote,
+    Downvote,
+    Reply,
+    Save,
+    ;
+
+    companion object {
+        fun getActionToRangeList(actions: List<SwipeActionType>): List<Pair<OpenEndRange<Float>, SwipeActionType>> {
+            return actions.mapIndexed { index, it ->
+                (0.1f + 0.12f * index)
+                    .rangeUntil(if (index == actions.size - 1) 1f else (0.1f + 0.12f * (index + 1))) to it
+            }
+        }
+    }
+
+    @Composable
+    fun getImageVector(): ImageVector {
+        return when (this) {
+            Upvote -> ImageVector.vectorResource(id = R.drawable.up_outline)
+            Downvote -> ImageVector.vectorResource(id = R.drawable.down_outline)
+            Reply -> Icons.Outlined.Comment
+            Save -> Icons.Outlined.Bookmark
+        }
+    }
+
+    @Composable
+    fun getActionColor(): Color {
+        return when (this) {
+            Upvote -> MaterialTheme.jerboaColorScheme.upvoteSwipe
+            Downvote -> MaterialTheme.jerboaColorScheme.downvoteSwipe
+            Reply -> MaterialTheme.jerboaColorScheme.replySwipe
+            Save -> MaterialTheme.jerboaColorScheme.saveSwipe
         }
     }
 }

--- a/app/src/main/java/com/jerboa/ui/components/common/SwipeToAction.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/SwipeToAction.kt
@@ -1,0 +1,170 @@
+package com.jerboa.ui.components.common
+
+import androidx.compose.animation.animateColor
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.material3.DismissDirection
+import androidx.compose.material3.DismissState
+import androidx.compose.material3.DismissValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SwipeToDismiss
+import androidx.compose.material3.rememberDismissState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.dp
+import com.jerboa.SwipeActionType
+
+@Composable
+@ExperimentalMaterial3Api
+fun SwipeToAction(
+    leftActions: List<SwipeActionType>,
+    rightActions: List<SwipeActionType>,
+    swipeableContent: @Composable RowScope.() -> Unit,
+    swipeState: DismissState,
+) {
+    val haptic = LocalHapticFeedback.current
+
+    val leftActionsRanges =
+        remember(leftActions) { SwipeActionType.getActionToRangeList(leftActions) }
+    val rightActionsRanges =
+        remember(rightActions) { SwipeActionType.getActionToRangeList(rightActions) }
+
+    fun actionByState(state: DismissState): Pair<OpenEndRange<Float>, SwipeActionType>? {
+        return when (state.currentValue) {
+            DismissValue.DismissedToEnd -> {
+                leftActionsRanges.findLast { swipeState.progress in it.first }
+            }
+
+            DismissValue.DismissedToStart -> {
+                rightActionsRanges.findLast { swipeState.progress in it.first }
+            }
+
+            else -> null
+        }
+    }
+
+    val swipeAction = remember(swipeState) { actionByState(swipeState) }
+
+    SwipeToDismiss(
+        directions =
+            remember(leftActions, rightActions) {
+                setOfNotNull(
+                    if (leftActions.isNotEmpty()) DismissDirection.StartToEnd else null,
+                    if (rightActions.isNotEmpty()) DismissDirection.EndToStart else null,
+                )
+            },
+        state = swipeState,
+        background = {
+            val lastSwipeAction = remember { mutableStateOf<SwipeActionType?>(null) }
+            val transition = updateTransition(swipeState, label = "swipe state")
+            val color by transition.animateColor(
+                transitionSpec = {
+                    val currentAction = remember(swipeState) { actionByState(swipeState) }
+                    // vibrates when icon changes
+                    if (lastSwipeAction.value != currentAction?.second) {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        lastSwipeAction.value = currentAction?.second
+                    }
+                    spring(stiffness = 50f)
+                },
+                label = "swipe color animation",
+                targetValueByState = { state ->
+                    val currentAction = remember(state) { actionByState(swipeState) }
+                    currentAction?.second?.getActionColor() ?: Color.Transparent
+                },
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize(),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth(if (swipeState.progress != 1f) swipeState.progress else 0f)
+                            .fillMaxHeight()
+                            .background(color = color)
+                            .align(if (swipeState.currentValue == DismissValue.DismissedToStart) Alignment.TopEnd else Alignment.TopStart),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    val tint = Color.White
+                    val modifier =
+                        Modifier
+                            .padding(10.dp)
+                            .requiredWidth(35.dp)
+                            .fillMaxHeight()
+
+                    swipeAction?.second?.getImageVector()?.let { icon ->
+                        Icon(
+                            imageVector = icon,
+                            contentDescription = null,
+                            tint = tint,
+                            modifier = modifier,
+                        )
+                    }
+                }
+            }
+        },
+        dismissContent = { swipeableContent() },
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun rememberSwipeActionState(
+    leftActions: List<SwipeActionType>,
+    rightActions: List<SwipeActionType>,
+    onAction: (action: SwipeActionType) -> Unit,
+): DismissState {
+    /*
+    This hacky solution is required because confirmValueChange lambda doesn't pass progress state
+     */
+    val leftActionsRanges =
+        remember(leftActions) { SwipeActionType.getActionToRangeList(leftActions) }
+    val rightActionsRanges =
+        remember(rightActions) { SwipeActionType.getActionToRangeList(rightActions) }
+    val progressState = remember { mutableFloatStateOf(1.0f) }
+    val dismissState =
+        rememberDismissState(
+            positionalThreshold = { 0f },
+            confirmValueChange = { dismissValue ->
+                val action =
+                    when (dismissValue) {
+                        DismissValue.DismissedToEnd -> {
+                            leftActionsRanges.findLast { progressState.floatValue in it.first }
+                        }
+
+                        DismissValue.DismissedToStart -> {
+                            rightActionsRanges.findLast { progressState.floatValue in it.first }
+                        }
+
+                        else -> {
+                            null
+                        }
+                    }
+                action?.second?.let { actionType ->
+                    onAction(actionType)
+                }
+                false // do not dismiss
+            },
+        )
+    progressState.floatValue = dismissState.progress
+    return dismissState
+}

--- a/app/src/main/java/com/jerboa/ui/theme/Color.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/Color.kt
@@ -373,6 +373,10 @@ fun crimson(): Pair<JerboaColorScheme, JerboaColorScheme> {
     val md_theme_dark_scrim = Color(0xFF000000)
     val jerboa_image_highlight = Color(0xCCD1D1D1)
     val jerboa_video_highlight = Color(0xCCC20000)
+    val jerboa_upvote_swipe = Color(0xff4caf50)
+    val jerboa_downvote_swipe = Color(0xfff44336)
+    val jerboa_save_swipe = Color(0xff448aff)
+    val jerboa_reply_swipe = Color(0xffffa000)
 
 //    val seed = Color(0xFF78B0FF)
 
@@ -447,6 +451,10 @@ fun crimson(): Pair<JerboaColorScheme, JerboaColorScheme> {
             material = light,
             imageHighlight = jerboa_image_highlight,
             videoHighlight = jerboa_video_highlight,
+            upvoteSwipe = jerboa_upvote_swipe,
+            downvoteSwipe = jerboa_downvote_swipe,
+            saveSwipe = jerboa_save_swipe,
+            replySwipe = jerboa_reply_swipe,
         )
 
     val jerboaDark =
@@ -454,6 +462,10 @@ fun crimson(): Pair<JerboaColorScheme, JerboaColorScheme> {
             material = dark,
             imageHighlight = jerboa_image_highlight,
             videoHighlight = jerboa_video_highlight,
+            upvoteSwipe = jerboa_upvote_swipe,
+            downvoteSwipe = jerboa_downvote_swipe,
+            saveSwipe = jerboa_save_swipe,
+            replySwipe = jerboa_reply_swipe,
         )
 
     return Pair(jerboaLight, jerboaDark)

--- a/app/src/main/java/com/jerboa/ui/theme/JerboaColorScheme.kt
+++ b/app/src/main/java/com/jerboa/ui/theme/JerboaColorScheme.kt
@@ -11,4 +11,8 @@ data class JerboaColorScheme(
     val material: ColorScheme = darkColorScheme(), // the default Material color scheme
     val imageHighlight: Color = Color(0xCCD1D1D1), // the color that highlights an image thumb
     val videoHighlight: Color = Color(0xCCC20000), // the color that highlights a video thumb
+    val upvoteSwipe: Color = Color(0xff4caf50), // the background color for upvote when swiping
+    val downvoteSwipe: Color = Color(0xfff44336), // the background color for downvote when swiping
+    val saveSwipe: Color = Color(0xff448aff), // the background color for share when swiping
+    val replySwipe: Color = Color(0xffffa000), // the background color for reply when swiping
 )


### PR DESCRIPTION
This feature will let user swipe to upvote/downvote  posts/comments

Closes feature request #52  

Currently it is WIP (implemented the composable that will wrap post/comment composables)

Thinking about customization - how should it be implemented? Doing it straight-forward will add a lot of stuff to the settings entity (that is stored in room). 

Also probably it would be better to set it up as "swipe to start - upvote, swipe to end - downvote" but this will affect "swipe to go back/to open drawer" gesture


There are multiple ways: 
1) Do a bunch of presets (it will limit the customization but it is the easiest one that won't affect the current settings structure a lot)
2) Create separate object for gestures preferences and convert it using the TypeConverter to json (with gson) when storing in room (4 lists of swipeactiontypes)
4 settings will be added (left/right gesture actions for posts/comments)
3) You tell me :)

![298275487-399f8213-c705-42d6-93c6-fcb65018ce8e](https://github.com/dessalines/jerboa/assets/32912696/73f03439-a51b-40cb-b643-92c760f78f4e)