### PR TITLE
Upgrading deps.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,7 +95,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.6"
+        kotlinCompilerExtensionVersion = "1.5.8"
     }
 }
 
@@ -114,7 +114,7 @@ dependencies {
     implementation("io.noties.markwon:linkify:4.6.2")
 
     // Accompanist
-    val accompanistVersion = "0.32.0"
+    val accompanistVersion = "0.34.0"
     implementation("com.google.accompanist:accompanist-pager:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-pager-indicators:$accompanistVersion")
     implementation("com.google.accompanist:accompanist-flowlayout:$accompanistVersion")
@@ -122,9 +122,9 @@ dependencies {
     implementation("com.google.accompanist:accompanist-systemuicontroller:$accompanistVersion")
 
     // LiveData
-    implementation("androidx.compose.runtime:runtime-livedata:1.5.4")
-    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.6.2")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.6.2")
+    implementation("androidx.compose.runtime:runtime-livedata:1.6.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
 
     // Images
     implementation("io.coil-kt:coil-compose:2.5.0")
@@ -154,7 +154,9 @@ dependencies {
 
     implementation("io.arrow-kt:arrow-core:1.2.1")
     // Unfortunately, ui tooling, and the markdown thing, still brings in the other material2 dependencies
-    implementation("androidx.compose.material3:material3:1.1.2")
+    // RC is necessary due to this bug
+    // https://stackoverflow.com/questions/77877363/no-virtual-method-atljava-lang-objectilandroidx-compose-animation-core-keyfra
+    implementation("androidx.compose.material3:material3:1.2.0-rc01")
     implementation("androidx.compose.material3:material3-window-size-class:1.1.2")
 
     implementation("org.ocpsoft.prettytime:prettytime:5.0.7.Final")
@@ -162,19 +164,19 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     testImplementation("androidx.arch.core:core-testing:2.2.0")
 
-    implementation("androidx.compose.ui:ui:1.5.4")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.5.4")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.4")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.5.4")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.5.4")
-    implementation("androidx.compose.material:material-icons-extended:1.5.4")
+    implementation("androidx.compose.ui:ui:1.6.0")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.6.0")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.0")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.6.0")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.0")
+    implementation("androidx.compose.material:material-icons-extended:1.6.0")
 
     implementation("androidx.activity:activity-compose:1.8.2")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-    testImplementation("org.mockito:mockito-core:5.8.0")
+    testImplementation("org.mockito:mockito-core:5.10.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 
     implementation("androidx.browser:browser:1.7.0")
@@ -187,6 +189,6 @@ dependencies {
     implementation("it.vercruysse.lemmyapi:lemmy-api:0.2.3-SNAPSHOT")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     // Ktor uses SLF4J
-    implementation("org.slf4j:slf4j-api:2.0.9")
-    implementation("uk.uuid.slf4j:slf4j-android:2.0.9-0")
+    implementation("org.slf4j:slf4j-api:2.0.11")
+    implementation("uk.uuid.slf4j:slf4j-android:2.0.11-0")
 }

--- a/app/src/main/java/com/jerboa/api/Http.kt
+++ b/app/src/main/java/com/jerboa/api/Http.kt
@@ -103,7 +103,7 @@ object API {
 
     fun setLemmyInstance(api: LemmyApiV19) {
         Log.d("setLemmyInstance", "Setting lemmy instance to ${api.baseUrl}")
-        API.version = api.version.toString()
+        version = api.version.toString()
         newApi = api
         initialized.complete(Unit)
     }

--- a/app/src/main/java/com/jerboa/model/HomeViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/HomeViewModel.kt
@@ -1,8 +1,6 @@
 package com.jerboa.model
 
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.jerboa.db.repository.AccountRepository

--- a/app/src/main/java/com/jerboa/ui/components/ban/BanFromCommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/ban/BanFromCommunityActivity.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.ban
 
 import android.util.Log
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -102,7 +102,7 @@ fun BanFromCommunityActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
                 onBackClick = appState::popBackStack,
             )
         },

--- a/app/src/main/java/com/jerboa/ui/components/ban/BanPersonActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/ban/BanPersonActivity.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.ban
 
 import android.util.Log
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -92,7 +92,7 @@ fun BanPersonActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
                 onBackClick = appState::popBackStack,
             )
         },

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -18,11 +18,11 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -269,7 +269,7 @@ fun LazyListScope.commentNodeItem(
                 Column(
                     modifier = Modifier.border(start = border),
                 ) {
-                    Divider(modifier = Modifier.padding(start = if (node.depth == 0) 0.dp else border.strokeWidth))
+                    HorizontalDivider(modifier = Modifier.padding(start = if (node.depth == 0) 0.dp else border.strokeWidth))
                     Column(
                         modifier =
                             Modifier.padding(
@@ -513,7 +513,7 @@ fun LazyListScope.missingCommentNodeItem(
                 Column(
                     modifier = Modifier.border(start = border),
                 ) {
-                    Divider(modifier = Modifier.padding(start = if (node.depth == 0) 0.dp else border.strokeWidth))
+                    HorizontalDivider(modifier = Modifier.padding(start = if (node.depth == 0) 0.dp else border.strokeWidth))
                     Column(
                         modifier =
                             Modifier.padding(
@@ -615,7 +615,7 @@ private fun ShowMoreChildrenNode(
                         start = offset,
                     ),
         ) {
-            Divider()
+            HorizontalDivider()
             Column(
                 modifier = Modifier.border(start = border),
             ) {
@@ -769,7 +769,7 @@ fun CommentFooterLine(
                 )
             }
             ActionBarButton(
-                icon = Icons.Outlined.Comment,
+                icon = Icons.AutoMirrored.Outlined.Comment,
                 onClick = { onReplyClick(commentView) },
                 contentDescription = stringResource(R.string.commentFooter_reply),
                 account = account,

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentOptionsDropdown.kt
@@ -2,8 +2,8 @@ package com.jerboa.ui.components.comment
 
 import android.widget.Toast
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.outlined.Block
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.CopyAll
 import androidx.compose.material.icons.outlined.Delete
@@ -14,7 +14,7 @@ import androidx.compose.material.icons.outlined.GppBad
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Restore
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -58,7 +58,7 @@ fun CommentOptionsDropdown(
     ) {
         PopupMenuItem(
             text = stringResource(R.string.comment_node_goto_comment),
-            icon = Icons.Outlined.Comment,
+            icon = Icons.AutoMirrored.Outlined.Comment,
             onClick = {
                 onDismissRequest()
                 onCommentLinkClick(commentView)
@@ -128,7 +128,7 @@ fun CommentOptionsDropdown(
             },
         )
 
-        Divider()
+        HorizontalDivider()
 
         if (isCreator) {
             PopupMenuItem(
@@ -178,7 +178,7 @@ fun CommentOptionsDropdown(
             )
 
             if (canMod) {
-                Divider()
+                HorizontalDivider()
                 val (removeText, removeIcon) =
                     if (commentView.comment.removed) {
                         Pair(stringResource(R.string.restore_comment), Icons.Outlined.Restore)

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -9,14 +9,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.MarkChatRead
 import androidx.compose.material.icons.outlined.MarkChatUnread
 import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -203,7 +203,7 @@ fun CommentMentionNodeFooterLine(
             // Don't let you respond to your own comment.
             if (personMentionView.creator.id != account.id) {
                 ActionBarButton(
-                    icon = Icons.Outlined.Comment,
+                    icon = Icons.AutoMirrored.Outlined.Comment,
                     contentDescription = stringResource(R.string.commentFooter_reply),
                     onClick = { onReplyClick(personMentionView) },
                     account = account,
@@ -278,7 +278,7 @@ fun CommentMentionNode(
     Column(
         modifier = Modifier.padding(horizontal = LARGE_PADDING),
     ) {
-        Divider()
+        HorizontalDivider()
         PostAndCommunityContextHeader(
             post = personMentionView.post,
             community = personMentionView.community,

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionOptionsDropdown.kt
@@ -2,8 +2,8 @@ package com.jerboa.ui.components.comment.mentionnode
 
 import android.widget.Toast
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.outlined.Block
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.CopyAll
 import androidx.compose.material.icons.outlined.Description
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.outlined.Gavel
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Restore
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -49,7 +49,7 @@ fun CommentMentionsOptionsDropdown(
     ) {
         PopupMenuItem(
             text = stringResource(R.string.comment_node_goto_comment),
-            icon = Icons.Outlined.Comment,
+            icon = Icons.AutoMirrored.Outlined.Comment,
             onClick = {
                 onDismissRequest()
                 onCommentLinkClick(personMentionView)
@@ -112,7 +112,7 @@ fun CommentMentionsOptionsDropdown(
         )
 
         if (!isCreator) {
-            Divider()
+            HorizontalDivider()
             PopupMenuItem(
                 text = stringResource(R.string.comment_node_block, personMentionView.creator.name),
                 icon = Icons.Outlined.Block,
@@ -133,7 +133,7 @@ fun CommentMentionsOptionsDropdown(
         }
 
         if (canMod) {
-            Divider()
+            HorizontalDivider()
             val (removeText, removeIcon) =
                 if (personMentionView.comment.removed) {
                     Pair(stringResource(R.string.restore_comment), Icons.Outlined.Restore)

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReply.kt
@@ -158,7 +158,7 @@ fun CommentReply(
             showAvatar = showAvatar,
             showScores = showScores,
         )
-        Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
+        HorizontalDivider(modifier = Modifier.padding(vertical = LARGE_PADDING))
         MarkdownTextField(
             text = reply,
             onTextChange = onReplyChange,
@@ -190,7 +190,7 @@ fun CommentReplyReply(
             showAvatar = showAvatar,
             showScores = showScores,
         )
-        Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
+        HorizontalDivider(modifier = Modifier.padding(vertical = LARGE_PADDING))
         MarkdownTextField(
             text = reply,
             onTextChange = onReplyChange,
@@ -222,7 +222,7 @@ fun MentionReply(
             showAvatar = showAvatar,
             showScores = showScores,
         )
-        Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
+        HorizontalDivider(modifier = Modifier.padding(vertical = LARGE_PADDING))
         MarkdownTextField(
             text = reply,
             onTextChange = onReplyChange,
@@ -254,7 +254,7 @@ fun PostReply(
             showAvatar = showAvatar,
             showScores = showScores,
         )
-        Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
+        HorizontalDivider(modifier = Modifier.padding(vertical = LARGE_PADDING))
         MarkdownTextField(
             text = reply,
             onTextChange = onReplyChange,

--- a/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/reply/CommentReplyActivity.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -83,7 +83,7 @@ fun CommentReplyActivity(
                     }
                 },
                 actionText = R.string.commentReply_send,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
             )
         },
         content = { padding ->

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyNode.kt
@@ -9,14 +9,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.MarkChatRead
 import androidx.compose.material.icons.outlined.MarkChatUnread
 import androidx.compose.material.icons.outlined.MoreVert
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -206,7 +206,7 @@ fun CommentReplyNodeInboxFooterLine(
             // Don't let you respond to your own comment.
             if (commentReplyView.creator.id != account.id) {
                 ActionBarButton(
-                    icon = Icons.Outlined.Comment,
+                    icon = Icons.AutoMirrored.Outlined.Comment,
                     contentDescription = stringResource(R.string.commentFooter_reply),
                     onClick = { onReplyClick(commentReplyView) },
                     account = account,
@@ -257,7 +257,7 @@ fun CommentReplyNodeInbox(
     Column(
         modifier = Modifier.padding(horizontal = LARGE_PADDING),
     ) {
-        Divider()
+        HorizontalDivider()
         PostAndCommunityContextHeader(
             post = commentReplyView.post,
             community = commentReplyView.community,

--- a/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/replynode/CommentReplyOptionsDropdown.kt
@@ -2,15 +2,15 @@ package com.jerboa.ui.components.comment.replynode
 
 import android.widget.Toast
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.outlined.Block
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.CopyAll
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Person
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -45,7 +45,7 @@ fun CommentReplyOptionsDropdown(
     ) {
         PopupMenuItem(
             text = stringResource(R.string.comment_node_goto_comment),
-            icon = Icons.Outlined.Comment,
+            icon = Icons.AutoMirrored.Outlined.Comment,
             onClick = {
                 onDismissRequest()
                 onCommentLinkClick(commentReplyView)
@@ -108,7 +108,7 @@ fun CommentReplyOptionsDropdown(
         )
 
         if (!isCreator) {
-            Divider()
+            HorizontalDivider()
             PopupMenuItem(
                 text = stringResource(R.string.comment_node_block, commentReplyView.creator.name),
                 icon = Icons.Outlined.Block,

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.outlined.*
@@ -82,7 +83,7 @@ fun SimpleTopAppBar(
         navigationIcon = {
             IconButton(onClick = onClickBack, modifier = Modifier.testTag("jerboa:back")) {
                 Icon(
-                    Icons.Outlined.ArrowBack,
+                    Icons.AutoMirrored.Outlined.ArrowBack,
                     contentDescription = stringResource(R.string.topAppBar_back),
                 )
             }
@@ -445,7 +446,6 @@ fun scoreColor(myVote: Int?): Color {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InboxIconAndBadge(
     iconBadgeCount: Int?,
@@ -555,7 +555,7 @@ fun Sidebar(
             }
         }
         item {
-            Divider()
+            HorizontalDivider()
         }
         item {
             content?.also {
@@ -733,7 +733,7 @@ fun ActionTopBar(
                 onClick = onBackClick,
             ) {
                 Icon(
-                    Icons.Outlined.ArrowBack,
+                    Icons.AutoMirrored.Outlined.ArrowBack,
                     contentDescription = stringResource(R.string.topAppBar_back),
                 )
             }

--- a/app/src/main/java/com/jerboa/ui/components/common/DrawerItems.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/DrawerItems.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowRight
+import androidx.compose.material.icons.automirrored.outlined.ArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -72,7 +72,7 @@ fun IconAndTextDrawerItem(
         }
         if (more) {
             Icon(
-                imageVector = Icons.Outlined.ArrowRight,
+                imageVector = Icons.AutoMirrored.Outlined.ArrowRight,
                 contentDescription = stringResource(R.string.dialog_moreOptions),
                 tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.size(24.dp),

--- a/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/InputFields.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.FormatListBulleted
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.FormatBold
 import androidx.compose.material.icons.outlined.FormatItalic
@@ -513,7 +514,7 @@ fun MarkdownHelperBar(
             },
         ) {
             Icon(
-                imageVector = Icons.Outlined.FormatListBulleted,
+                imageVector = Icons.AutoMirrored.Outlined.FormatListBulleted,
                 contentDescription = stringResource(R.string.markdownHelper_insertList),
                 tint = MaterialTheme.colorScheme.onBackground.muted,
             )

--- a/app/src/main/java/com/jerboa/ui/components/common/LinkDropDownMenu.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/LinkDropDownMenu.kt
@@ -8,7 +8,7 @@ import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.OpenInBrowser
 import androidx.compose.material.icons.outlined.OpenInFull
 import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -79,7 +79,7 @@ fun LinkDropDownMenu(
                 },
             )
 
-            Divider()
+            HorizontalDivider()
 
             PopupMenuItem(
                 text = stringResource(R.string.post_listing_copy_link),
@@ -106,7 +106,7 @@ fun LinkDropDownMenu(
 
             when (mediaType) {
                 PostType.Image -> {
-                    Divider()
+                    HorizontalDivider()
                     PopupMenuItem(
                         text = stringResource(R.string.share_image),
                         icon = Icons.Outlined.Share,
@@ -126,7 +126,7 @@ fun LinkDropDownMenu(
                 }
 
                 PostType.Video -> {
-                    Divider()
+                    HorizontalDivider()
                     PopupMenuItem(
                         text = stringResource(R.string.share_video),
                         icon = Icons.Outlined.Share,
@@ -147,7 +147,7 @@ fun LinkDropDownMenu(
 
                 PostType.Link -> {
                     if (isMedia(link)) {
-                        Divider()
+                        HorizontalDivider()
                         PopupMenuItem(
                             text = stringResource(R.string.share_media),
                             icon = Icons.Outlined.Share,

--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -210,7 +210,7 @@ object MarkdownHelper {
                 TextStyle(
                     color = textColor,
                     fontSize = if (fontSize != TextUnit.Unspecified) fontSize else style.fontSize,
-                    textAlign = textAlign,
+                    textAlign = textAlign ?: TextAlign.Unspecified,
                 ),
             )
         return TextView(context).apply {

--- a/app/src/main/java/com/jerboa/ui/components/community/Community.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/Community.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -160,7 +162,7 @@ fun CommunityHeader(
         navigationIcon = {
             IconButton(onClick = onClickBack) {
                 Icon(
-                    Icons.Outlined.ArrowBack,
+                    Icons.AutoMirrored.Outlined.ArrowBack,
                     contentDescription = stringResource(R.string.topAppBar_back),
                 )
             }
@@ -171,7 +173,7 @@ fun CommunityHeader(
                     showSortOptions = !showSortOptions
                 }) {
                     Icon(
-                        Icons.Outlined.Sort,
+                        Icons.AutoMirrored.Outlined.Sort,
                         contentDescription = stringResource(R.string.community_sortBy),
                     )
                 }
@@ -296,7 +298,7 @@ fun CommunityMoreDropdown(
                 onClickCommunityShare()
             },
         )
-        Divider()
+        HorizontalDivider()
         DropdownMenuItem(
             text = {
                 Text(

--- a/app/src/main/java/com/jerboa/ui/components/drawer/Drawer.kt
+++ b/app/src/main/java/com/jerboa/ui/components/drawer/Drawer.kt
@@ -17,17 +17,17 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Login
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.LocationCity
-import androidx.compose.material.icons.outlined.Login
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.WarningAmber
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -147,7 +147,7 @@ fun DrawerContent(
         enter = expandVertically(),
         exit = shrinkVertically(),
     ) {
-        Divider()
+        HorizontalDivider()
         DrawerAddAccountMode(
             accountViewModel = accountViewModel,
             onAddAccount = onAddAccount,
@@ -157,7 +157,7 @@ fun DrawerContent(
         )
     }
 
-    Divider()
+    HorizontalDivider()
     DrawerItemsMain(
         myUserInfo = myUserInfo,
         follows = follows,
@@ -224,7 +224,7 @@ fun DrawerItemsMain(
             )
         }
         item {
-            Divider()
+            HorizontalDivider()
         }
 
         if (!showBottomNav) {
@@ -242,7 +242,7 @@ fun DrawerItemsMain(
             }
 
             item(contentType = "divider") {
-                Divider()
+                HorizontalDivider()
             }
         }
         item("settings") {
@@ -254,7 +254,7 @@ fun DrawerItemsMain(
         }
         myUserInfo?.also {
             item(contentType = "divider") {
-                Divider()
+                HorizontalDivider()
             }
         }
 
@@ -323,7 +323,7 @@ fun DrawerAddAccountMode(
 
             IconAndTextDrawerItem(
                 text = stringResource(R.string.home_switch_anon),
-                icon = Icons.Outlined.Login,
+                icon = Icons.AutoMirrored.Outlined.Login,
                 onClick = onSwitchAnon,
             )
         }
@@ -331,7 +331,7 @@ fun DrawerAddAccountMode(
         accountsWithoutCurrent.forEach {
             IconAndTextDrawerItem(
                 text = stringResource(R.string.home_switch_to, it.name, it.instance),
-                icon = Icons.Outlined.Login,
+                icon = Icons.AutoMirrored.Outlined.Login,
                 onClick = { onSwitchAccountClick(it) },
             )
         }

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.Bookmarks
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.Info
@@ -13,7 +14,6 @@ import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Refresh
-import androidx.compose.material.icons.outlined.Sort
 import androidx.compose.material.icons.outlined.ViewAgenda
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -132,7 +132,7 @@ fun HomeHeader(
                     showSortOptions = !showSortOptions
                 }) {
                     Icon(
-                        Icons.Outlined.Sort,
+                        Icons.AutoMirrored.Outlined.Sort,
                         contentDescription = stringResource(R.string.selectSort),
                     )
                 }

--- a/app/src/main/java/com/jerboa/ui/components/imageviewer/ImageViewerActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/imageviewer/ImageViewerActivity.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Share
@@ -170,10 +170,11 @@ fun ImageViewer(
 
                         if (currentProgress.value.progressAvailable) {
                             LinearProgressIndicator(
-                                currentProgress.value.progress,
-                                Modifier
-                                    .padding(it)
-                                    .fillMaxWidth(),
+                                progress = { currentProgress.value.progress },
+                                modifier =
+                                    Modifier
+                                        .padding(it)
+                                        .fillMaxWidth(),
                             )
                         } else {
                             LoadingBar(it)
@@ -228,7 +229,7 @@ fun ViewerHeader(
                 onClick = appState::navigateUp,
             ) {
                 Icon(
-                    Icons.Outlined.ArrowBack,
+                    Icons.AutoMirrored.Outlined.ArrowBack,
                     tint = Color.White,
                     contentDescription = stringResource(R.string.topAppBar_back),
                 )

--- a/app/src/main/java/com/jerboa/ui/components/inbox/Inbox.kt
+++ b/app/src/main/java/com/jerboa/ui/components/inbox/Inbox.kt
@@ -5,9 +5,9 @@ package com.jerboa.ui.components.inbox
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.List
 import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.FilterList
-import androidx.compose.material.icons.outlined.List
 import androidx.compose.material.icons.outlined.MarkunreadMailbox
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.material3.DropdownMenu
@@ -124,7 +124,7 @@ fun UnreadOrAllOptionsDropDown(
     ) {
         MenuItem(
             text = stringResource(R.string.dialogs_all),
-            icon = Icons.Outlined.List,
+            icon = Icons.AutoMirrored.Outlined.List,
             onClick = { onClickUnreadOrAll(UnreadOrAll.All) },
             highlight = (selectedUnreadOrAll == UnreadOrAll.All),
         )

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
@@ -284,7 +284,7 @@ fun LoginHeader(onClickBack: () -> Unit) {
                 onClick = onClickBack,
             ) {
                 Icon(
-                    Icons.Outlined.ArrowBack,
+                    Icons.AutoMirrored.Outlined.ArrowBack,
                     contentDescription = stringResource(R.string.topAppBar_back),
                 )
             }

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfile.kt
@@ -10,10 +10,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Message
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -187,7 +190,7 @@ fun PersonProfileHeader(
             } else {
                 IconButton(onClick = onBack, modifier = Modifier.testTag("jerboa:back")) {
                     Icon(
-                        Icons.Outlined.ArrowBack,
+                        Icons.AutoMirrored.Outlined.ArrowBack,
                         contentDescription = stringResource(R.string.topAppBar_back),
                     )
                 }
@@ -199,7 +202,7 @@ fun PersonProfileHeader(
                     showSortOptions = !showSortOptions
                 }) {
                     Icon(
-                        Icons.Outlined.Sort,
+                        Icons.AutoMirrored.Outlined.Sort,
                         contentDescription = stringResource(R.string.community_sortBy),
                     )
                 }
@@ -286,7 +289,7 @@ fun PersonProfileMoreDropdown(
         MenuItem(
             text = stringResource(R.string.person_profile_dm_person),
             onClick = onMessagePersonClick,
-            icon = Icons.Outlined.Message,
+            icon = Icons.AutoMirrored.Outlined.Message,
         )
 
         if (openMatrix != null) {
@@ -303,7 +306,7 @@ fun PersonProfileMoreDropdown(
             )
         }
 
-        Divider()
+        HorizontalDivider()
         MenuItem(
             text = stringResource(R.string.person_profile_block_person),
             onClick = onBlockPersonClick,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -12,8 +12,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.Sort
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Sort
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -236,7 +236,7 @@ fun PostActivity(
                             onClick = appState::navigateUp,
                         ) {
                             Icon(
-                                Icons.Outlined.ArrowBack,
+                                Icons.AutoMirrored.Outlined.ArrowBack,
                                 contentDescription = stringResource(R.string.topAppBar_back),
                             )
                         }
@@ -247,7 +247,7 @@ fun PostActivity(
                                 showSortOptions = true
                             }) {
                                 Icon(
-                                    Icons.Outlined.Sort,
+                                    Icons.AutoMirrored.Outlined.Sort,
                                     contentDescription = stringResource(R.string.selectSort),
                                 )
                             }

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -20,9 +20,9 @@ import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.outlined.BookmarkBorder
-import androidx.compose.material.icons.outlined.Comment
 import androidx.compose.material.icons.outlined.CommentsDisabled
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Forum
@@ -31,8 +31,8 @@ import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.Card
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -686,7 +686,7 @@ fun PostFooterLine(
 
         if (showReply) {
             ActionBarButton(
-                icon = Icons.Outlined.Comment,
+                icon = Icons.AutoMirrored.Outlined.Comment,
                 contentDescription = stringResource(R.string.postListing_reply),
                 onClick = { onReplyClick(postView) },
                 account = account,
@@ -1687,7 +1687,7 @@ fun MetadataCard(post: Post) {
                     style = MaterialTheme.typography.titleLarge,
                 )
                 post.embed_description?.also {
-                    Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
+                    HorizontalDivider(modifier = Modifier.padding(vertical = LARGE_PADDING))
                     // This is actually html, but markdown can render it
                     MyMarkdownText(
                         markdown = it,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -141,7 +141,7 @@ fun PostListings(
                     }
                 }
             }
-            Divider(modifier = Modifier.padding(bottom = SMALL_PADDING))
+            HorizontalDivider(modifier = Modifier.padding(bottom = SMALL_PADDING))
         }
 
         if (showPostAppendRetry) {

--- a/app/src/main/java/com/jerboa/ui/components/post/composables/PostOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/composables/PostOptionsDropdown.kt
@@ -19,7 +19,7 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -88,7 +88,11 @@ fun PostOptionsDropdown(
         onDismissRequest = onDismissRequest,
     ) {
         PopupMenuItem(
-            text = stringResource(R.string.post_listing_go_to, communityNameShown(postView.community)),
+            text =
+                stringResource(
+                    R.string.post_listing_go_to,
+                    communityNameShown(postView.community),
+                ),
             icon = Icons.Outlined.Forum,
             onClick = {
                 onDismissRequest()
@@ -321,7 +325,7 @@ fun PostOptionsDropdown(
             }
         }
 
-        Divider()
+        HorizontalDivider()
 
         if (isCreator) {
             PopupMenuItem(
@@ -400,7 +404,13 @@ fun PostOptionsDropdown(
                         onClick = {
                             onDismissRequest()
                             scope.launch(Dispatchers.IO) {
-                                val resp = api.blockInstance(BlockInstance(postView.community.instance_id, true))
+                                val resp =
+                                    api.blockInstance(
+                                        BlockInstance(
+                                            postView.community.instance_id,
+                                            true,
+                                        ),
+                                    )
                                 withContext(Dispatchers.Main) {
                                     showBlockCommunityToast(resp, instance, ctx)
                                 }
@@ -420,7 +430,7 @@ fun PostOptionsDropdown(
             )
 
             if (canMod) {
-                Divider()
+                HorizontalDivider()
 
                 val (removeText, removeIcon) =
                     if (postView.post.removed) {

--- a/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/create/CreatePostActivity.kt
@@ -5,8 +5,8 @@ import android.util.Log
 import android.util.Patterns
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Send
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -145,9 +145,9 @@ fun CreatePostActivity(
                         },
                         actionIcon =
                             if (formValid) {
-                                Icons.Filled.Send
+                                Icons.AutoMirrored.Filled.Send
                             } else {
-                                Icons.Outlined.Send
+                                Icons.AutoMirrored.Outlined.Send
                             },
                         actionText = R.string.form_submit,
                         title = stringResource(R.string.create_post_create_post),

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/CreatePrivateMessageActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/CreatePrivateMessageActivity.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -94,7 +94,7 @@ fun CreatePrivateMessageActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
             )
         },
         content = { padding ->

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessage.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessage.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Comment
+import androidx.compose.material.icons.automirrored.outlined.Comment
 import androidx.compose.material.icons.outlined.MarkChatRead
 import androidx.compose.material.icons.outlined.MarkChatUnread
 import androidx.compose.material3.MaterialTheme
@@ -179,7 +179,7 @@ fun PrivateMessageFooterLine(
                     account = account,
                 )
                 ActionBarButton(
-                    icon = Icons.Outlined.Comment,
+                    icon = Icons.AutoMirrored.Outlined.Comment,
                     contentDescription = stringResource(R.string.privateMessage_reply),
                     onClick = { onReplyClick(privateMessageView) },
                     account = account,

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReply.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReply.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -71,7 +71,7 @@ fun PrivateMessageReply(
             onPersonClick = onPersonClick,
             showAvatar = showAvatar,
         )
-        Divider(modifier = Modifier.padding(vertical = LARGE_PADDING))
+        HorizontalDivider(modifier = Modifier.padding(vertical = LARGE_PADDING))
         MarkdownTextField(
             text = reply,
             onTextChange = onReplyChange,

--- a/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/privatemessage/PrivateMessageReplyActivity.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -77,7 +77,7 @@ fun PrivateMessageReplyActivity(
                     },
                     title = stringResource(R.string.private_message_reply_reply),
                     actionText = R.string.form_submit,
-                    actionIcon = Icons.Outlined.Send,
+                    actionIcon = Icons.AutoMirrored.Outlined.Send,
                 )
             },
             content = { padding ->

--- a/app/src/main/java/com/jerboa/ui/components/remove/comment/CommentRemoveActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/remove/comment/CommentRemoveActivity.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.remove.comment
 
 import android.util.Log
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -79,7 +79,7 @@ fun CommentRemoveActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
                 onBackClick = appState::popBackStack,
             )
         },

--- a/app/src/main/java/com/jerboa/ui/components/remove/post/PostRemoveActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/remove/post/PostRemoveActivity.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.remove.post
 
 import android.util.Log
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -79,7 +79,7 @@ fun PostRemoveActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
                 onBackClick = appState::popBackStack,
             )
         },

--- a/app/src/main/java/com/jerboa/ui/components/report/comment/CreateCommentReportActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/comment/CreateCommentReportActivity.kt
@@ -2,7 +2,7 @@ package com.jerboa.ui.components.report.comment
 
 import android.util.Log
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,7 +63,7 @@ fun CreateCommentReportActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
             )
         },
         content = { padding ->

--- a/app/src/main/java/com/jerboa/ui/components/report/post/CreatePostReportActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/report/post/CreatePostReportActivity.kt
@@ -3,7 +3,7 @@ package com.jerboa.ui.components.report.post
 
 import android.util.Log
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Send
+import androidx.compose.material.icons.automirrored.outlined.Send
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -65,7 +65,7 @@ fun CreatePostReportActivity(
                     }
                 },
                 actionText = R.string.form_submit,
-                actionIcon = Icons.Outlined.Send,
+                actionIcon = Icons.AutoMirrored.Outlined.Send,
             )
         },
         content = { padding ->

--- a/app/src/main/java/com/jerboa/ui/components/settings/about/AboutActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/about/AboutActivity.kt
@@ -1,4 +1,3 @@
-
 package com.jerboa.ui.components.settings.about
 
 import android.util.Log
@@ -8,9 +7,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Chat
 import androidx.compose.material.icons.outlined.*
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -60,7 +60,10 @@ fun AboutActivity(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            SimpleTopAppBar(text = stringResource(R.string.settings_about_about), onClickBack = onBack)
+            SimpleTopAppBar(
+                text = stringResource(R.string.settings_about_about),
+                onClickBack = onBack,
+            )
         },
         content = { padding ->
             Column(
@@ -71,7 +74,14 @@ fun AboutActivity(
             ) {
                 SettingsMenuLink(
                     title = { Text(stringResource(R.string.settings_about_what_s_new)) },
-                    subtitle = { Text(stringResource(R.string.settings_about_version, version ?: "")) },
+                    subtitle = {
+                        Text(
+                            stringResource(
+                                R.string.settings_about_version,
+                                version ?: "",
+                            ),
+                        )
+                    },
                     icon = {
                         Icon(
                             imageVector = Icons.Outlined.NewReleases,
@@ -110,7 +120,7 @@ fun AboutActivity(
                     title = { Text(stringResource(R.string.settings_about_developer_matrix_chatroom)) },
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.Chat,
+                            imageVector = Icons.AutoMirrored.Outlined.Chat,
                             contentDescription = null,
                         )
                     },
@@ -185,7 +195,7 @@ fun AboutActivity(
 
 @Composable
 fun SettingsDivider() {
-    Divider(modifier = Modifier.padding(vertical = 10.dp))
+    HorizontalDivider(modifier = Modifier.padding(vertical = 10.dp))
 }
 
 @Composable

--- a/app/src/main/java/com/jerboa/ui/components/settings/crashlogs/CrashLogsActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/crashlogs/CrashLogsActivity.kt
@@ -11,8 +11,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -150,7 +150,7 @@ fun CrashLog(
             )
         }
     }
-    Divider(modifier = Modifier.padding(bottom = SMALL_PADDING))
+    HorizontalDivider(modifier = Modifier.padding(bottom = SMALL_PADDING))
 }
 
 @Preview

--- a/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/settings/lookandfeel/LookAndFeelActivity.kt
@@ -7,15 +7,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ExitToApp
+import androidx.compose.material.icons.automirrored.outlined.ViewList
 import androidx.compose.material.icons.outlined.Colorize
-import androidx.compose.material.icons.outlined.ExitToApp
 import androidx.compose.material.icons.outlined.FormatSize
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.LensBlur
 import androidx.compose.material.icons.outlined.Palette
 import androidx.compose.material.icons.outlined.Swipe
-import androidx.compose.material.icons.outlined.ViewList
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -227,7 +227,7 @@ fun LookAndFeelActivity(
                     items = PostViewMode.entries.map { stringResource(it.mode) },
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.ViewList,
+                            imageVector = Icons.AutoMirrored.Outlined.ViewList,
                             contentDescription = null,
                         )
                     },
@@ -268,7 +268,7 @@ fun LookAndFeelActivity(
                     },
                     icon = {
                         Icon(
-                            imageVector = Icons.Outlined.ExitToApp,
+                            imageVector = Icons.AutoMirrored.Outlined.ExitToApp,
                             contentDescription = null,
                         )
                     },

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -375,7 +375,7 @@
     <string name="unblocked_community_toast">%1s разблокирован</string>
     <string name="community_block_toast_failure">Не удалось (раз)блокировать это сообщество</string>
     <string name="instance_block_toast_failure">Не удалось (раз)блокировать этот экземпляр</string>
-    <string name="saving_media">Сохраняем медиа...</string>
+    <string name="saving_media">Сохраняем медиа…</string>
     <string name="saved_media">Сохраенные медиа</string>
     <string name="share_image">Поделится картинкой</string>
     <string name="save_image">Сохранить изображение</string>

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -66,6 +66,6 @@ baselineProfile {
 dependencies {
     implementation("androidx.test.ext:junit:1.1.5")
     implementation("androidx.test.espresso:espresso-core:3.5.1")
-    implementation("androidx.test.uiautomator:uiautomator:2.3.0-alpha05")
+    implementation("androidx.test.uiautomator:uiautomator:2.3.0-beta01")
     implementation("androidx.benchmark:benchmark-macro-junit4:1.2.2")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,13 +1,13 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("com.android.application") version "8.2.1" apply false
-    id("com.android.library") version "8.2.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.21" apply false
+    id("com.android.application") version "8.2.2" apply false
+    id("com.android.library") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
     id("com.github.ben-manes.versions") version "0.42.0"
     id("org.jmailen.kotlinter") version "4.2.0" apply false
-    id("com.google.devtools.ksp") version "1.9.21-1.0.15" apply false
-    id("com.android.test") version "8.2.1" apply false
+    id("com.google.devtools.ksp") version "1.9.22-1.0.16" apply false
+    id("com.android.test") version "8.2.2" apply false
     id("androidx.baselineprofile") version "1.2.2" apply false
 }
 


### PR DESCRIPTION
Was pretty straightforward, but to recap:

- Lots of icons are in a new automirrored package.
- Divider -> HorizontalDivider
-  There's a current bug in material3 related to animations, I linked the stackoverflow issue.

Some things I didn't handle:

- `rememberSystemUiController` is now deprecated, it recommends something about EdgeToEdge which I'm not familiar with.
- TabIndicator has a deprecation that will need to be fixed eventually.