### PR TITLE
Fix #2050: Prevent superscript clashing with markdown footnotes

### DIFF
--- a/app/src/main/java/com/jerboa/util/markwon/ScriptRewriteSupportPlugin.kt
+++ b/app/src/main/java/com/jerboa/util/markwon/ScriptRewriteSupportPlugin.kt
@@ -17,8 +17,9 @@ class ScriptRewriteSupportPlugin : AbstractMarkwonPlugin() {
          * Superscript has the definition:
          * Any text between a '^' that is not interrupted by a linebreak where the starting
          * or ending text can't be a whitespace character.
+         * The '^' must not be prefixed by a '[' (To prevent clashing with markdown links)
          */
-        val SUPERSCRIPT_RGX = Regex("""\^(?!\s)([^\n^]+)(?<!\s)\^""")
+        val SUPERSCRIPT_RGX = Regex("""(?<!\[)\^(?!\s)([^\n^]+)(?<!\s)\^""")
 
         /*
          * Subscript has the definition:

--- a/app/src/test/java/com/jerboa/util/markwon/ScriptRewriteSupportPluginTest.kt
+++ b/app/src/test/java/com/jerboa/util/markwon/ScriptRewriteSupportPluginTest.kt
@@ -56,5 +56,13 @@ class ScriptRewriteSupportPluginTest {
             listOf("~ 99 ~", "~ 99 ~"),
             listOf("~ 99~", "~ 99~"),
             listOf("~99 ~", "~99 ~"),
+            listOf(
+                "Here's a simple footnote[^1].\n\n[^1]: <This is the first footnote.>",
+                "Here's a simple footnote[^1].\n\n[^1]: <This is the first footnote.>",
+            ),
+            listOf(
+                "[^0] steht an und wir als Hochschulgruppe KIT GameJam laden euch herzlich ein, bei uns am Global Game Jam teilzunehmen. im **TRIANGEL**[^1]",
+                "[^0] steht an und wir als Hochschulgruppe KIT GameJam laden euch herzlich ein, bei uns am Global Game Jam teilzunehmen. im **TRIANGEL**[^1]",
+            ),
         )
 }


### PR DESCRIPTION
The superscript was clashing with the footnotes. I have added additional check to the regex to prevent it from clashing.


<img width="423" height="630" alt="image" src="https://github.com/user-attachments/assets/56d31473-24f4-433c-98ac-758f1984d748" />

