### PR TITLE
Remove ImmutableList and add stability config file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ You can run it by doing
 You can generate the compose compiler metrics by executing the following gradle task.
 
 ```shell
-./gradlew assembleRelease --rerun-tasks -P com.jerboa.enableComposeCompilerReports=true
+./gradlew assembleRelease --rerun-tasks -P enableComposeCompilerReports=true
 ```
 
 Then you will find the metrics in `app/build/compose_metrics` directory.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -184,8 +184,6 @@ dependencies {
     implementation("androidx.profileinstaller:profileinstaller:1.3.1")
     baselineProfile(project(":benchmarks"))
 
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.7")
-
     implementation("it.vercruysse.lemmyapi:lemmy-api:0.2.8-SNAPSHOT")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     // Ktor uses SLF4J

--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -57,8 +57,6 @@ import com.jerboa.db.entity.AppSettings
 import com.jerboa.ui.components.common.Route
 import com.jerboa.ui.theme.SMALL_PADDING
 import it.vercruysse.lemmyapi.v0x19.datatypes.*
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import okhttp3.Request
@@ -126,8 +124,8 @@ class MissingCommentNode(
     override fun getPath() = missingCommentView.path
 }
 
-fun commentsToFlatNodes(comments: List<CommentView>): ImmutableList<CommentNode> {
-    return comments.map { c -> CommentNode(c, depth = 0) }.toImmutableList()
+fun commentsToFlatNodes(comments: List<CommentView>): List<CommentNode> {
+    return comments.map { c -> CommentNode(c, depth = 0) }
 }
 
 /**
@@ -141,7 +139,7 @@ fun buildCommentsTree(
     comments: List<CommentView>,
     // If it's in CommentView, then we need to know the root comment id
     rootCommentId: CommentId?,
-): ImmutableList<CommentNodeData> {
+): List<CommentNodeData> {
     val isCommentView = rootCommentId != null
 
     val map = LinkedHashMap<Number, CommentNodeData>()
@@ -169,7 +167,7 @@ fun buildCommentsTree(
         }
     }
 
-    return tree.toImmutableList()
+    return tree
 }
 
 /**

--- a/app/src/main/java/com/jerboa/feat/ModActions.kt
+++ b/app/src/main/java/com/jerboa/feat/ModActions.kt
@@ -3,7 +3,6 @@ package com.jerboa.feat
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityModeratorView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
-import kotlinx.collections.immutable.ImmutableList
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
@@ -12,8 +11,8 @@ import java.time.temporal.ChronoUnit
  */
 fun canMod(
     creatorId: PersonId,
-    admins: ImmutableList<PersonView>?,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>?,
+    moderators: List<CommunityModeratorView>?,
     myId: PersonId?,
     onSelf: Boolean = false,
 ): Boolean {
@@ -46,14 +45,14 @@ fun futureDaysToUnixTime(days: Long?): Long? {
 }
 
 fun amMod(
-    moderators: ImmutableList<CommunityModeratorView>?,
+    moderators: List<CommunityModeratorView>?,
     myId: PersonId?,
 ): Boolean {
     return moderators?.map { it.moderator.id }?.contains(myId) ?: false
 }
 
 fun amAdmin(
-    admins: ImmutableList<PersonView>?,
+    admins: List<PersonView>?,
     myId: PersonId?,
 ): Boolean {
     return admins?.map { it.person.id }?.contains(myId) ?: false

--- a/app/src/main/java/com/jerboa/model/AppSettingsViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/AppSettingsViewModel.kt
@@ -1,5 +1,6 @@
 package com.jerboa.model
 
+import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
@@ -9,6 +10,7 @@ import com.jerboa.db.repository.AppSettingsRepository
 import com.jerboa.jerboaApplication
 import kotlinx.coroutines.launch
 
+@Stable
 class AppSettingsViewModel(private val repository: AppSettingsRepository) : ViewModel() {
     val appSettings = repository.appSettings
     val changelog = repository.changelog

--- a/app/src/main/java/com/jerboa/model/CommunityListViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/CommunityListViewModel.kt
@@ -17,10 +17,9 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityFollowerView
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Search
 import it.vercruysse.lemmyapi.v0x19.datatypes.SearchResponse
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
 
-class CommunityListViewModel(communities: ImmutableList<CommunityFollowerView>) : ViewModel() {
+class CommunityListViewModel(communities: List<CommunityFollowerView>) : ViewModel() {
     var searchRes: ApiState<SearchResponse> by mutableStateOf(ApiState.Empty)
         private set
 
@@ -35,7 +34,7 @@ class CommunityListViewModel(communities: ImmutableList<CommunityFollowerView>) 
         setCommunityListFromFollowed(communities)
     }
 
-    private fun setCommunityListFromFollowed(myFollows: ImmutableList<CommunityFollowerView>) {
+    private fun setCommunityListFromFollowed(myFollows: List<CommunityFollowerView>) {
         // A hack to convert communityFollowerView into CommunityView
         val followsIntoCommunityViews =
             myFollows.map { cfv ->
@@ -72,7 +71,7 @@ class CommunityListViewModel(communities: ImmutableList<CommunityFollowerView>) 
 
     companion object {
         class Factory(
-            private val followedCommunities: ImmutableList<CommunityFollowerView>,
+            private val followedCommunities: List<CommunityFollowerView>,
         ) : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(

--- a/app/src/main/java/com/jerboa/model/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/SiteViewModel.kt
@@ -24,9 +24,6 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.GetSiteResponse
 import it.vercruysse.lemmyapi.v0x19.datatypes.GetUnreadCountResponse
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.SaveUserSettings
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -159,17 +156,17 @@ class SiteViewModel(private val accountRepository: AccountRepository) : ViewMode
         }
     }
 
-    fun getFollowList(): ImmutableList<CommunityFollowerView> {
+    fun getFollowList(): List<CommunityFollowerView> {
         return when (val res = siteRes) {
-            is ApiState.Success -> res.data.my_user?.follows?.toImmutableList() ?: persistentListOf()
-            else -> persistentListOf()
+            is ApiState.Success -> res.data.my_user?.follows ?: emptyList()
+            else -> emptyList()
         }
     }
 
-    fun admins(): ImmutableList<PersonView> {
+    fun admins(): List<PersonView> {
         return when (val res = siteRes) {
-            is ApiState.Success -> res.data.admins.toImmutableList()
-            else -> persistentListOf()
+            is ApiState.Success -> res.data.admins
+            else -> emptyList()
         }
     }
 

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -73,9 +73,6 @@ import com.jerboa.ui.theme.XXL_PADDING
 import com.jerboa.ui.theme.colorList
 import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.v0x19.datatypes.*
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun CommentNodeHeader(
@@ -174,8 +171,8 @@ fun CommentBodyPreview() {
 
 fun LazyListScope.commentNodeItem(
     node: CommentNode,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,
@@ -386,7 +383,7 @@ fun LazyListScope.commentNodeItem(
     }
 
     commentNodeItems(
-        nodes = node.children.toImmutableList(),
+        nodes = node.children.toList(),
         increaseLazyListIndexTracker = increaseLazyListIndexTracker,
         addToParentIndexes = addToParentIndexes,
         isFlat = isFlat,
@@ -429,8 +426,8 @@ fun LazyListScope.commentNodeItem(
 
 fun LazyListScope.missingCommentNodeItem(
     node: MissingCommentNode,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,
@@ -532,7 +529,7 @@ fun LazyListScope.missingCommentNodeItem(
     increaseLazyListIndexTracker()
 
     commentNodeItems(
-        nodes = node.children.toImmutableList(),
+        nodes = node.children.toList(),
         admins = admins,
         moderators = moderators,
         increaseLazyListIndexTracker = increaseLazyListIndexTracker,
@@ -669,8 +666,8 @@ fun PostAndCommunityContextHeaderPreview() {
 @Composable
 fun CommentFooterLine(
     commentView: CommentView,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     enableDownVotes: Boolean,
     instantScores: InstantScores,
     onUpvoteClick: () -> Unit,
@@ -811,8 +808,8 @@ fun CommentNodesPreview() {
     val tree = buildCommentsTree(comments, null)
     CommentNodes(
         nodes = tree,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         increaseLazyListIndexTracker = {},
         addToParentIndexes = {},
         isFlat = false,

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
@@ -21,13 +21,12 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.Person
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostId
-import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun CommentNodes(
-    nodes: ImmutableList<CommentNodeData>,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    nodes: List<CommentNodeData>,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,
@@ -113,9 +112,9 @@ fun CommentNodes(
 }
 
 fun LazyListScope.commentNodeItems(
-    nodes: ImmutableList<CommentNodeData>,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    nodes: List<CommentNodeData>,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -47,7 +47,6 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonMentionView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostId
-import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun CommentMentionNodeHeader(
@@ -97,8 +96,8 @@ fun CommentMentionNodeHeaderPreview() {
 @Composable
 fun CommentMentionNodeFooterLine(
     personMentionView: PersonMentionView,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     onUpvoteClick: () -> Unit,
     onDownvoteClick: () -> Unit,
     onReplyClick: (personMentionView: PersonMentionView) -> Unit,
@@ -247,8 +246,8 @@ fun CommentMentionNodeFooterLine(
 @Composable
 fun CommentMentionNode(
     personMentionView: PersonMentionView,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     onUpvoteClick: (personMentionView: PersonMentionView) -> Unit,
     onDownvoteClick: (personMentionView: PersonMentionView) -> Unit,
     onReplyClick: (personMentionView: PersonMentionView) -> Unit,

--- a/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/Modifiers.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.ImmutableList
 
 inline fun Modifier.ifDo(
     predicate: Boolean,
@@ -42,7 +41,7 @@ fun Modifier.getBlurredOrRounded(
 fun Modifier.onAutofill(
     tree: AutofillTree,
     autofill: Autofill?,
-    autofillTypes: ImmutableList<AutofillType>,
+    autofillTypes: List<AutofillType>,
     onFill: (String) -> Unit,
 ): Modifier {
     val autofillNode =

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -72,7 +72,6 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.MarkPostAsRead
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostView
 import it.vercruysse.lemmyapi.v0x19.datatypes.SavePost
-import kotlinx.collections.immutable.toImmutableList
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
@@ -212,7 +211,7 @@ fun CommunityActivity(
                         val moderators =
                             remember(communityRes) {
                                 when (communityRes) {
-                                    is ApiState.Success -> communityRes.data.moderators.toImmutableList()
+                                    is ApiState.Success -> communityRes.data.moderators
                                     else -> {
                                         null
                                     }
@@ -220,7 +219,7 @@ fun CommunityActivity(
                             }
 
                         PostListings(
-                            posts = postsRes.data.posts.toImmutableList(),
+                            posts = postsRes.data.posts,
                             admins = siteViewModel.admins(),
                             moderators = moderators,
                             contentAboveListings = {

--- a/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/list/CommunityListActivity.kt
@@ -26,7 +26,6 @@ import it.vercruysse.lemmyapi.dto.SearchType
 import it.vercruysse.lemmyapi.dto.SortType
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityFollowerView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Search
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -41,7 +40,7 @@ object CommunityListReturn {
 fun CommunityListActivity(
     appState: JerboaAppState,
     selectMode: Boolean = false,
-    followList: ImmutableList<CommunityFollowerView>,
+    followList: List<CommunityFollowerView>,
     blurNSFW: Int,
     drawerState: DrawerState,
 ) {

--- a/app/src/main/java/com/jerboa/ui/components/drawer/Drawer.kt
+++ b/app/src/main/java/com/jerboa/ui/components/drawer/Drawer.kt
@@ -69,13 +69,11 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.Community
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityFollowerView
 import it.vercruysse.lemmyapi.v0x19.datatypes.MyUserInfo
 import it.vercruysse.lemmyapi.v0x19.datatypes.Person
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun Drawer(
     myUserInfo: MyUserInfo?,
-    follows: ImmutableList<CommunityFollowerView>,
+    follows: List<CommunityFollowerView>,
     unreadCount: Long,
     accountViewModel: AccountViewModel,
     onAddAccount: () -> Unit,
@@ -126,7 +124,7 @@ fun Drawer(
 @Composable
 fun DrawerContent(
     showAccountAddMode: Boolean,
-    follows: ImmutableList<CommunityFollowerView>,
+    follows: List<CommunityFollowerView>,
     onAddAccount: () -> Unit,
     accountViewModel: AccountViewModel,
     onSwitchAccountClick: (account: Account) -> Unit,
@@ -175,7 +173,7 @@ fun DrawerContent(
 @Composable
 fun DrawerItemsMain(
     myUserInfo: MyUserInfo?,
-    follows: ImmutableList<CommunityFollowerView>,
+    follows: List<CommunityFollowerView>,
     onClickSettings: () -> Unit,
     onClickListingType: (ListingType) -> Unit,
     onCommunityClick: (community: Community) -> Unit,
@@ -287,7 +285,7 @@ fun DrawerItemsMain(
 fun DrawerItemsMainPreview() {
     DrawerItemsMain(
         myUserInfo = null,
-        follows = persistentListOf(),
+        follows = emptyList(),
         onClickListingType = {},
         onCommunityClick = {},
         onClickSettings = {},

--- a/app/src/main/java/com/jerboa/ui/components/drawer/DrawerActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/drawer/DrawerActivity.kt
@@ -18,7 +18,6 @@ import com.jerboa.ui.components.common.getCurrentAccount
 import com.jerboa.ui.components.home.NavTab
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityFollowerView
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityId
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
@@ -64,7 +63,7 @@ fun MainDrawer(
                 }
                 else -> null
             },
-        follows = follows.toImmutableList(),
+        follows = follows.toList(),
         unreadCount = siteViewModel.unreadCount,
         accountViewModel = accountViewModel,
         onAddAccount = onClickLogin,

--- a/app/src/main/java/com/jerboa/ui/components/home/Home.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/Home.kt
@@ -49,7 +49,6 @@ import com.jerboa.ui.theme.LARGE_PADDING
 import it.vercruysse.lemmyapi.dto.ListingType
 import it.vercruysse.lemmyapi.dto.SortType
 import it.vercruysse.lemmyapi.v0x19.datatypes.Tagline
-import kotlinx.collections.immutable.ImmutableList
 import me.saket.cascade.CascadeDropdownMenu
 
 @Composable
@@ -281,7 +280,7 @@ fun ListingTypeOptionsDropDown(
 }
 
 @Composable
-fun Taglines(taglines: ImmutableList<Tagline>) {
+fun Taglines(taglines: List<Tagline>) {
     if (taglines.isNotEmpty()) {
         val tagline by remember { mutableStateOf(taglines.random()) }
         Column(

--- a/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/home/HomeActivity.kt
@@ -75,8 +75,6 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostView
 import it.vercruysse.lemmyapi.v0x19.datatypes.SavePost
 import it.vercruysse.lemmyapi.v0x19.datatypes.Tagline
-import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
@@ -253,10 +251,10 @@ fun MainPostListingsContent(
             when (val postsRes = homeViewModel.postsRes) {
                 is ApiState.Failure -> {
                     apiErrorToast(ctx, postsRes.msg)
-                    persistentListOf()
+                    emptyList()
                 }
-                is ApiState.Holder -> postsRes.data.posts.toImmutableList()
-                else -> persistentListOf()
+                is ApiState.Holder -> postsRes.data.posts.toList()
+                else -> emptyList()
             }
 
         PostListings(
@@ -264,7 +262,7 @@ fun MainPostListingsContent(
             admins = siteViewModel.admins(),
             // No community moderators available here
             moderators = null,
-            contentAboveListings = { if (taglines !== null) Taglines(taglines = taglines.toImmutableList()) },
+            contentAboveListings = { if (taglines !== null) Taglines(taglines = taglines.toList()) },
             onUpvoteClick = { postView ->
                 account.doIfReadyElseDisplayInfo(
                     appState,

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -55,9 +55,8 @@ import com.jerboa.DEFAULT_LEMMY_INSTANCES
 import com.jerboa.R
 import com.jerboa.ui.components.common.onAutofill
 import it.vercruysse.lemmyapi.v0x19.datatypes.Login
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun MyTextField(
     modifier: Modifier = Modifier,
@@ -65,7 +64,7 @@ fun MyTextField(
     placeholder: String? = null,
     text: String,
     onValueChange: (String) -> Unit,
-    autofillTypes: ImmutableList<AutofillType> = persistentListOf(),
+    autofillTypes: List<AutofillType> = emptyList(),
 ) {
     var wasAutofilled by remember { mutableStateOf(false) }
 
@@ -110,7 +109,7 @@ fun PasswordField(
                 .onAutofill(
                     LocalAutofillTree.current,
                     LocalAutofill.current,
-                    persistentListOf(AutofillType.Password),
+                    listOf(AutofillType.Password),
                 ) {
                     onValueChange(it)
                     wasAutofilled = true
@@ -233,7 +232,7 @@ fun LoginForm(
             label = stringResource(R.string.login_email_or_username),
             text = username,
             onValueChange = { username = it },
-            autofillTypes = persistentListOf(AutofillType.Username, AutofillType.EmailAddress),
+            autofillTypes = listOf(AutofillType.Username, AutofillType.EmailAddress),
         )
         PasswordField(
             password = password,
@@ -243,7 +242,7 @@ fun LoginForm(
             label = stringResource(R.string.login_totp),
             text = totp,
             onValueChange = { totp = it },
-            autofillTypes = persistentListOf(AutofillType.SmsOtpCode),
+            autofillTypes = listOf(AutofillType.SmsOtpCode),
         )
         Button(
             enabled = isValid && !loading,

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -100,7 +100,6 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostView
 import it.vercruysse.lemmyapi.v0x19.datatypes.SaveComment
 import it.vercruysse.lemmyapi.v0x19.datatypes.SavePost
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -453,7 +452,7 @@ fun UserTabs(
                             is ApiState.Failure -> ApiErrorText(profileRes.msg)
                             is ApiState.Holder -> {
                                 PostListings(
-                                    posts = profileRes.data.posts.toImmutableList(),
+                                    posts = profileRes.data.posts.toList(),
                                     admins = siteViewModel.admins(),
                                     // No community moderators available here
                                     moderators = null,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -92,7 +92,6 @@ import com.jerboa.ui.components.remove.comment.CommentRemoveReturn
 import com.jerboa.ui.components.remove.post.PostRemoveReturn
 import it.vercruysse.lemmyapi.dto.CommentSortType
 import it.vercruysse.lemmyapi.v0x19.datatypes.*
-import kotlinx.collections.immutable.toImmutableList
 
 object PostViewReturn {
     const val POST_VIEW = "post-view::return(post-view)"
@@ -292,7 +291,7 @@ fun PostActivity(
                     is ApiState.Failure -> ApiErrorText(postRes.msg, padding)
                     is ApiState.Success -> {
                         val postView = postRes.data.post_view
-                        val moderators = postRes.data.moderators.toImmutableList()
+                        val moderators = postRes.data.moderators
 
                         if (!account.isAnon()) appState.addReturn(PostViewReturn.POST_VIEW, postView.copy(read = true))
                         LazyColumn(

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListing.kt
@@ -118,8 +118,6 @@ import com.jerboa.ui.theme.XXL_PADDING
 import com.jerboa.ui.theme.jerboaColorScheme
 import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.v0x19.datatypes.*
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
@@ -547,8 +545,8 @@ fun PreviewSourcePost() {
 @Composable
 fun PostFooterLine(
     postView: PostView,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     instantScores: InstantScores,
     onUpvoteClick: () -> Unit,
     onDownvoteClick: () -> Unit,
@@ -801,8 +799,8 @@ fun PostFooterLinePreview() {
         )
     PostFooterLine(
         postView = postView,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         instantScores = instantScores,
         onUpvoteClick = {},
         onDownvoteClick = {},
@@ -834,8 +832,8 @@ fun PostFooterLinePreview() {
 fun PreviewPostListingCard() {
     PostListing(
         postView = samplePostView,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         useCustomTabs = false,
         usePrivateTabs = false,
         onUpvoteClick = {},
@@ -873,8 +871,8 @@ fun PreviewPostListingCard() {
 fun PreviewLinkPostListing() {
     PostListing(
         postView = sampleLinkPostView,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         useCustomTabs = false,
         usePrivateTabs = false,
         onUpvoteClick = {},
@@ -912,8 +910,8 @@ fun PreviewLinkPostListing() {
 fun PreviewImagePostListingCard() {
     PostListing(
         postView = sampleImagePostView,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         useCustomTabs = false,
         usePrivateTabs = false,
         onUpvoteClick = {},
@@ -951,8 +949,8 @@ fun PreviewImagePostListingCard() {
 fun PreviewImagePostListingSmallCard() {
     PostListing(
         postView = sampleImagePostView,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         useCustomTabs = false,
         usePrivateTabs = false,
         onUpvoteClick = {},
@@ -990,8 +988,8 @@ fun PreviewImagePostListingSmallCard() {
 fun PreviewLinkNoThumbnailPostListing() {
     PostListing(
         postView = sampleLinkNoThumbnailPostView,
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        admins = emptyList(),
+        moderators = emptyList(),
         useCustomTabs = false,
         usePrivateTabs = false,
         onUpvoteClick = {},
@@ -1027,8 +1025,8 @@ fun PreviewLinkNoThumbnailPostListing() {
 @Composable
 fun PostListing(
     postView: PostView,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     useCustomTabs: Boolean,
     usePrivateTabs: Boolean,
     onUpvoteClick: (postView: PostView) -> Unit,
@@ -1525,8 +1523,8 @@ fun PostListingListWithThumbPreview() {
 @Composable
 fun PostListingCard(
     postView: PostView,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     instantScores: InstantScores,
     onUpvoteClick: () -> Unit,
     onDownvoteClick: () -> Unit,

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -37,14 +37,12 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.Person
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
 import it.vercruysse.lemmyapi.v0x19.datatypes.PostView
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun PostListings(
-    posts: ImmutableList<PostView>,
-    admins: ImmutableList<PersonView>,
-    moderators: ImmutableList<CommunityModeratorView>?,
+    posts: List<PostView>,
+    admins: List<PersonView>,
+    moderators: List<CommunityModeratorView>?,
     contentAboveListings: @Composable () -> Unit = {},
     onUpvoteClick: (postView: PostView) -> Unit,
     onDownvoteClick: (postView: PostView) -> Unit,
@@ -171,9 +169,9 @@ fun PostListings(
 @Composable
 fun PreviewPostListings() {
     PostListings(
-        posts = persistentListOf(samplePostView, sampleLinkPostView),
-        admins = persistentListOf(),
-        moderators = persistentListOf(),
+        posts = listOf(samplePostView, sampleLinkPostView),
+        admins = emptyList(),
+        moderators = emptyList(),
         onUpvoteClick = {},
         onDownvoteClick = {},
         onPostClick = {},

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,25 +16,32 @@ subprojects {
 }
 
 // Enables compose compiler metrics
-// Generate them with `./gradlew assembleRelease --rerun-tasks -P com.jerboa.enableComposeCompilerReports=true`
+// Generate them with `./gradlew assembleRelease --rerun-tasks -P enableComposeCompilerReports=true`
 // see https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md
 subprojects {
     tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
-            if (project.findProperty("com.jerboa.enableComposeCompilerReports") == "true") {
+            val destination = project.layout.buildDirectory.get().asFile.absolutePath
+            if (project.findProperty("enableComposeCompilerReports") == "true") {
 
                 freeCompilerArgs.addAll(
                     "-P",
                     "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                        project.layout.buildDirectory + "/compose_metrics"
+                            destination + "/compose_metrics"
                 )
 
                 freeCompilerArgs.addAll(
                     "-P",
                     "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                        project.layout.buildDirectory + "/compose_metrics"
+                        destination + "/compose_metrics"
                 )
             }
+            val configPath = "${project.projectDir.absolutePath}/../compose_compiler_config.conf"
+            println(configPath)
+            freeCompilerArgs.addAll(
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=$configPath"
+            )
         }
     }
 }

--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,0 +1,10 @@
+// This file marks classes as stable for the Compose compiler
+// see https://developer.android.com/jetpack/compose/performance/stability/fix#configuration-file
+
+// External modules need to be marked as stable, the compiler doesn't run on them
+// They are unknown and thus declared as unstable
+it.vercruysse.lemmyapi.*.datatypes.**
+arrow.core.Either
+
+// Consider List, etc stable, see https://github.com/dessalines/jerboa/issues/1332
+kotlin.collections.*


### PR DESCRIPTION
Compose metrics before:
```json
{
 "skippableComposables": 568,
 "restartableComposables": 868,
 "readonlyComposables": 1,
 "totalComposables": 880,
 "restartGroups": 868,
 "totalGroups": 1206,
 "staticArguments": 1847,
 "certainArguments": 696,
 "knownStableArguments": 10855,
 "knownUnstableArguments": 408,
 "unknownStableArguments": 11,
 "totalArguments": 11274,
 "markedStableClasses": 4,
 "inferredStableClasses": 82,
 "inferredUnstableClasses": 34,
 "inferredUncertainClasses": 1,
 "effectivelyStableClasses": 86,
 "totalClasses": 121,
 "memoizedLambdas": 1055,
 "singletonLambdas": 306,
 "singletonComposableLambdas": 170,
 "composableLambdas": 443,
 "totalLambdas": 1324
}
```

Compose metrics after:

```json

{
 "skippableComposables": 642,
 "restartableComposables": 868,
 "readonlyComposables": 1,
 "totalComposables": 880,
 "restartGroups": 868,
 "totalGroups": 1212,
 "staticArguments": 1886,
 "certainArguments": 696,
 "knownStableArguments": 11070,
 "knownUnstableArguments": 193,
 "unknownStableArguments": 11,
 "totalArguments": 11274,
 "markedStableClasses": 5,
 "inferredStableClasses": 95,
 "inferredUnstableClasses": 20,
 "inferredUncertainClasses": 1,
 "effectivelyStableClasses": 100,
 "totalClasses": 121,
 "memoizedLambdas": 1158,
 "singletonLambdas": 306,
 "singletonComposableLambdas": 170,
 "composableLambdas": 443,
 "totalLambdas": 1324
}
```

Something to keep in mind is that all (external) modules that aren't being run in the compose compiler are also considered unstable. (Such as all my datatypes from lemmyapi)

So these need to be added there too

see 
https://developer.android.com/jetpack/compose/performance/stability#summary

Fixes #1332 