### PR TITLE
Remove v0.18.4 and less workaround for missing timezone in datetime

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("com.google.devtools.ksp")
     id("androidx.baselineprofile")
-    kotlin("plugin.serialization") version "1.9.21"
+    kotlin("plugin.serialization") version "1.9.22"
 
 }
 
@@ -130,14 +130,14 @@ dependencies {
     implementation("com.google.accompanist:accompanist-systemuicontroller:$accompanistVersion")
 
     // LiveData
-    implementation("androidx.compose.runtime:runtime-livedata:1.6.1")
+    implementation("androidx.compose.runtime:runtime-livedata:1.6.2")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
 
     // Images
-    implementation("io.coil-kt:coil-compose:2.5.0")
-    implementation("io.coil-kt:coil-gif:2.5.0")
-    implementation("io.coil-kt:coil-svg:2.5.0")
+    implementation("io.coil-kt:coil-compose:2.6.0")
+    implementation("io.coil-kt:coil-gif:2.6.0")
+    implementation("io.coil-kt:coil-svg:2.6.0")
     // Allows for proper subsampling of large images
     implementation("me.saket.telephoto:zoomable-image-coil:0.8.0")
     // Animated dropdowns
@@ -160,7 +160,7 @@ dependencies {
     testImplementation("pl.pragmatists:JUnitParams:1.1.1")
     androidTestImplementation("androidx.room:room-testing:2.6.1")
 
-    implementation("io.arrow-kt:arrow-core:1.2.1")
+    implementation("io.arrow-kt:arrow-core:1.2.3")
     // Unfortunately, ui tooling, and the markdown thing, still brings in the other material2 dependencies
     implementation("androidx.compose.material3:material3:1.2.0")
     implementation("androidx.compose.material3:material3-window-size-class:1.2.0")
@@ -170,19 +170,19 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
     testImplementation("androidx.arch.core:core-testing:2.2.0")
 
-    implementation("androidx.compose.ui:ui:1.6.1")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.6.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.1")
-    debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.1")
-    implementation("androidx.compose.material:material-icons-extended:1.6.1")
+    implementation("androidx.compose.ui:ui:1.6.2")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.6.2")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.6.2")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.6.2")
+    debugImplementation("androidx.compose.ui:ui-test-manifest:1.6.2")
+    implementation("androidx.compose.material:material-icons-extended:1.6.2")
 
     implementation("androidx.activity:activity-compose:1.8.2")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 
-    testImplementation("org.mockito:mockito-core:5.10.0")
+    testImplementation("org.mockito:mockito-core:5.11.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 
     implementation("androidx.browser:browser:1.7.0")
@@ -190,7 +190,7 @@ dependencies {
     implementation("androidx.profileinstaller:profileinstaller:1.3.1")
     baselineProfile(project(":benchmarks"))
 
-    implementation("it.vercruysse.lemmyapi:lemmy-api:0.2.9-SNAPSHOT")
+    implementation("it.vercruysse.lemmyapi:lemmy-api:0.2.10-SNAPSHOT")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
     // Ktor uses SLF4J
     implementation("org.slf4j:slf4j-api:2.0.12")

--- a/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/TimeAgo.kt
@@ -100,10 +100,7 @@ fun dateStringToPretty(
     longTimeFormat: Boolean = false,
 ): String? {
     return try {
-        // TODO: v0.18.4_deprecated Remove this hack once backward API compatibility is implemented
-        // pre 0.19 Datetimes didn't have a timezone, so we add one here
-        val withTimezone = if (dateStr.last() == 'Z') dateStr else dateStr + "Z"
-        val publishedDate = Date.from(Instant.parse(withTimezone))
+        val publishedDate = Date.from(Instant.parse(dateStr))
         formatDuration(publishedDate, longTimeFormat)
     } catch (e: DateTimeParseException) {
         Log.d("TimeAgo", "Failed to parse date string: $dateStr", e)

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -66,6 +66,6 @@ baselineProfile {
 dependencies {
     implementation("androidx.test.ext:junit:1.1.5")
     implementation("androidx.test.espresso:espresso-core:3.5.1")
-    implementation("androidx.test.uiautomator:uiautomator:2.3.0-rc01")
+    implementation("androidx.test.uiautomator:uiautomator:2.3.0")
     implementation("androidx.benchmark:benchmark-macro-junit4:1.2.3")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ subprojects {
                 )
             }
             val configPath = "${project.projectDir.absolutePath}/../compose_compiler_config.conf"
-            println(configPath)
             freeCompilerArgs.addAll(
                 "-P",
                 "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=$configPath"


### PR DESCRIPTION
Fix #1358 