### PR TITLE
Fix too large images in comments being cutoff

### DIFF
--- a/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
+++ b/app/src/main/java/com/jerboa/ui/components/common/MarkdownHelper.kt
@@ -170,7 +170,7 @@ object MarkdownHelper {
             update = { textView ->
                 val md = markwon!!.toMarkdown(markdown)
                 for (img in md.getSpans(0, md.length, AsyncDrawableSpan::class.java)) {
-                    img.drawable.initWithKnownDimensions(textView.maxWidth, textView.textSize)
+                    img.drawable.initWithKnownDimensions(textView.width, textView.textSize)
                 }
                 markwon!!.setParsedMarkdown(textView, md)
             },


### PR DESCRIPTION
Before:


https://github.com/user-attachments/assets/b64b6f5b-4339-4595-b00b-2840bc4f8f0a


After:


https://github.com/user-attachments/assets/6a0e0d1f-5c3b-4992-874b-8e164e166113

