### PR TITLE
Add first frame video support for comment videos

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,7 @@ dependencies {
     implementation("io.coil-kt:coil-compose:2.6.0")
     implementation("io.coil-kt:coil-gif:2.6.0")
     implementation("io.coil-kt:coil-svg:2.6.0")
+    implementation("io.coil-kt:coil-video:2.6.0")
     // Allows for proper subsampling of large images
     implementation("me.saket.telephoto:zoomable-image-coil:0.8.0")
     // Animated dropdowns

--- a/app/src/main/java/com/jerboa/JerboaApplication.kt
+++ b/app/src/main/java/com/jerboa/JerboaApplication.kt
@@ -7,6 +7,7 @@ import coil.ImageLoaderFactory
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.decode.SvgDecoder
+import coil.decode.VideoFrameDecoder
 import com.jerboa.api.API
 import com.jerboa.db.AppDBContainer
 import com.jerboa.util.downloadprogress.DownloadProgress
@@ -29,12 +30,14 @@ class JerboaApplication : Application(), ImageLoaderFactory {
                 .placeholder(R.drawable.ic_launcher_foreground)
                 .components {
                     add(SvgDecoder.Factory())
+                    add(VideoFrameDecoder.Factory())
                 }
                 .build()
 
         imageGifLoader =
             imageLoader.newBuilder()
                 .components {
+                    add(SvgDecoder.Factory())
                     if (Build.VERSION.SDK_INT >= 28) {
                         add(ImageDecoderDecoder.Factory())
                     } else {

--- a/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
+++ b/app/src/main/java/com/jerboa/feat/AccountVerificationState.kt
@@ -21,6 +21,7 @@ import com.jerboa.loginFirstToast
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.SiteViewModel
 import com.jerboa.toEnum
+import com.jerboa.ui.components.common.apiErrorToast
 import it.vercruysse.lemmyapi.exception.LemmyBadRequestException
 import it.vercruysse.lemmyapi.v0x19.LemmyApi
 import it.vercruysse.lemmyapi.v0x19.datatypes.GetPersonDetails
@@ -427,8 +428,11 @@ suspend fun Account.isReadyAndIfNotDisplayInfo(
                         }
 
                         AccountVerificationState.JWT_VERIFIED to CheckState.Failed -> {
-                            accountVM.deleteAccountAndSwapCurrent(this, swapToAnon = true).invokeOnCompletion {
+                            accountVM.deleteAccountAndSwapCurrent(this, swapToAnon = true).invokeOnCompletion { err ->
                                 appState.toLogin()
+                                if (err != null) {
+                                    apiErrorToast(ctx, err)
+                                }
                             }
                         }
 


### PR DESCRIPTION
Coil has support to show first frames of videos.

Now this doesn't work for the image viewer. Not sure why.
Also discovered that the `components` override each in the newBuilder() thing but setting it for gifImage  loader which is used by the imageviewer doesn't solve it. (Just displays black instead of failure)

Add logging for that login action, but i doubt that it errors. Else the delete action wouldn't succeed

