### PR TITLE
Making swipe colors softer.

### DIFF
--- a/app/src/main/java/com/jerboa/feat/SwipeToAction.kt
+++ b/app/src/main/java/com/jerboa/feat/SwipeToAction.kt
@@ -42,15 +42,32 @@ enum class SwipeToActionType {
     }
 
     @Composable
-    fun getActionColor(): Color {
+    fun getActionColor(): ActionColor {
         return when (this) {
-            Upvote -> MaterialTheme.colorScheme.secondary
-            Downvote -> MaterialTheme.colorScheme.error
-            Reply -> MaterialTheme.colorScheme.inversePrimary
-            Save -> MaterialTheme.colorScheme.primary
+            Upvote -> ActionColor(
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                background = MaterialTheme.colorScheme.secondaryContainer,
+            )
+            Downvote -> ActionColor(
+                tint = MaterialTheme.colorScheme.onErrorContainer,
+                background = MaterialTheme.colorScheme.errorContainer,
+            )
+            Reply -> ActionColor(
+                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                background = MaterialTheme.colorScheme.tertiaryContainer,
+            )
+            Save -> ActionColor(
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                background = MaterialTheme.colorScheme.primaryContainer,
+            )
         }
     }
 }
+
+data class ActionColor(
+    val tint: Color,
+    val background: Color,
+)
 
 enum class SwipeToActionPreset(
     val leftActions: List<SwipeToActionType>,

--- a/app/src/main/java/com/jerboa/ui/components/common/SwipeToAction.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/SwipeToAction.kt
@@ -95,7 +95,7 @@ fun SwipeToAction(
                 label = "swipe color animation",
                 targetValueByState = { state ->
                     val currentAction = actionByState(state)
-                    currentAction?.second?.getActionColor() ?: Color.Transparent
+                    currentAction?.second?.getActionColor()?.background ?: Color.Transparent
                 },
             )
             Box(
@@ -119,7 +119,7 @@ fun SwipeToAction(
                             Alignment.CenterEnd
                         },
                 ) {
-                    val tint = Color.White
+                    val tint = swipeAction?.second?.getActionColor()?.tint ?: Color.Transparent
                     val modifier =
                         Modifier
                             .padding(10.dp)


### PR DESCRIPTION
This uses the container / onContainer variants as outlined in the [material v3 color design docs.](https://m3.material.io/styles/color/system/overview)

Light theme: 

https://github.com/dessalines/jerboa/assets/930215/1ae9fa9f-bbc7-4a92-98ec-fa1e7e77f9e7

Dark Theme:

https://github.com/dessalines/jerboa/assets/930215/ee8c9c87-d988-48b1-97da-76f3f52387f2

cc @Snow4DV 