### PR TITLE
Fixing a few other top app bar title sizes.

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -84,6 +84,7 @@ fun SimpleTopAppBar(
         title = {
             Text(
                 text = text,
+                style = MaterialTheme.typography.titleSmall,
                 maxLines = 1,
                 modifier = Modifier.customMarquee(),
             )
@@ -782,6 +783,7 @@ fun ActionTopBar(
         title = {
             Text(
                 text = title,
+                style = MaterialTheme.typography.titleSmall,
             )
         },
         actions = {

--- a/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/AppBars.kt
@@ -84,7 +84,7 @@ fun SimpleTopAppBar(
         title = {
             Text(
                 text = text,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleMedium,
                 maxLines = 1,
                 modifier = Modifier.customMarquee(),
             )
@@ -783,7 +783,7 @@ fun ActionTopBar(
         title = {
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleSmall,
+                style = MaterialTheme.typography.titleMedium,
             )
         },
         actions = {

--- a/app/src/main/java/com/jerboa/ui/components/login/Login.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/Login.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.Button
@@ -29,7 +28,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -266,35 +264,5 @@ fun LoginForm(
 fun LoginFormPreview() {
     LoginForm(
         onClickLogin = { _: Login, _: String -> },
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun LoginHeader(onClickBack: () -> Unit) {
-    TopAppBar(
-        title = {
-            Text(
-                text = stringResource(R.string.login_login),
-            )
-        },
-        navigationIcon = {
-            IconButton(
-                onClick = onClickBack,
-            ) {
-                Icon(
-                    Icons.AutoMirrored.Outlined.ArrowBack,
-                    contentDescription = stringResource(R.string.topAppBar_back),
-                )
-            }
-        },
-    )
-}
-
-@Preview
-@Composable
-fun LoginHeaderPreview() {
-    LoginHeader(
-        onClickBack = {},
     )
 }

--- a/app/src/main/java/com/jerboa/ui/components/login/LoginActivity.kt
+++ b/app/src/main/java/com/jerboa/ui/components/login/LoginActivity.kt
@@ -3,6 +3,7 @@ package com.jerboa.ui.components.login
 import android.util.Log
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -10,12 +11,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.jerboa.JerboaAppState
+import com.jerboa.R
 import com.jerboa.model.AccountViewModel
 import com.jerboa.model.LoginViewModel
 import com.jerboa.model.SiteViewModel
+import com.jerboa.ui.components.common.SimpleTopAppBar
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LoginActivity(
     appState: JerboaAppState,
@@ -32,8 +37,9 @@ fun LoginActivity(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            LoginHeader(
-                appState::popBackStack,
+            SimpleTopAppBar(
+                text = stringResource(R.string.login_login),
+                onClickBack = appState::popBackStack,
             )
         },
         content = { padding ->


### PR DESCRIPTION
This fixes a few other top app bar titles by using `titleSmall`