### PR TITLE
Prevents posts from reloading when changing the comments sorting

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -207,33 +207,32 @@ fun PostActivity(
     Scaffold(
         snackbarHost = { JerboaSnackbarHost(snackbarHostState) },
         modifier =
-        Modifier
-            .nestedScroll(scrollBehavior.nestedScrollConnection)
-            .semantics { testTagsAsResourceId = true }
-            .nestedScroll(scrollBehavior.nestedScrollConnection)
-            .focusRequester(focusRequester)
-            .focusable()
-            .onKeyEvent { keyEvent ->
-                if (navigateParentCommentsWithVolumeButtons) {
-                    when (keyEvent.key) {
-                        Key.VolumeUp -> {
-                            scrollToPreviousParentComment(scope, parentListStateIndexes, listState)
-                            true
-                        }
+            Modifier
+                .nestedScroll(scrollBehavior.nestedScrollConnection)
+                .semantics { testTagsAsResourceId = true }
+                .focusRequester(focusRequester)
+                .focusable()
+                .onKeyEvent { keyEvent ->
+                    if (navigateParentCommentsWithVolumeButtons) {
+                        when (keyEvent.key) {
+                            Key.VolumeUp -> {
+                                scrollToPreviousParentComment(scope, parentListStateIndexes, listState)
+                                true
+                            }
 
-                        Key.VolumeDown -> {
-                            scrollToNextParentComment(scope, parentListStateIndexes, listState)
-                            true
-                        }
+                            Key.VolumeDown -> {
+                                scrollToNextParentComment(scope, parentListStateIndexes, listState)
+                                true
+                            }
 
-                        else -> {
-                            false
+                            else -> {
+                                false
+                            }
                         }
+                    } else {
+                        false
                     }
-                } else {
-                    false
-                }
-            },
+                },
         bottomBar = {
             if (showParentCommentNavigationButtons) {
                 CommentNavigationBottomAppBar(
@@ -304,9 +303,7 @@ fun PostActivity(
                         .zIndex(100f),
                 )
                 when (val postRes = postViewModel.postRes) {
-                    is ApiState.Loading ->
-                        LoadingBar(padding)
-
+                    is ApiState.Loading -> LoadingBar(padding)
                     is ApiState.Failure -> ApiErrorText(postRes.msg, padding)
                     is ApiState.Success -> {
                         val postView = postRes.data.post_view

--- a/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/post/PostActivity.kt
@@ -174,7 +174,7 @@ fun PostActivity(
 
     val onClickSortType = { commentSortType: CommentSortType ->
         postViewModel.updateSortType(commentSortType)
-        postViewModel.getData()
+        postViewModel.getComments()
     }
 
     val selectedSortType = postViewModel.sortType
@@ -207,33 +207,33 @@ fun PostActivity(
     Scaffold(
         snackbarHost = { JerboaSnackbarHost(snackbarHostState) },
         modifier =
-            Modifier
-                .nestedScroll(scrollBehavior.nestedScrollConnection)
-                .semantics { testTagsAsResourceId = true }
-                .nestedScroll(scrollBehavior.nestedScrollConnection)
-                .focusRequester(focusRequester)
-                .focusable()
-                .onKeyEvent { keyEvent ->
-                    if (navigateParentCommentsWithVolumeButtons) {
-                        when (keyEvent.key) {
-                            Key.VolumeUp -> {
-                                scrollToPreviousParentComment(scope, parentListStateIndexes, listState)
-                                true
-                            }
-
-                            Key.VolumeDown -> {
-                                scrollToNextParentComment(scope, parentListStateIndexes, listState)
-                                true
-                            }
-
-                            else -> {
-                                false
-                            }
+        Modifier
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .semantics { testTagsAsResourceId = true }
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+            .focusRequester(focusRequester)
+            .focusable()
+            .onKeyEvent { keyEvent ->
+                if (navigateParentCommentsWithVolumeButtons) {
+                    when (keyEvent.key) {
+                        Key.VolumeUp -> {
+                            scrollToPreviousParentComment(scope, parentListStateIndexes, listState)
+                            true
                         }
-                    } else {
-                        false
+
+                        Key.VolumeDown -> {
+                            scrollToNextParentComment(scope, parentListStateIndexes, listState)
+                            true
+                        }
+
+                        else -> {
+                            false
+                        }
                     }
-                },
+                } else {
+                    false
+                }
+            },
         bottomBar = {
             if (showParentCommentNavigationButtons) {
                 CommentNavigationBottomAppBar(


### PR DESCRIPTION
## Description

When we sort the comments on the PostActivity, the post information is also fetched (instead of just the comments). This PR fixes this. 

### Before

https://github.com/dessalines/jerboa/assets/56604262/d09796f6-a7df-4522-9f95-5d9d64f31275

### After

https://github.com/dessalines/jerboa/assets/56604262/6670a095-4a15-4523-aa9a-459758466d37

