### PR TITLE
restrict low bandwidth auto mode to Data Saver

### DIFF
--- a/app/src/main/java/com/jerboa/Utils.kt
+++ b/app/src/main/java/com/jerboa/Utils.kt
@@ -1290,14 +1290,6 @@ fun ConnectivityManager?.isCurrentlyConnected(): Boolean =
         ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
         ?: true
 
-fun ConnectivityManager?.isConnectionMetered(): Boolean =
-    this
-        ?.activeNetwork
-        ?.let(::getNetworkCapabilities)
-        ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
-        ?.not()
-        ?: false
-
 fun ConnectivityManager?.isDataSaverEnabled(): Boolean =
     this?.restrictBackgroundStatus == ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED
 

--- a/app/src/main/java/com/jerboa/feat/LowBandwidthMode.kt
+++ b/app/src/main/java/com/jerboa/feat/LowBandwidthMode.kt
@@ -3,7 +3,6 @@ package com.jerboa.feat
 import android.net.ConnectivityManager
 import androidx.annotation.StringRes
 import com.jerboa.R
-import com.jerboa.isConnectionMetered
 import com.jerboa.isDataSaverEnabled
 
 enum class LowBandwidthMode(
@@ -16,7 +15,7 @@ enum class LowBandwidthMode(
 
     fun isActive(connectivityManager: ConnectivityManager?): Boolean =
         when (this) {
-            Auto -> connectivityManager.isConnectionMetered() || connectivityManager.isDataSaverEnabled()
+            Auto -> connectivityManager.isDataSaverEnabled()
             Always -> true
             Never -> false
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -370,7 +370,7 @@
     <string name="settings_autoplaygifs">Autoplay GIFs</string>
     <string name="settings_disable_video_autoplay">Disable video autoplay</string>
     <string name="settings_low_bandwidth_mode">Low bandwidth mode</string>
-    <string name="low_bandwidth_mode_auto">Auto (metered or Data Saver)</string>
+    <string name="low_bandwidth_mode_auto">Auto (Data Saver)</string>
     <string name="low_bandwidth_mode_always">Always on</string>
     <string name="low_bandwidth_mode_never">Off</string>
     <string name="community_unblock_community">Unblock community</string>


### PR DESCRIPTION
Drop the metered-network check from `LowBandwidthMode.Auto` so it activates only when the system Data Saver setting is enabled. Most mobile networks report as metered, which made Auto trigger far more often than users expected.

Addresses https://github.com/LemmyNet/jerboa/issues/1594#issuecomment-4330034240.

/cc @MV-GH
