### PR TITLE
Fix admin actions visibility for non admin mods

### DIFF
--- a/app/src/main/java/com/jerboa/model/SiteViewModel.kt
+++ b/app/src/main/java/com/jerboa/model/SiteViewModel.kt
@@ -21,6 +21,7 @@ import com.jerboa.db.entity.isAnon
 import com.jerboa.db.repository.AccountRepository
 import com.jerboa.jerboaApplication
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityFollowerView
+import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityId
 import it.vercruysse.lemmyapi.v0x19.datatypes.GetReportCount
 import it.vercruysse.lemmyapi.v0x19.datatypes.GetReportCountResponse
 import it.vercruysse.lemmyapi.v0x19.datatypes.GetSiteResponse
@@ -209,6 +210,13 @@ class SiteViewModel(private val accountRepository: AccountRepository) : ViewMode
         }
     }
 
+    fun moderatedCommunities(): List<CommunityId>? {
+        return when (val res = siteRes) {
+            is ApiState.Success -> res.data.my_user?.moderates?.map { it.community.id }
+            else -> null
+        }
+    }
+
     fun enableDownvotes(): Boolean {
         return when (val res = siteRes) {
             is ApiState.Success -> res.data.site_view.local_site.enable_downvotes
@@ -231,6 +239,7 @@ class SiteViewModel(private val accountRepository: AccountRepository) : ViewMode
                 } ?: run {
                     defaultMode
                 }
+
             else -> defaultMode
         }
     }

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNode.kt
@@ -65,7 +65,6 @@ import com.jerboa.feat.InstantScores
 import com.jerboa.feat.SwipeToActionPreset
 import com.jerboa.feat.SwipeToActionType
 import com.jerboa.feat.VoteType
-import com.jerboa.feat.amAdmin
 import com.jerboa.feat.amMod
 import com.jerboa.feat.canMod
 import com.jerboa.feat.isReadyAndIfNotShowSimplifiedInfoToast
@@ -88,7 +87,6 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.Comment
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentId
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Community
-import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityModeratorView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Person
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
@@ -186,7 +184,7 @@ fun CommentBodyPreview() {
 fun LazyListScope.commentNodeItem(
     node: CommentNode,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,
@@ -495,7 +493,7 @@ fun LazyListScope.commentNodeItem(
 fun LazyListScope.missingCommentNodeItem(
     node: MissingCommentNode,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,
@@ -744,7 +742,7 @@ fun PostAndCommunityContextHeaderPreview() {
 fun CommentFooterLine(
     commentView: CommentView,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     enableDownVotes: Boolean,
     instantScores: InstantScores,
     onUpvoteClick: () -> Unit,
@@ -770,31 +768,21 @@ fun CommentFooterLine(
 ) {
     var showMoreOptions by remember { mutableStateOf(false) }
 
-    val amAdmin =
-        remember(admins) {
-            amAdmin(
-                admins = admins,
-                myId = account.id,
-            )
-        }
+    val amMod = remember(moderators) {
+        amMod(
+            moderators = moderators,
+            myId = account.id,
+        )
+    }
 
-    val amMod =
-        remember {
-            amMod(
-                moderators = moderators,
-                myId = account.id,
-            )
-        }
-
-    val canMod =
-        remember(admins) {
-            canMod(
-                creatorId = commentView.comment.creator_id,
-                admins = admins,
-                moderators = moderators,
-                myId = account.id,
-            )
-        }
+    val canMod = remember(admins) {
+        canMod(
+            creatorId = commentView.comment.creator_id,
+            admins = admins,
+            moderators = moderators,
+            myId = account.id,
+        )
+    }
 
     if (showMoreOptions) {
         CommentOptionsDropdown(
@@ -815,7 +803,7 @@ fun CommentFooterLine(
             isCreator = account.id == commentView.creator.id,
             canMod = canMod,
             amMod = amMod,
-            amAdmin = amAdmin,
+            amAdmin = account.isAdmin,
             viewSource = viewSource,
         )
     }

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentNodes.kt
@@ -19,7 +19,6 @@ import com.jerboa.feat.SwipeToActionPreset
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentId
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Community
-import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityModeratorView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Person
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
@@ -29,7 +28,7 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.PostId
 fun CommentNodes(
     nodes: List<CommentNodeData>,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,
@@ -123,7 +122,7 @@ fun CommentNodes(
 fun LazyListScope.commentNodeItems(
     nodes: List<CommentNodeData>,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     increaseLazyListIndexTracker: () -> Unit,
     addToParentIndexes: () -> Unit,
     isFlat: Boolean,

--- a/app/src/main/java/com/jerboa/ui/components/comment/CommentOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/CommentOptionsDropdown.kt
@@ -33,8 +33,6 @@ import com.jerboa.ui.components.common.BanFromCommunityPopupMenuItem
 import com.jerboa.ui.components.common.BanPersonPopupMenuItem
 import com.jerboa.ui.components.common.PopupMenuItem
 import com.jerboa.util.cascade.CascadeCenteredDropdownMenu
-import io.github.z4kn4fein.semver.toVersion
-import it.vercruysse.lemmyapi.FeatureFlags
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentId
 import it.vercruysse.lemmyapi.v0x19.datatypes.CommentView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Person
@@ -215,7 +213,9 @@ fun CommentOptionsDropdown(
                             onRemoveClick(commentView)
                         },
                     )
-                    BanPersonPopupMenuItem(commentView.creator, onDismissRequest, onBanPersonClick)
+                    if (amAdmin) {
+                        BanPersonPopupMenuItem(commentView.creator, onDismissRequest, onBanPersonClick)
+                    }
 
                     // Only show ban from community button if its a local community
                     if (commentView.community.local) {
@@ -251,7 +251,7 @@ fun CommentOptionsDropdown(
                 }
 
                 // You can do these actions on mods above you
-                if (FeatureFlags(version = API.version.toVersion()).listAdminVotes()) {
+                if (amAdmin && API.getInstanceOrNull()?.FF?.listAdminVotes() == true) {
                     PopupMenuItem(
                         text = stringResource(R.string.view_votes),
                         icon = ImageVector.vectorResource(R.drawable.up_filled),

--- a/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
+++ b/app/src/main/java/com/jerboa/ui/components/comment/mentionnode/CommentMentionNode.kt
@@ -44,7 +44,6 @@ import com.jerboa.ui.theme.SMALL_PADDING
 import com.jerboa.ui.theme.XXL_PADDING
 import com.jerboa.ui.theme.muted
 import it.vercruysse.lemmyapi.v0x19.datatypes.Community
-import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityModeratorView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Person
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonMentionView
@@ -101,7 +100,7 @@ fun CommentMentionNodeHeaderPreview() {
 fun CommentMentionNodeFooterLine(
     personMentionView: PersonMentionView,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     onUpvoteClick: () -> Unit,
     onDownvoteClick: () -> Unit,
     onReplyClick: (personMentionView: PersonMentionView) -> Unit,
@@ -244,7 +243,7 @@ fun CommentMentionNodeFooterLine(
 fun CommentMentionNode(
     personMentionView: PersonMentionView,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     onUpvoteClick: (personMentionView: PersonMentionView) -> Unit,
     onDownvoteClick: (personMentionView: PersonMentionView) -> Unit,
     onReplyClick: (personMentionView: PersonMentionView) -> Unit,

--- a/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/community/CommunityActivity.kt
@@ -226,7 +226,7 @@ fun CommunityActivity(
                         PostListings(
                             posts = postsRes.data.posts,
                             admins = siteViewModel.admins(),
-                            moderators = moderators,
+                            moderators = remember(moderators) { moderators?.map { it.moderator.id } },
                             contentAboveListings = {
                                 when (communityRes) {
                                     is ApiState.Success -> {

--- a/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/person/PersonProfileActivity.kt
@@ -193,13 +193,13 @@ fun PersonProfileActivity(
                 }
                 is ApiState.Holder -> {
                     val person = profileRes.data.person_view.person
-                    val canBan =
-                        canMod(
-                            creatorId = person.id,
-                            admins = siteViewModel.admins(),
-                            moderators = null,
-                            myId = account.id,
-                        )
+                    val canBan = canMod(
+                        creatorId = person.id,
+                        admins = siteViewModel.admins(),
+                        moderators = null,
+                        myId = account.id,
+                    )
+
                     PersonProfileHeader(
                         scrollBehavior = scrollBehavior,
                         personName =

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -309,7 +309,7 @@ fun PostActivity(
                     is ApiState.Failure -> ApiErrorText(postRes.msg, padding)
                     is ApiState.Success -> {
                         val postView = postRes.data.post_view
-                        val moderators = postRes.data.moderators
+                        val moderators = remember(postRes) { postRes.data.moderators.map { it.moderator.id } }
 
                         if (!account.isAnon()) appState.addReturn(PostViewReturn.POST_VIEW, postView.copy(read = true))
                         LazyColumn(

--- a/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostListings.kt
@@ -36,7 +36,6 @@ import com.jerboa.ui.components.common.RetryLoadingPosts
 import com.jerboa.ui.components.common.simpleVerticalScrollbar
 import com.jerboa.ui.theme.SMALL_PADDING
 import it.vercruysse.lemmyapi.v0x19.datatypes.Community
-import it.vercruysse.lemmyapi.v0x19.datatypes.CommunityModeratorView
 import it.vercruysse.lemmyapi.v0x19.datatypes.Person
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonId
 import it.vercruysse.lemmyapi.v0x19.datatypes.PersonView
@@ -47,7 +46,7 @@ import it.vercruysse.lemmyapi.v0x19.datatypes.PostView
 fun PostListings(
     posts: List<PostView>,
     admins: List<PersonView>,
-    moderators: List<CommunityModeratorView>?,
+    moderators: List<PersonId>?,
     contentAboveListings: @Composable () -> Unit = {},
     onUpvoteClick: (postView: PostView) -> Unit,
     onDownvoteClick: (postView: PostView) -> Unit,

--- a/app/src/main/java/com/jerboa/ui/components/post/composables/PostOptionsDropdown.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/composables/PostOptionsDropdown.kt
@@ -458,7 +458,9 @@ fun PostOptionsDropdown(
                             onRemoveClick(postView)
                         },
                     )
-                    BanPersonPopupMenuItem(postView.creator, onDismissRequest, onBanPersonClick)
+                    if (amAdmin) {
+                        BanPersonPopupMenuItem(postView.creator, onDismissRequest, onBanPersonClick)
+                    }
 
                     // Only show ban from community button if its a local community
                     if (postView.community.local) {
@@ -477,7 +479,7 @@ fun PostOptionsDropdown(
                 // You can do these actions on mods above you
 
                 // These are all amMod || amAdmin
-                if (getInstanceOrNull()?.FF?.listAdminVotes() == true) {
+                if (amAdmin && getInstanceOrNull()?.FF?.listAdminVotes() == true) {
                     PopupMenuItem(
                         text = stringResource(R.string.view_votes),
                         icon = ImageVector.vectorResource(R.drawable.up_filled),


### PR DESCRIPTION
Fix #1411 
Fix #1408 

- Fixed some admin actions being shown to non admin mods
- Did more deep research into the non admin can't ban user from community. I couldn't reproduce this at all. *User was certain though it was a community ban and not a instance ban* 

- Added a simulateModerators only for post options popup menu, it is not completely correct but this way non admin mods which probably make up most of the mods can actually moderate from the main feed. In case of the edge case moderator moderates a higher mod, the call will fail. So not that bad

- Also fixed the weird movement of the post when opening the morePostOptions menu (regression)
see https://stackoverflow.com/questions/77010371/prevent-popup-from-adding-padding-in-a-column-with-arrangement-spacedbylarge-p